### PR TITLE
fix: ghc コマンドで Fork 時に upstream を登録

### DIFF
--- a/home/dot_bashrc.d/executable_40-ghq.sh
+++ b/home/dot_bashrc.d/executable_40-ghq.sh
@@ -95,7 +95,7 @@ ghc() {
         return 1
       fi
 
-      # 元のリポジトリ名を保存（ upstream 登録用）
+      # 元のリポジトリ名を保存（upstream 登録用）
       original_repo_name="$repo_name"
 
       # Fork のリポジトリに変更
@@ -115,7 +115,7 @@ ghc() {
 
   # リポジトリを取得
   if ! ghq get "$repo"; then
-    echo "Failed to clone repository." >&2
+    echo "Failed to clone repository. Please check if ghq is properly configured." >&2
     return 1
   fi
 
@@ -124,11 +124,16 @@ ghc() {
   if [[ -n "$repo_name" ]]; then
     repo_path=$(ghq list -p -e "$repo_name")
   else
+    # URL 形式の場合は ghq list で検索（複数マッチの可能性に注意）
     repo_path=$(ghq list -p "$repo" | head -n1)
+    if [[ -z "$repo_path" ]]; then
+      echo "Failed to find repository in ghq list." >&2
+      return 1
+    fi
   fi
 
   if [[ -z "$repo_path" ]]; then
-    echo "Failed to get repository path." >&2
+    echo "Failed to get repository path. Please check if the repository was cloned successfully." >&2
     return 1
   fi
 

--- a/home/dot_zshrc.d/executable_40-ghq.zsh
+++ b/home/dot_zshrc.d/executable_40-ghq.zsh
@@ -95,7 +95,7 @@ ghc() {
         return 1
       fi
 
-      # 元のリポジトリ名を保存（ upstream 登録用）
+      # 元のリポジトリ名を保存（upstream 登録用）
       original_repo_name="$repo_name"
 
       # Fork のリポジトリに変更
@@ -115,7 +115,7 @@ ghc() {
 
   # リポジトリを取得
   if ! ghq get "$repo"; then
-    echo "Failed to clone repository." >&2
+    echo "Failed to clone repository. Please check if ghq is properly configured." >&2
     return 1
   fi
 
@@ -124,11 +124,16 @@ ghc() {
   if [[ -n "$repo_name" ]]; then
     repo_path=$(ghq list -p -e "$repo_name")
   else
+    # URL 形式の場合は ghq list で検索（複数マッチの可能性に注意）
     repo_path=$(ghq list -p "$repo" | head -n1)
+    if [[ -z "$repo_path" ]]; then
+      echo "Failed to find repository in ghq list." >&2
+      return 1
+    fi
   fi
 
   if [[ -z "$repo_path" ]]; then
-    echo "Failed to get repository path." >&2
+    echo "Failed to get repository path. Please check if the repository was cloned successfully." >&2
     return 1
   fi
 


### PR DESCRIPTION
## Summary

`ghc` (`gcl`) コマンドで Fork したリポジトリをクローンする際、元のリポジトリが upstream として自動登録されるように改善しました。

## 問題

`ghc`/`gcl` コマンドで write 権限がないリポジトリをクローンする際、自動的に Fork が作成されますが、元のリポジトリが upstream として登録されませんでした。

### 修正前の動作

1. write 権限がないリポジトリを `ghc`/`gcl` でクローンしようとする
2. 自動的に Fork を作成
3. `ghq get --look` で Fork をクローン（サブシェルを起動）
4. サブシェル終了後、元のシェルで `git remote add upstream` を実行
5. **upstream が誤ったディレクトリで登録される** ⚠️

### 修正後の動作

1. write 権限がないリポジトリを `ghc`/`gcl` でクローンしようとする
2. 自動的に Fork を作成
3. `ghq get` で Fork をクローン
4. `ghq list -p` でクローン先のパスを取得
5. `cd` でクローンしたディレクトリに移動
6. **元のリポジトリを upstream として正しく登録** ✅

## 主な変更点

- **元のリポジトリ名の保存**: Fork 作成時に元のリポジトリ名を `original_repo_name` 変数に保存
- **正しいディレクトリでの upstream 登録**: `ghq get` でクローン後、`ghq list -p` でパスを取得し `cd` で移動してから upstream を登録
- **エラーハンドリング**: クローン失敗時、パス取得失敗時のエラーハンドリングを追加
- **重複チェック**: 既に upstream が存在する場合はスキップ
- **対応シェル**: bash (`executable_40-ghq.sh`) と zsh (`executable_40-ghq.zsh`) の両方に対応
- **CLAUDE.md 準拠**: 日本語と英数字の間の半角スペースを適切に配置
- **エラーメッセージの改善**: ユーザーへのヒントを含む詳細なエラーメッセージ

## コード例

```bash
# Fork した場合は upstream を登録
if [[ -n "$original_repo_name" ]]; then
  echo "Adding upstream remote..."
  if git remote get-url upstream &>/dev/null; then
    echo "Upstream remote already exists."
  else
    git remote add upstream "git@github.com:${original_repo_name}.git"
    echo "Upstream remote added: $original_repo_name"
  fi
fi
```

## テスト方法

1. Docker コンテナで検証環境を構築
2. Fork が必要なリポジトリで `ghc <owner/repo>` を実行
3. `git remote -v` で upstream が正しく登録されていることを確認

## 影響範囲

- bash および zsh で `ghc`/`gcl` コマンドを使用し、write 権限がないリポジトリをクローンする場合
- 既存の挙動（Fork 作成、クローン）には影響なし

## レビュー対応

### 初回コードレビュー指摘事項

1. **重大なバグ修正** (005af19): `ghq get --look` がサブシェルを起動するため、`git remote add upstream` が誤ったディレクトリで実行される問題を修正
2. **CLAUDE.md 違反修正** (005af19): 日本語と英数字の間に半角スペースを追加

### GitHub Copilot 指摘事項

1. **エラーハンドリング追加** (005af19): `ghq get` 失敗時のエラーハンドリングを追加

### 2回目コードレビュー指摘事項

1. **日本語と英数字の間のスペース修正** (92255b1): コメント内の `（ upstream` を `（upstream` に修正（CLAUDE.md 準拠）
2. **ghq list の曖昧性対応** (92255b1): URL 形式の場合のエラーハンドリングを追加
3. **エラーメッセージの改善** (92255b1): ユーザーへのヒントを含む詳細なエラーメッセージに変更

## 関連 Issue

- Closes #40

## 関連 PR

- PR #46: hookify と chezmoi の統合（シンボリックリンク）
  - 当初は本 PR に含まれていましたが、関心事の分離のため別 PR に分割しました