### PR TITLE
fix: shellcheck 警告の修正

### DIFF
--- a/home/dot_bash_profile
+++ b/home/dot_bash_profile
@@ -1,5 +1,6 @@
 # Load interactive settings.
 if [ -f "$HOME/.bashrc" ]; then
+  # shellcheck source=/dev/null
   . "$HOME/.bashrc"
 fi
 
@@ -8,6 +9,7 @@ if [ -d "$HOME/.bash_profile.d" ]; then
   shopt -s nullglob
   mapfile -t __bash_profile_files < <(LC_ALL=C printf '%s\n' "$HOME/.bash_profile.d/"*.sh | LC_ALL=C sort)
   for f in "${__bash_profile_files[@]}"; do
+    # shellcheck source=/dev/null
     [ -r "$f" ] && . "$f"
   done
   unset f __bash_profile_files

--- a/home/dot_bash_profile.d/executable_10-tmux-selector.sh
+++ b/home/dot_bash_profile.d/executable_10-tmux-selector.sh
@@ -36,8 +36,8 @@ tmux_session_selector() {
     if [[ -d "$d" ]]; then
       local f
       for f in "$d"/*.sh; do
-        [[ -f "$f" ]] && # shellcheck source=/dev/null
-          source "$f"
+        # shellcheck source=/dev/null
+        [[ -f "$f" ]] && source "$f"
       done
     fi
   }

--- a/home/dot_bash_profile.d/executable_10-tmux-selector.sh
+++ b/home/dot_bash_profile.d/executable_10-tmux-selector.sh
@@ -137,6 +137,7 @@ tmux_session_selector() {
   # --- fzf preview ---
   # クォート崩壊を避けるため、bash -c に {1}{2}{4} を引数で渡す
   local preview_cmd
+  # shellcheck disable=SC2016
   preview_cmd='bash -c '\''
   t="$1"; key="$2"; pane="$3";
   lines="${TMUX_FZF_PREVIEW_LINES:-15}"

--- a/home/dot_bashrc
+++ b/home/dot_bashrc
@@ -9,6 +9,7 @@ if [ -d "$HOME/.bashrc.d" ]; then
   shopt -s nullglob
   mapfile -t __bashrc_files < <(LC_ALL=C printf '%s\n' "$HOME/.bashrc.d/"*.sh | LC_ALL=C sort)
   for f in "${__bashrc_files[@]}"; do
+    # shellcheck source=/dev/null
     [ -r "$f" ] && . "$f"
   done
   unset f __bashrc_files

--- a/home/dot_bashrc.d/executable_40-ghq.sh
+++ b/home/dot_bashrc.d/executable_40-ghq.sh
@@ -9,7 +9,7 @@ gcd() {
   # fzfを使ってリポジトリを選択
   dir="$(ghq list -p | fzf)" || return 1
   # 選択されたディレクトリが存在すれば移動
-  [[ -n "$dir" ]] && cd "$dir" || return
+  [[ -n "$dir" ]] && { cd "$dir" || return; }
 }
 
 # リポジトリを ghq get し、必要に応じて移動や表示を行う関数

--- a/home/dot_bashrc.d/executable_40-ghq.sh
+++ b/home/dot_bashrc.d/executable_40-ghq.sh
@@ -9,7 +9,7 @@ gcd() {
   # fzfを使ってリポジトリを選択
   dir="$(ghq list -p | fzf)" || return 1
   # 選択されたディレクトリが存在すれば移動
-  [[ -n "$dir" ]] && cd "$dir"
+  [[ -n "$dir" ]] && cd "$dir" || return
 }
 
 # リポジトリを ghq get し、必要に応じて移動や表示を行う関数

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -69,6 +69,7 @@ GRAPHQL_RESPONSE=$(gh api graphql \
   -f owner="$OWNER" \
   -f repo="$REPO" \
   -F number="$PR_NUMBER" \
+  # shellcheck disable=SC2016
   -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -121,6 +122,7 @@ while IFS= read -r thread; do
     break
   fi
 
+  # shellcheck disable=SC2034
   THREAD_ID=$(echo "$thread" | jq -r '.id' 2>/dev/null)
   THREAD_PATH=$(echo "$thread" | jq -r '.path // "unknown"' 2>/dev/null)
   THREAD_LINE=$(echo "$thread" | jq -r '.line // "N/A"' 2>/dev/null)

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -65,11 +65,11 @@ fi
 
 # GraphQL API で未解決レビュースレッドを取得
 # セキュリティのため、変数をパラメータ化して使用
+# shellcheck disable=SC2016
 GRAPHQL_RESPONSE=$(gh api graphql \
   -f owner="$OWNER" \
   -f repo="$REPO" \
   -F number="$PR_NUMBER" \
-  # shellcheck disable=SC2016
   -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {

--- a/home/dot_claude/scripts/completion-notify/executable_notify-completion.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-completion.sh
@@ -11,6 +11,7 @@
 # }
 
 cd "$(dirname "$0")" || exit 1
+# shellcheck source=/dev/null
 source ./.env
 
 # Windowsパスをシェル互換パスに変換する関数
@@ -30,7 +31,7 @@ convert_path() {
   if [[ "$path" =~ ^[A-Za-z]: ]]; then
     local third_char="${path:2:1}"
     # 3文字目がスラッシュまたはバックスラッシュの場合のみ変換
-    if [[ "$third_char" == "/" ]] || [[ "$third_char" == '\' ]]; then
+    if [[ "$third_char" == "/" ]] || [[ "$third_char" == "\\" ]]; then
       local drive_letter="${path:0:1}"
       local rest="${path:2}"
       # バックスラッシュをスラッシュに変換 (tr を使用)
@@ -127,7 +128,7 @@ LAST_MESSAGES=$(jq -r '
     ]
   | select(.[1] != "")
   | @tsv
-' $SESSION_PATH | tail -n 5)
+' "$SESSION_PATH" | tail -n 5)
 if [[ -n "$LAST_MESSAGES" ]]; then
   IFS=$'\n' read -r -d '' -a messages_array <<< "$LAST_MESSAGES"
   for message in "${messages_array[@]}"; do

--- a/home/dot_claude/scripts/completion-notify/executable_notify-completion.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-completion.sh
@@ -35,6 +35,7 @@ convert_path() {
       local drive_letter="${path:0:1}"
       local rest="${path:2}"
       # バックスラッシュをスラッシュに変換 (tr を使用)
+      # shellcheck disable=SC1003
       rest=$(echo "$rest" | tr '\\' '/')
       # ドライブレターを小文字に変換
       drive_letter=$(echo "$drive_letter" | tr '[:upper:]' '[:lower:]')

--- a/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
@@ -38,6 +38,7 @@ convert_path() {
       local drive_letter="${path:0:1}"
       local rest="${path:2}"
       # バックスラッシュをスラッシュに変換 (tr を使用)
+      # shellcheck disable=SC1003
       rest=$(echo "$rest" | tr '\\' '/')
       # ドライブレターを小文字に変換
       drive_letter=$(echo "$drive_letter" | tr '[:upper:]' '[:lower:]')

--- a/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
@@ -14,6 +14,7 @@
 # }
 
 cd "$(dirname "$0")" || exit 1
+# shellcheck source=/dev/null
 source ./.env
 
 # Windows パスをシェル互換パスに変換する関数
@@ -33,7 +34,7 @@ convert_path() {
   if [[ "$path" =~ ^[A-Za-z]: ]]; then
     local third_char="${path:2:1}"
     # 3 文字目がスラッシュまたはバックスラッシュの場合のみ変換
-    if [[ "$third_char" == "/" ]] || [[ "$third_char" == '\' ]]; then
+    if [[ "$third_char" == "/" ]] || [[ "$third_char" == "\\" ]]; then
       local drive_letter="${path:0:1}"
       local rest="${path:2}"
       # バックスラッシュをスラッシュに変換 (tr を使用)
@@ -175,7 +176,7 @@ LAST_MESSAGES=$(jq -r '
     ]
   | select(.[1] != "")
   | @tsv
-' $SESSION_PATH | tail -n 5)
+' "$SESSION_PATH" | tail -n 5)
 if [[ -n "$LAST_MESSAGES" ]]; then
   IFS=$'\n' read -r -d '' -a messages_array <<< "$LAST_MESSAGES"
   for message in "${messages_array[@]}"; do

--- a/home/dot_claude/scripts/completion-notify/executable_notify-permission-request.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-permission-request.sh
@@ -14,6 +14,7 @@
 # }
 
 cd "$(dirname "$0")" || exit 1
+# shellcheck source=/dev/null
 source ./.env
 
 # Windows パスをシェル互換パスに変換する関数
@@ -33,7 +34,7 @@ convert_path() {
   if [[ "$path" =~ ^[A-Za-z]: ]]; then
     local third_char="${path:2:1}"
     # 3 文字目がスラッシュまたはバックスラッシュの場合のみ変換
-    if [[ "$third_char" == "/" ]] || [[ "$third_char" == '\' ]]; then
+    if [[ "$third_char" == "/" ]] || [[ "$third_char" == "\\" ]]; then
       local drive_letter="${path:0:1}"
       local rest="${path:2}"
       # バックスラッシュをスラッシュに変換 (tr を使用)
@@ -139,7 +140,7 @@ LAST_MESSAGES=$(jq -r '
     ]
   | select(.[1] != "")
   | @tsv
-' $SESSION_PATH | tail -n 5)
+' "$SESSION_PATH" | tail -n 5)
 if [[ -n "$LAST_MESSAGES" ]]; then
   IFS=$'\n' read -r -d '' -a messages_array <<< "$LAST_MESSAGES"
   for message in "${messages_array[@]}"; do

--- a/home/dot_claude/scripts/completion-notify/executable_notify-permission-request.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-permission-request.sh
@@ -38,6 +38,7 @@ convert_path() {
       local drive_letter="${path:0:1}"
       local rest="${path:2}"
       # バックスラッシュをスラッシュに変換 (tr を使用)
+      # shellcheck disable=SC1003
       rest=$(echo "$rest" | tr '\\' '/')
       # ドライブレターを小文字に変換
       drive_letter=$(echo "$drive_letter" | tr '[:upper:]' '[:lower:]')

--- a/home/dot_claude/scripts/completion-notify/executable_notify-user-prompt-submit.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-user-prompt-submit.sh
@@ -11,6 +11,7 @@
 # }
 
 cd "$(dirname "$0")" || exit 1
+# shellcheck source=/dev/null
 source ./.env
 
 # データディレクトリの作成
@@ -18,6 +19,7 @@ DATA_DIR="$HOME/.claude/scripts/completion-notify/data"
 mkdir -p "$DATA_DIR"
 
 # 入力 JSON を読み取る（使用しないが標準入力を消費する）
+# shellcheck disable=SC2034
 INPUT_JSON=$(cat)
 
 # 現在時刻を Unix timestamp で記録

--- a/home/dot_claude/scripts/completion-notify/executable_send-discord-notification.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_send-discord-notification.sh
@@ -2,6 +2,7 @@
 # バックグラウンド通知処理: 1 分待機後、条件を満たせば Discord に通知を送信
 
 cd "$(dirname "$0")" || exit 1
+# shellcheck source=/dev/null
 source ./.env
 
 export DISCORD_WEBHOOK_URL="${DISCORD_CLAUDE_WEBHOOK:-}"

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -9,10 +9,11 @@ PAST_FILE="$HOME/.claude/scripts/limit-unlocked/data/past.txt"
 FUTURE_FILE="$HOME/.claude/scripts/limit-unlocked/data/future.txt"
 NOTIFIED_FILE="$HOME/.claude/scripts/limit-unlocked/data/notified.txt"
 
+# shellcheck source=/dev/null
 source ./.env
 
-> "$PAST_FILE"
-> "$FUTURE_FILE"
+: > "$PAST_FILE"
+: > "$FUTURE_FILE"
 
 find "$TARGET_DIR" -type f -name "*.jsonl" | while read -r file; do
     jq -c '

--- a/install.sh
+++ b/install.sh
@@ -318,7 +318,7 @@ install_chezmoi() {
 
   # PATH の確認と案内
   if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    log_warn "~/.local/bin が PATH に含まれていません"
+    log_warn "$HOME/.local/bin が PATH に含まれていません"
     log_warn "シェル設定ファイルに以下の行を追加してください:"
     log_warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
 
@@ -465,7 +465,7 @@ install_ghq() {
   temp_dir=$(mktemp -d)
 
   # 一時ディレクトリのクリーンアップを設定
-  trap "rm -rf '$temp_dir'" RETURN
+  trap 'rm -rf "$temp_dir"' RETURN
 
   if [[ ! -d "$temp_dir" ]]; then
     log_error "Failed to create temporary directory"

--- a/install.sh
+++ b/install.sh
@@ -593,6 +593,7 @@ setup_gitconfig_local() {
 
     local git_email
     read -r -p "Git メールアドレス: " git_email
+    # shellcheck disable=SC2129
     echo "    email = $git_email" >> "$gitconfig_local"
 
     # ghq.root 設定
@@ -688,6 +689,7 @@ setup_env() {
 EOF
 
   # Claude completion-notify
+  # shellcheck disable=SC2129
   echo "# -----------------------------------------" >> "$env_file"
   echo "# Discord Webhooks - Claude completion-notify" >> "$env_file"
   echo "# -----------------------------------------" >> "$env_file"
@@ -702,6 +704,7 @@ EOF
 
   local mention_user_id
   read -r -p "メンションする Discord ユーザー ID (空欄でスキップ): " mention_user_id
+  # shellcheck disable=SC2129
   echo "DISCORD_CLAUDE_MENTION_USER_ID=\"$mention_user_id\"" >> "$env_file"
   echo "" >> "$env_file"
 
@@ -718,6 +721,7 @@ EOF
   fi
 
   read -r -p "メンションする Discord ユーザー ID (空欄でスキップ): " mention_user_id
+  # shellcheck disable=SC2129
   echo "DISCORD_CLAUDE_LIMIT_MENTION_USER_ID=\"$mention_user_id\"" >> "$env_file"
   echo "" >> "$env_file"
 

--- a/update.sh
+++ b/update.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-cd $HOME || exit
+cd "$HOME" || exit
 sh -c "$(curl -fsSL get.chezmoi.io)" -- update


### PR DESCRIPTION
## 概要

CI テストで発生していた shellcheck 警告をすべて修正しました。

## 修正内容

### SC1091/SC1090: 動的 source の警告抑制

動的に source されるファイル (.env, .bashrc.d/*.sh など) に `# shellcheck source=/dev/null` ディレクティブを追加しました。

**修正ファイル**:
- 通知スクリプト (6 ファイル): `.env` source
- `home/dot_bashrc`: `.bashrc.d/*.sh` source
- `home/dot_bash_profile`: `.bashrc` と `.bash_profile.d/*.sh` source

### SC2188: リダイレクション単体

`> "$FILE"` を `: > "$FILE"` に修正しました。

**修正ファイル**:
- `home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh`

### SC2086: クォート不足

変数を適切にクォートしました。

**修正ファイル**:
- `update.sh`: `cd $HOME` → `cd "$HOME"`
- 通知スクリプト (3 ファイル): `$SESSION_PATH` → `"$SESSION_PATH"`

### SC2164: cd のエラーハンドリング

`cd "$dir"` に `|| return` を追加しました。

**修正ファイル**:
- `home/dot_bashrc.d/executable_40-ghq.sh`

### SC2034: 未使用変数

意図的に未使用の変数に `# shellcheck disable=SC2034` を追加しました。

**修正ファイル**:
- `home/dot_claude/scripts/completion-notify/executable_notify-user-prompt-submit.sh`: `INPUT_JSON`
- `home/dot_claude/hooks/executable_require-review-thread-fixes.sh`: `THREAD_ID`

### SC2016: シングルクォート内の変数展開

GraphQL クエリや bash -c スクリプトで意図的にシングルクォートを使用している箇所に `# shellcheck disable=SC2016` を追加しました。

**修正ファイル**:
- `home/dot_claude/hooks/executable_require-review-thread-fixes.sh`
- `home/dot_bash_profile.d/executable_10-tmux-selector.sh`

### SC1003: バックスラッシュのエスケープ

`tr` コマンドでバックスラッシュを扱う箇所に `# shellcheck disable=SC1003` を追加しました。

**修正ファイル**:
- 通知スクリプト (3 ファイル)

### SC2064: trap コマンドのクォート

trap コマンドで二重引用符を単一引用符に変更し、変数がシグナル受信時に展開されるようにしました。

**修正ファイル**:
- `install.sh`: `trap "rm -rf '$temp_dir'"` → `trap 'rm -rf "$temp_dir"'`

### SC2129: 複数リダイレクションのスタイル

対話的な入力を含む箇所では、ブロックでまとめると可読性が低下するため `# shellcheck disable=SC2129` を追加しました。

**修正ファイル**:
- `install.sh` (4 箇所)

## 動作確認

すべての CI チェックが成功しました:
- ✅ Shellcheck
- ✅ Bash Syntax Check
- ✅ Chezmoi Configuration Verify
- ✅ JSON Schema Validation
- ✅ Test chezmoi apply
- ✅ Test chezmoi apply in Docker
- ✅ Unit Tests

## 関連 PR

- PR #50: CI テストインフラストラクチャの実装
- PR #52: CI ワークフローの改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)