### PR TITLE
fix: extraKnownMarketplaces を record 形式に修正

### DIFF
--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -2,20 +2,20 @@
   "env": {
     "IS_DEMO": "1"
   },
-  "extraKnownMarketplaces": [
-    {
-      "type": "github",
-      "owner": "hiroro-work",
-      "repo": "claude-plugins",
-      "alias": "hiropon-plugins"
+  "extraKnownMarketplaces": {
+    "hiropon-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "hiroro-work/claude-plugins"
+      }
     },
-    {
-      "type": "github",
-      "owner": "wakatime",
-      "repo": "claude-code-wakatime",
-      "alias": "wakatime"
+    "wakatime": {
+      "source": {
+        "source": "github",
+        "repo": "wakatime/claude-code-wakatime"
+      }
     }
-  ],
+  },
   "hooks": {
     "Stop": [
       {


### PR DESCRIPTION
## Summary

Claude Code settings.json の `extraKnownMarketplaces` 設定を配列形式から record 形式に修正しました。

## 主な変更点

- `extraKnownMarketplaces` を配列（array）から record（オブジェクト）形式に変更
- 各マーケットプレイスの定義を Claude Code が期待する形式に修正:
  - `hiropon-plugins`: `hiroro-work/claude-plugins`
  - `wakatime`: `wakatime/claude-code-wakatime`

## 修正前

```json
"extraKnownMarketplaces": [
  {
    "type": "github",
    "owner": "hiroro-work",
    "repo": "claude-plugins",
    "alias": "hiropon-plugins"
  },
  ...
]
```

## 修正後

```json
"extraKnownMarketplaces": {
  "hiropon-plugins": {
    "source": {
      "source": "github",
      "repo": "hiroro-work/claude-plugins"
    }
  },
  ...
}
```

## テスト結果

- JSON 形式の検証: OK
- `enabledPlugins` の参照との整合性確認: OK

---

- Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)