### PR TITLE
feat: gcl コマンドに write 権限チェックと自動 Fork 機能を追加

### DIFF
--- a/home/dot_bashrc.d/40-ghq.sh
+++ b/home/dot_bashrc.d/40-ghq.sh
@@ -100,6 +100,7 @@ ghc() {
     elif [[ "$permission" == "null" ]] || [[ -z "$permission" ]]; then
       echo "Failed to determine repository permissions." >&2
       return 1
+    # permission == "true" の場合は write 権限があるため、そのままクローンする
     fi
   fi
 

--- a/home/dot_zshrc.d/40-ghq.zsh
+++ b/home/dot_zshrc.d/40-ghq.zsh
@@ -100,6 +100,7 @@ ghc() {
     elif [[ "$permission" == "null" ]] || [[ -z "$permission" ]]; then
       echo "Failed to determine repository permissions." >&2
       return 1
+    # permission == "true" の場合は write 権限があるため、そのままクローンする
     fi
   fi
 


### PR DESCRIPTION
## 概要

issue#13 に対応し、`gcl` コマンドにリポジトリへの write 権限チェック機能を追加しました。write 権限がない場合は自動的に Fork を作成してからクローンします。

## 変更内容

### 主要機能
- **write 権限チェック**: GitHub API の `permissions.push` でリポジトリへの write 権限を確認
- **Fork の自動作成**: write 権限がない場合、既存の Fork を確認し、存在しなければ自動作成
- **Fork の正確な判定**: `.fork` フラグと `.parent.full_name` を確認して、同名の別リポジトリとの誤認を防止
- **エラーハンドリング強化**: API エラー、認証エラー、null 値などに対する適切なエラーメッセージを追加

### バグ修正・改善
- `jq` の不要な依存チェックを削除（`gh --jq` は外部 jq 不要）
- API 失敗時のエラーハンドリングを追加
- Fork 判定の精度向上（Codex CLI レビューの指摘を反映）

## 影響範囲

- `home/dot_bashrc.d/40-ghq.sh`
- `home/dot_zshrc.d/40-ghq.zsh`

## テスト計画

- [ ] write 権限のない public リポジトリで Fork が自動作成されることを確認
- [ ] 既存の Fork がある場合、再作成せずに Fork を使用することを確認
- [ ] write 権限のあるリポジトリで通常通りクローンできることを確認
- [ ] API エラー時に適切なエラーメッセージが表示されることを確認

## 関連 Issue

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)