### PR TITLE
プロンプトファイルを追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,124 @@
+# GitHub Copilot Instructions
+
+## プロジェクト概要
+
+- 目的: chezmoi を使用して個人の dotfiles と AI エージェント設定を一元管理する
+- 主な機能: シェル設定（bash/zsh）の集中管理、AI エージェント設定の同期、機密情報の暗号化管理
+- 対象ユーザー: 開発者（個人用環境設定）
+
+## 共通ルール
+
+- 会話は日本語で行う。
+- PR とコミットは Conventional Commits に従う。`<description>` は日本語で記載する。
+  - 例: `feat: ユーザー認証機能を追加`
+- ブランチ命名は Conventional Branch に従う。`<type>` は短縮形（feat, fix）を使用する。
+  - 例: `feat/add-user-auth`
+- 日本語と英数字の間には半角スペースを入れる。
+
+## 技術スタック
+
+- ツール: chezmoi（dotfiles 管理フレームワーク）
+- 暗号化: age（最小限の暗号化ツール）
+- シェル: Bash / Zsh
+- テンプレート: Go template（chezmoi 組み込み）
+- 対応 AI エージェント: Claude Code、Codex CLI、Gemini CLI、GitHub Copilot
+
+## ディレクトリ構造
+
+```
+dotfiles/
+├── .chezmoi.toml.tmpl              # chezmoi 設定テンプレート
+├── .chezmoiignore                  # chezmoi が無視するファイル
+├── .chezmoiroot                    # chezmoi ルートマーカー
+├── home/                            # chezmoi ソース（実ファイルの定義）
+│   ├── dot_bashrc                   # bash 設定
+│   ├── dot_bashrc.d/                # bash 設定分割
+│   ├── dot_zshrc                    # zsh 設定
+│   ├── dot_zshrc.d/                 # zsh 設定分割
+│   ├── dot_claude/                  # Claude Code 設定
+│   ├── dot_codex/                   # Codex エージェント設定
+│   ├── dot_gemini/                  # Gemini エージェント設定
+│   └── dot_copilot/                 # GitHub Copilot 設定
+└── run_onchange_before_decrypt-private-key.sh.tmpl  # 秘密鍵復号化フック
+```
+
+## コーディング規約
+
+- **コメント**: 日本語で記載する
+- **エラーメッセージ**: 英語で記載する
+- **シェルスクリプト**: 既存のコーディングスタイルに従う
+- **chezmoi テンプレート**: Go template 構文を使用する
+  - ファイル名: `dot_` プレフィックスで `.` を表す
+  - テンプレート: `.tmpl` サフィックス
+  - 暗号化: `.age` サフィックス
+
+## 開発コマンド
+
+```bash
+# chezmoi の初期化（新規マシン）
+chezmoi init <repo> --branch <branch-name>
+
+# ドライラン（変更内容の確認）
+chezmoi apply --dry-run
+
+# 設定の適用
+chezmoi apply
+
+# リポジトリの更新
+chezmoi update
+
+# 差分確認
+chezmoi diff
+
+# 設定ファイルの編集
+chezmoi edit <file>
+
+# 暗号化ファイルの編集
+chezmoi edit --encrypt <file>
+```
+
+## テスト方針
+
+- **テストフレームワーク**: なし（手動検証）
+- **検証方法**: Docker コンテナでの動作確認を推奨
+  ```bash
+  docker run -it -v $(pwd):/dotfiles ubuntu:latest
+  cd /dotfiles
+  chezmoi apply --dry-run
+  chezmoi apply
+  ```
+- **検証ポイント**:
+  - テンプレート処理が正しく行われているか
+  - 暗号化ファイルが復号化されているか
+  - シェル起動時のエラーがないか
+
+## セキュリティ / 機密情報
+
+- **認証情報のコミット禁止**: API キーや認証情報は暗号化（age）して管理する
+  - WakaTime API キー: `encrypted_dot_wakatime.cfg.age`
+  - Discord Webhook URL: `.chezmoi.toml.tmpl` でテンプレート管理
+- **ログへの機密情報出力禁止**: エラーメッセージに機密情報を含めない
+- **age 秘密鍵の管理**: `key.txt` はローカルのみ保管（リポジトリにコミットしない）
+
+## ドキュメント更新
+
+コードや設定の変更時には、以下のドキュメントを更新する：
+
+- `README.md`: プロジェクトの概要と使用方法
+- `home/dot_bashrc.d/README.md`: bash 設定分割の説明
+- `home/dot_zshrc.d/README.md`: zsh 設定分割の説明
+- プロンプトファイル（`.github/copilot-instructions.md`、`CLAUDE.md`、`AGENTS.md`、`GEMINI.md`）
+
+## リポジトリ固有
+
+- **chezmoi の命名規則**:
+  - `dot_` プレフィックス: `.` で始まるファイル名（例: `dot_bashrc` → `~/.bashrc`）
+  - `.tmpl` サフィックス: chezmoi テンプレート処理対象
+  - `.age` サフィックス: age 暗号化ファイル
+- **設定分割パターン**:
+  - `.d/` ディレクトリ内のファイルは `LC_ALL=C` でソート順に読み込まれる
+  - 数字プレフィックスで読み込み順序を制御（例: `00-path.sh`、`10-history.sh`）
+- **マルチエージェント対応**:
+  - 各 AI エージェント専用のディレクトリを配置（`dot_claude/`、`dot_codex/`、`dot_gemini/`、`dot_copilot/`）
+  - 各エージェント独立の設定ファイルとスクリプトを管理
+- **Git Worktree**: このプロジェクトでは使用しない

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# AI エージェント共通ルール
+
+## 目的
+
+このドキュメントは、一般的な AI エージェントがこのプロジェクトで作業を行う際の共通の作業方針を定義します。
+
+## 基本方針
+
+### 言語
+
+- **会話言語**: 日本語
+- **コード内コメント**: 日本語
+- **エラーメッセージ**: 英語
+- **日本語と英数字の間**: 半角スペースを挿入
+
+### コミット規約
+
+- **コミットメッセージ**: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) に従う
+  - `<type>(<scope>): <description>` 形式
+  - `<description>` は日本語で記載
+  - 例: `feat: ユーザー認証機能を追加`
+
+### ブランチ命名
+
+- **ブランチ命名**: [Conventional Branch](https://conventional-branch.github.io) に従う
+  - `<type>/<description>` 形式
+  - `<type>` は短縮形（feat, fix）を使用
+  - 例: `feat/add-user-auth`
+
+## 判断記録のルール
+
+判断を行う際は、必ず以下を記録すること：
+
+1. **判断内容の要約**: 何を決定したかを明確に記載
+2. **検討した代替案**: 他にどのような選択肢があったかをリストアップ
+3. **採用しなかった案とその理由**: なぜその案を選ばなかったかを説明
+4. **前提条件・仮定・不確実性**: 判断の前提となる情報を明示
+5. **レビューの必要性**: 他のエージェントやユーザーによるレビューが必要かを判断
+
+**重要**: 前提・仮定・不確実性を明示すること。仮定を事実のように扱ってはならない。
+
+## プロジェクト概要
+
+- **目的**: chezmoi を使用して個人の dotfiles と AI エージェント設定を一元管理する
+- **主な機能**:
+  - シェル設定（bash/zsh）の集中管理
+  - AI エージェント設定の同期
+  - 機密情報の暗号化管理
+  - ツール設定（tmux、vim、git など）の統一
+
+## 技術スタック
+
+- **ツール**: chezmoi（dotfiles 管理フレームワーク）
+- **暗号化**: age（最小限の暗号化ツール）
+- **シェル**: Bash / Zsh
+- **テンプレート**: Go template（chezmoi 組み込み）
+
+## ディレクトリ構造
+
+```
+dotfiles/
+├── .chezmoi.toml.tmpl              # chezmoi 設定テンプレート
+├── .chezmoiignore                  # chezmoi が無視するファイル
+├── .chezmoiroot                    # chezmoi ルートマーカー
+├── home/                            # chezmoi ソース（実ファイルの定義）
+│   ├── dot_bashrc                   # bash 設定
+│   ├── dot_bashrc.d/                # bash 設定分割
+│   ├── dot_zshrc                    # zsh 設定
+│   ├── dot_zshrc.d/                 # zsh 設定分割
+│   ├── dot_claude/                  # Claude Code 設定
+│   ├── dot_codex/                   # Codex エージェント設定
+│   ├── dot_gemini/                  # Gemini エージェント設定
+│   └── dot_copilot/                 # GitHub Copilot 設定
+└── run_onchange_before_decrypt-private-key.sh.tmpl  # 秘密鍵復号化フック
+```
+
+## 開発手順（概要）
+
+### 1. プロジェクトの理解
+
+- リポジトリの構造を確認する
+- chezmoi の命名規則を理解する（`dot_` プレフィックス、`.tmpl` サフィックス、`.age` サフィックス）
+- 既存の設定ファイルのパターンを把握する
+
+### 2. 変更の実装
+
+- 既存のコーディングスタイルに従う
+- chezmoi テンプレート構文（Go template）を使用する
+- 設定分割パターン（`.d/` ディレクトリ）に従う
+
+### 3. 動作確認
+
+- `chezmoi apply --dry-run` でドライラン確認
+- Docker コンテナでの動作確認を推奨
+- シェルスクリプトの構文エラーチェック（`bash -n`）
+
+### 4. コミットと PR
+
+- Conventional Commits に従ったコミットメッセージ
+- Conventional Branch に従ったブランチ命名
+- センシティブな情報がコミットされていないことを確認
+
+## セキュリティ / 機密情報
+
+### 認証情報のコミット禁止
+
+- API キーや認証情報は age で暗号化して管理する
+  - WakaTime API キー: `encrypted_dot_wakatime.cfg.age`
+  - Discord Webhook URL: `.chezmoi.toml.tmpl` でテンプレート管理
+- age 秘密鍵（`key.txt`）はローカルのみ保管（リポジトリにコミットしない）
+
+### ログへの機密情報出力禁止
+
+- エラーメッセージに機密情報を含めない
+- デバッグ出力に認証情報を表示しない
+
+## リポジトリ固有
+
+### chezmoi の命名規則
+
+- **`dot_` プレフィックス**: `.` で始まるファイル名（例: `dot_bashrc` → `~/.bashrc`）
+- **`.tmpl` サフィックス**: chezmoi テンプレート処理対象
+- **`.age` サフィックス**: age 暗号化ファイル
+
+### 設定分割パターン
+
+- シェル設定は `.d/` ディレクトリ内に分割管理
+- ファイルは `LC_ALL=C` でソート順に読み込まれる
+- 数字プレフィックスで読み込み順序を制御（例: `00-path.sh`、`10-history.sh`）
+
+### 暗号化戦略
+
+- age で機密情報を暗号化
+- `run_onchange_before_decrypt-private-key.sh.tmpl` で自動復号化
+- chezmoi テンプレートでマシンごとにカスタマイズ可能
+
+### マルチシェル対応
+
+- bash と zsh の両方に対応
+- `.d/` 分割設定で共通管理
+- シェル固有の設定は各シェルのディレクトリに配置
+
+### マルチエージェント対応
+
+- 各 AI エージェント専用のディレクトリを配置
+  - `dot_claude/`: Claude Code 設定
+  - `dot_codex/`: Codex エージェント設定
+  - `dot_gemini/`: Gemini エージェント設定
+  - `dot_copilot/`: GitHub Copilot 設定
+- 各エージェント独立の設定ファイルとスクリプトを管理

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,263 @@
+# Claude Code 作業方針
+
+## 目的
+
+このドキュメントは、Claude Code がこのプロジェクトで作業を行う際の方針とルールを定義します。判断の記録と透明性を重視し、他のエージェントとの連携を促進します。
+
+## 判断記録のルール
+
+判断は必ずレビュー可能な形で記録すること：
+
+1. **判断内容の要約**: 何を決定したかを明確に記載
+2. **検討した代替案**: 他にどのような選択肢があったかをリストアップ
+3. **採用しなかった案とその理由**: なぜその案を選ばなかったかを説明
+4. **前提条件・仮定・不確実性**: 判断の前提となる情報を明示
+5. **他エージェントによるレビュー可否**: Codex CLI や Gemini CLI によるレビューが必要かを判断
+
+**重要**: 前提・仮定・不確実性を明示すること。仮定を事実のように扱ってはならない。
+
+## プロジェクト概要
+
+- **目的**: chezmoi を使用して個人の dotfiles と AI エージェント設定を一元管理する
+- **主な機能**:
+  - シェル設定（bash/zsh）の集中管理
+  - AI エージェント（Claude Code、Codex、Gemini、GitHub Copilot）の設定を同期
+  - 機密情報（API キー、Webhook）の暗号化管理
+  - tmux、vim、git などのツール設定を統一
+
+## 重要ルール
+
+### 言語
+
+- **会話言語**: 日本語
+- **コード内コメント**: 日本語
+- **エラーメッセージ**: 英語
+- **日本語と英数字の間**: 半角スペースを挿入
+
+### コミット規約
+
+- **コミットメッセージ**: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) に従う
+  - `<type>(<scope>): <description>` 形式
+  - `<description>` は日本語で記載
+  - 例: `feat: ユーザー認証機能を追加`
+
+### ブランチ命名
+
+- **ブランチ命名**: [Conventional Branch](https://conventional-branch.github.io) に従う
+  - `<type>/<description>` 形式
+  - `<type>` は短縮形（feat, fix）を使用
+  - 例: `feat/add-user-auth`
+
+## 環境のルール
+
+- **GitHub リポジトリ調査**: テンポラリディレクトリに git clone してコード検索する
+- **シェル環境**: Git Bash で動作（Windows 環境）
+  - bash コマンドを使用する
+  - PowerShell コマンドは明示的に `powershell -Command ...` または `pwsh -Command ...` を使用
+- **Renovate PR の扱い**: Renovate が作成した既存のプルリクエストに対して、追加コミットや更新を行ってはならない
+
+## Git Worktree について
+
+このプロジェクトでは Git Worktree を採用していません。
+
+## コード改修時のルール
+
+- **日本語と英数字の間隔**: 半角スペースを挿入する
+- **エラーメッセージの絵文字**: 既存のエラーメッセージに絵文字がある場合、全体で統一して設定する
+- **docstring 記載**: 関数やインターフェースには docstring（JSDoc など）を日本語で記載・更新する
+
+## 相談ルール
+
+Codex CLI や Gemini CLI の他エージェントに相談することができます。以下の観点で使い分けてください。
+
+### Codex CLI (ask-codex)
+
+- 実装コードに対するソースコードレビュー
+- 関数設計、モジュール内部の実装方針などの局所的な技術判断
+- アーキテクチャ、モジュール間契約、パフォーマンス／セキュリティといった全体影響の判断
+- 実装の正当性確認、機械的ミスの検出、既存コードとの整合性確認
+
+### Gemini CLI (ask-gemini)
+
+- SaaS 仕様、言語・ランタイムのバージョン差、料金・制限・クォータといった、最新の適切な情報が必要な外部依存の判断
+- 外部一次情報の確認、最新仕様の調査、外部前提条件の検証
+
+### 指摘への対応ルール
+
+他エージェントが指摘・異議を提示した場合、Claude Code は必ず以下のいずれかを行う。**黙殺・無言での不採用は禁止する。**
+
+- 指摘を受け入れ、判断を修正する
+- 指摘を退け、その理由を明示する
+
+以下は必ず実施する：
+
+- 他エージェントの提案を鵜呑みにせず、その根拠や理由を理解する
+- 自身の分析結果と他エージェントの意見が異なる場合は、双方の視点を比較検討する
+- 最終的な判断は、両者の意見を総合的に評価した上で、自身で下す
+
+## 開発コマンド
+
+```bash
+# chezmoi の初期化（新規マシン）
+age-keygen -o ~/.config/chezmoi/key.txt
+chezmoi init <repo> --branch <branch-name>
+chezmoi apply
+
+# ドライラン（変更内容の確認）
+chezmoi apply --dry-run
+
+# 設定の適用
+chezmoi apply
+
+# リポジトリの更新
+chezmoi update
+chezmoi apply
+
+# 差分確認
+chezmoi diff
+
+# 設定ファイルの編集
+chezmoi edit <file>
+
+# 暗号化ファイルの編集
+chezmoi edit --encrypt <file>
+```
+
+## アーキテクチャと主要ファイル
+
+### ディレクトリ構造
+
+```
+dotfiles/
+├── .chezmoi.toml.tmpl              # chezmoi 設定テンプレート
+├── .chezmoiignore                  # chezmoi が無視するファイル
+├── .chezmoiroot                    # chezmoi ルートマーカー
+├── home/                            # chezmoi ソース（実ファイルの定義）
+│   ├── dot_bash_profile             # bash ログインシェル設定
+│   ├── dot_bash_profile.d/          # bash ログイン設定分割
+│   ├── dot_bashrc                   # bash インタラクティブシェル設定
+│   ├── dot_bashrc.d/                # bash 設定分割（12 ファイル）
+│   ├── dot_zprofile                 # zsh ログインシェル設定
+│   ├── dot_zprofile.d/              # zsh ログイン設定分割
+│   ├── dot_zshrc                    # zsh インタラクティブシェル設定
+│   ├── dot_zshrc.d/                 # zsh 設定分割（5 ファイル）
+│   ├── dot_p10k.zsh                 # powerlevel10k テーマ設定
+│   ├── dot_tmux.conf                # tmux マルチプレクサ設定
+│   ├── dot_vimrc                    # vim エディタ設定
+│   ├── dot_gitconfig.tmpl           # git 設定（テンプレート）
+│   ├── dot_gitignore_global         # git グローバル無視
+│   ├── dot_ssh/config               # SSH 接続設定
+│   ├── dot_claude/                  # Claude Code 設定
+│   ├── dot_codex/                   # Codex エージェント設定
+│   ├── dot_gemini/                  # Gemini エージェント設定
+│   ├── dot_copilot/                 # GitHub Copilot 設定
+│   ├── dot_config/                  # アプリケーション設定
+│   └── encrypted_dot_wakatime.cfg.age # WakaTime 設定（暗号化）
+└── run_onchange_before_decrypt-private-key.sh.tmpl  # 秘密鍵復号化フック
+```
+
+### 主要ファイル
+
+- **`.chezmoi.toml.tmpl`**: chezmoi 初期化時のテンプレート（age 暗号化設定、git ユーザー情報、Discord Webhook 設定）
+- **`.chezmoiignore`**: 配布対象外ファイル（ホワイトリスト形式）
+- **`dot_bashrc` / `dot_zshrc`**: シェル設定のメインファイル
+- **`dot_bashrc.d/` / `dot_zshrc.d/`**: シェル設定の分割管理（`LC_ALL=C` でソート順に読み込み）
+- **`dot_gitconfig.tmpl`**: git 設定テンプレート
+- **`dot_claude/`、`dot_codex/`、`dot_gemini/`、`dot_copilot/`**: 各 AI エージェント専用ディレクトリ
+- **`run_onchange_before_decrypt-private-key.sh.tmpl`**: chezmoi apply 時に age 秘密鍵を自動復号化
+
+## 実装パターン
+
+### 推奨パターン
+
+- **設定分割**: シェル設定は `.d/` ディレクトリ内に分割し、数字プレフィックスで読み込み順序を制御（例: `00-path.sh`、`10-history.sh`）
+- **chezmoi 命名規則**:
+  - `dot_` プレフィックス: `.` で始まるファイル名（例: `dot_bashrc` → `~/.bashrc`）
+  - `.tmpl` サフィックス: chezmoi テンプレート処理対象
+  - `.age` サフィックス: age 暗号化ファイル
+- **機密情報管理**: age で暗号化し、`run_onchange` フックで自動復号化
+- **テンプレート変数**: `.chezmoi.toml.tmpl` で chezmoi init 時にプロンプト入力
+
+### 非推奨パターン
+
+- **平文での機密情報保存**: API キーや認証情報を暗号化せずに保存しない
+- **ハードコードされたユーザー情報**: git user.name や user.email をハードコードしない（テンプレート化する）
+- **設定ファイルの肥大化**: 単一ファイルに全設定を記載せず、`.d/` ディレクトリで分割管理する
+
+## テスト
+
+### テスト方針
+
+- **テストフレームワーク**: なし（手動検証）
+- **検証方法**: Docker コンテナでの動作確認を推奨
+  ```bash
+  docker run -it -v $(pwd):/dotfiles ubuntu:latest
+  cd /dotfiles
+  chezmoi apply --dry-run
+  chezmoi apply
+  ```
+
+### テスト追加条件
+
+- 新しい設定ファイルや暗号化ファイルを追加した場合、Docker で動作確認を行う
+- テンプレート処理が正しく行われているかを確認する
+- シェル起動時のエラーがないかを確認する
+
+## ドキュメント更新ルール
+
+### 更新対象
+
+以下のドキュメントは、関連する変更があった場合に必ず更新する：
+
+- `README.md`: プロジェクトの概要と使用方法
+- `home/dot_bashrc.d/README.md`: bash 設定分割の説明
+- `home/dot_zshrc.d/README.md`: zsh 設定分割の説明
+- プロンプトファイル（`.github/copilot-instructions.md`、`CLAUDE.md`、`AGENTS.md`、`GEMINI.md`）
+
+### 更新タイミング
+
+- 技術スタックの変更時（言語、フレームワーク、ツールの変更）
+- 設定ファイルの追加・削除時
+- プロジェクト要件の変更時（新しい制約、要件、注意事項の追加）
+
+## 作業チェックリスト
+
+### 新規改修時
+
+1. プロジェクトについて詳細に探索し理解すること
+2. 作業を行うブランチが適切であること。すでに PR を提出しクローズされたブランチでないこと
+3. 最新のリモートブランチに基づいた新規ブランチであること
+4. PR がクローズされ、不要となったブランチは削除されていること
+5. このプロジェクトではパッケージマネージャーは使用していないため、この手順はスキップ
+
+### コミット・プッシュ前
+
+1. コミットメッセージが Conventional Commits に従っていること。ただし、`<description>` は日本語で記載する
+2. コミット内容にセンシティブな情報が含まれていないこと
+3. シェルスクリプトの構文エラーがないこと（bash -n でチェック）
+4. chezmoi apply --dry-run で動作確認を行い、期待通り動作すること
+
+### プルリクエスト作成前
+
+1. プルリクエストの作成をユーザーから依頼されていること
+2. コミット内容にセンシティブな情報が含まれていないこと
+3. コンフリクトする恐れがないこと
+
+### プルリクエスト作成後
+
+1. コンフリクトが発生していないこと
+2. PR 本文の内容は、ブランチの現在の状態を、今までのこの PR での更新履歴を含むことなく、最新の状態のみ、漏れなく日本語で記載されていること。この PR を見たユーザーが、最終的にどのような変更を含む PR なのかをわかりやすく、細かく記載されていること
+3. GitHub Actions CI が存在しないため、この手順はスキップ
+4. GitHub Copilot レビュー依頼（`request-review-copilot` コマンドが存在する場合）
+5. 10 分以内に投稿される GitHub Copilot レビューへの対応を行うこと。対応したら、レビューコメントそれぞれに対して返信を行うこと。レビュアーに GitHub Copilot がアサインされていない場合はスキップして構わない
+6. `/code-review:code-review` によるコードレビューを実施したこと。コードレビュー内容に対しては、**スコアが 50 以上の指摘事項**に対して対応する
+
+## リポジトリ固有
+
+- **chezmoi ベースの構造**: `home/` ディレクトリ配下に chezmoi ソースファイルを配置し、`chezmoi apply` で実環境に適用する
+- **暗号化戦略**: age で機密情報を暗号化し、`run_onchange` フックで自動復号化する
+  - WakaTime API キー: `encrypted_dot_wakatime.cfg.age`
+  - Discord Webhook URL: `.chezmoi.toml.tmpl` でテンプレート管理
+- **マルチシェル対応**: bash と zsh の両方に対応し、`.d/` 分割設定で共通管理
+- **マルチエージェント対応**: 各 AI エージェント専用のディレクトリを配置（`dot_claude/`、`dot_codex/`、`dot_gemini/`、`dot_copilot/`）
+- **テンプレート化**: git ユーザー情報や Discord Webhook は chezmoi テンプレートでマシンごとにカスタマイズ可能

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,156 @@
+# Gemini CLI 作業方針
+
+## 目的
+
+このドキュメントは、Gemini CLI がこのプロジェクトで作業を行う際のコンテキストと作業方針を定義します。
+
+## 出力スタイル
+
+### 言語
+
+- **会話言語**: 日本語
+- **コード内コメント**: 日本語
+- **エラーメッセージ**: 英語
+
+### トーン
+
+- 簡潔かつ明確な説明を心がける
+- 技術的な正確さを優先する
+- 前提条件や不確実性を明示する
+
+### 形式
+
+- マークダウン形式で出力する
+- コードブロックは適切な言語指定を行う
+- 日本語と英数字の間には半角スペースを挿入する
+
+## 共通ルール
+
+- **会話は日本語で行う**
+- **コミットメッセージ**: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) に従う
+  - `<type>(<scope>): <description>` 形式
+  - `<description>` は日本語で記載
+  - 例: `feat: ユーザー認証機能を追加`
+- **ブランチ命名**: [Conventional Branch](https://conventional-branch.github.io) に従う
+  - `<type>/<description>` 形式
+  - `<type>` は短縮形（feat, fix）を使用
+  - 例: `feat/add-user-auth`
+- **日本語と英数字の間**: 半角スペースを挿入する
+
+## プロジェクト概要
+
+- **目的**: chezmoi を使用して個人の dotfiles と AI エージェント設定を一元管理する
+- **主な機能**:
+  - シェル設定（bash/zsh）の集中管理
+  - AI エージェント（Claude Code、Codex、Gemini、GitHub Copilot）の設定を同期
+  - 機密情報（API キー、Webhook）の暗号化管理
+  - tmux、vim、git などのツール設定を統一
+
+## 技術スタック
+
+- **ツール**: chezmoi（dotfiles 管理フレームワーク）
+- **暗号化**: age（最小限の暗号化ツール）
+- **シェル**: Bash / Zsh
+- **テンプレート**: Go template（chezmoi 組み込み）
+- **対応 AI エージェント**: Claude Code、Codex CLI、Gemini CLI、GitHub Copilot
+
+## コーディング規約
+
+- **コメント**: 日本語で記載する
+- **エラーメッセージ**: 英語で記載する
+- **シェルスクリプト**: 既存のコーディングスタイルに従う
+- **chezmoi テンプレート**: Go template 構文を使用する
+  - ファイル名: `dot_` プレフィックスで `.` を表す
+  - テンプレート: `.tmpl` サフィックス
+  - 暗号化: `.age` サフィックス
+
+## 開発コマンド
+
+```bash
+# chezmoi の初期化（新規マシン）
+age-keygen -o ~/.config/chezmoi/key.txt
+chezmoi init <repo> --branch <branch-name>
+chezmoi apply
+
+# ドライラン（変更内容の確認）
+chezmoi apply --dry-run
+
+# 設定の適用
+chezmoi apply
+
+# リポジトリの更新
+chezmoi update
+chezmoi apply
+
+# 差分確認
+chezmoi diff
+
+# 設定ファイルの編集
+chezmoi edit <file>
+
+# 暗号化ファイルの編集
+chezmoi edit --encrypt <file>
+```
+
+## 注意事項
+
+### セキュリティ / 機密情報
+
+- **認証情報のコミット禁止**: API キーや認証情報は age で暗号化して管理する
+  - WakaTime API キー: `encrypted_dot_wakatime.cfg.age`
+  - Discord Webhook URL: `.chezmoi.toml.tmpl` でテンプレート管理
+- **ログへの機密情報出力禁止**: エラーメッセージに機密情報を含めない
+- **age 秘密鍵の管理**: `key.txt` はローカルのみ保管（リポジトリにコミットしない）
+
+### 既存ルールの優先
+
+- プロジェクトの既存のコーディングスタイルを尊重する
+- 既存の設定ファイルのパターンに従う
+- 新しい機能を追加する場合は、既存の構造に統合する
+
+### 既知の制約
+
+- **テストフレームワーク**: なし（手動検証のみ）
+- **CI/CD**: GitHub Actions は設定されていない
+- **パッケージマネージャー**: なし（Shell scripts のみ）
+
+## リポジトリ固有
+
+### chezmoi の命名規則
+
+- **`dot_` プレフィックス**: `.` で始まるファイル名（例: `dot_bashrc` → `~/.bashrc`）
+- **`.tmpl` サフィックス**: chezmoi テンプレート処理対象
+- **`.age` サフィックス**: age 暗号化ファイル
+
+### 設定分割パターン
+
+- シェル設定は `.d/` ディレクトリ内に分割管理
+- ファイルは `LC_ALL=C` でソート順に読み込まれる
+- 数字プレフィックスで読み込み順序を制御（例: `00-path.sh`、`10-history.sh`）
+
+### 暗号化戦略
+
+- age で機密情報を暗号化
+- `run_onchange_before_decrypt-private-key.sh.tmpl` で自動復号化
+- chezmoi テンプレートでマシンごとにカスタマイズ可能
+
+### マルチシェル対応
+
+- bash と zsh の両方に対応
+- `.d/` 分割設定で共通管理
+- シェル固有の設定は各シェルのディレクトリに配置
+
+### マルチエージェント対応
+
+- 各 AI エージェント専用のディレクトリを配置
+  - `dot_claude/`: Claude Code 設定
+  - `dot_codex/`: Codex エージェント設定
+  - `dot_gemini/`: Gemini エージェント設定
+  - `dot_copilot/`: GitHub Copilot 設定
+- 各エージェント独立の設定ファイルとスクリプトを管理
+
+### テンプレート化
+
+- git ユーザー情報や Discord Webhook は chezmoi テンプレートでマシンごとにカスタマイズ可能
+- `.chezmoi.toml.tmpl` で chezmoi init 時にプロンプト入力
+- 機密情報は age で暗号化し、テンプレートで動的に生成


### PR DESCRIPTION
## 概要

このプルリクエストは、AI エージェント向けのプロンプトファイルを追加します。

## 追加ファイル

### `.github/copilot-instructions.md`

GitHub Copilot 向けの指示ファイル。以下の内容を含みます：

- プロジェクト概要（目的、主な機能、対象ユーザー）
- 共通ルール（会話言語、コミット規約、日本語と英数字の間隔ルール）
- 技術スタック（chezmoi、age、Bash/Zsh、Go template）
- ディレクトリ構造
- コーディング規約（コメント、エラーメッセージ、chezmoi テンプレート）
- 開発コマンド（chezmoi の初期化、適用、更新など）
- テスト方針（Docker での手動検証）
- セキュリティ / 機密情報（認証情報のコミット禁止、ログへの機密情報出力禁止）
- ドキュメント更新ルール
- リポジトリ固有の注意事項

### `CLAUDE.md`

Claude Code 向けの作業方針ファイル。以下の内容を含みます：

- 目的（Claude Code の作業方針とプロジェクト固有ルールの定義）
- 判断記録のルール（判断内容、代替案、採用理由、前提条件、不確実性の明示）
- プロジェクト概要
- 重要ルール（言語、コミット規約、ブランチ命名）
- 環境のルール（GitHub リポジトリ調査方法、Renovate PR の扱い）
- コード改修時のルール（日本語と英数字の間隔、エラーメッセージの絵文字、docstring 記載）
- 相談ルール（Codex CLI、Gemini CLI の使い分け、指摘への対応ルール）
- 開発コマンド
- アーキテクチャと主要ファイル（ディレクトリ構造、主要ファイルの説明）
- 実装パターン（推奨パターン、非推奨パターン）
- テスト（テスト方針、テスト追加条件）
- ドキュメント更新ルール（更新対象、更新タイミング）
- 作業チェックリスト（新規改修時、コミット・プッシュ前、PR 作成前、PR 作成後）
- リポジトリ固有の注意事項

### `AGENTS.md`

一般的な AI エージェント向けの基本方針ファイル。以下の内容を含みます：

- 目的（エージェント共通の作業方針を定義）
- 基本方針（言語、コミット規約、ブランチ命名）
- 判断記録のルール（判断内容、代替案、採用理由、前提条件、不確実性の明示）
- プロジェクト概要
- 技術スタック
- ディレクトリ構造
- 開発手順（概要）（プロジェクトの理解、変更の実装、動作確認、コミットと PR）
- セキュリティ / 機密情報（認証情報のコミット禁止、ログへの機密情報出力禁止）
- リポジトリ固有の注意事項（chezmoi の命名規則、設定分割パターン、暗号化戦略、マルチシェル対応、マルチエージェント対応）

### `GEMINI.md`

Gemini CLI 向けのコンテキストと作業方針ファイル。以下の内容を含みます：

- 目的（Gemini CLI 向けのコンテキストと作業方針を定義）
- 出力スタイル（言語、トーン、形式）
- 共通ルール（会話言語、コミット規約、日本語と英数字の間隔）
- プロジェクト概要
- 技術スタック
- コーディング規約
- 開発コマンド
- 注意事項（セキュリティ / 機密情報、既存ルールの優先、既知の制約）
- リポジトリ固有の注意事項（chezmoi の命名規則、設定分割パターン、暗号化戦略、マルチシェル対応、マルチエージェント対応、テンプレート化）

## 変更内容

- 4 つの AI エージェント向けプロンプトファイルを追加
- 各ファイルは、ガイドライン `/mnt/hdd/work/20260125_create-genai-prompt-part2/PROMPT_GUIDELINES.md` に従って作成
- プロジェクトの実際の構成と内容に基づいて記載

## 参考

- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [Conventional Branch](https://conventional-branch.github.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)