### PR TITLE
fix: tmux セッション内で claude コマンドが使用できるように PATH を同期

### DIFF
--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -11,6 +11,10 @@ set -g status-interval 5
 # ステータスバーのスタイルを設定（背景色: colour235, 文字色: colour250）
 set -g status-style "bg=colour235,fg=colour250"
 
+# クライアント側の PATH を tmux サーバに同期する
+# これにより、tmux セッション内の新しいウィンドウ/ペインで最新の PATH が使用される
+set -ga update-environment "PATH"
+
 # rキーで設定ファイルをリロードする
 bind r source-file ~/.tmux.conf \; display-message "Reloaded tmux.conf"
 


### PR DESCRIPTION
## 概要

tmux セッション内で claude コマンドが使用できない問題（Issue#9）を修正しました。

## 変更内容

### `home/dot_tmux.conf`

- `set -ga update-environment "PATH"` を追加
- クライアント側の PATH を tmux サーバに同期するように設定

## 解決方法

tmux は起動時の環境変数（特に PATH）を保持し、`update-environment` に PATH が含まれていない限り更新されません。この設定により、クライアント側の PATH が tmux サーバに自動的に同期され、tmux セッション内の新しいウィンドウ/ペインで最新の PATH が使用されます。

## テスト結果

Docker 環境で以下を確認しました:

1. ログインシェル: PATH に `~/.local/bin` が含まれていない（claude コマンドが見つからない）
2. tmux セッション内: PATH に `~/.local/bin` が含まれている（claude コマンドが見つかる）
3. `update-environment` に PATH が追加されている

## 注意事項

この設定を有効にするには、tmux サーバの再起動が必要です:

\`\`\`bash
tmux kill-server
\`\`\`

## 関連 Issue

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)