### PR TITLE
fix: ping ベースのネットワークチェックを curl に変更

### DIFF
--- a/home/bin/executable_update-ai-agents.sh
+++ b/home/bin/executable_update-ai-agents.sh
@@ -66,10 +66,22 @@ check_timestamp() {
 
 # ネットワーク接続チェック
 check_network() {
-    if ! ping -c 1 -W 2 8.8.8.8 >/dev/null 2>&1; then
-        log "⚠️  No network connection, skipping update"
-        exit 0
-    fi
+    # 複数のエンドポイントを試行
+    local targets=(
+        "https://www.google.com"
+        "https://1.1.1.1"
+    )
+
+    for target in "${targets[@]}"; do
+        if curl -s --connect-timeout 3 --max-time 5 "$target" >/dev/null 2>&1; then
+            # いずれか 1 つが成功すれば OK
+            return 0
+        fi
+    done
+
+    # すべて失敗した場合
+    log "⚠️  No network connection, skipping update"
+    exit 0
 }
 
 # ディスク容量チェック

--- a/home/bin/executable_update-ai-agents.sh
+++ b/home/bin/executable_update-ai-agents.sh
@@ -66,6 +66,12 @@ check_timestamp() {
 
 # ネットワーク接続チェック
 check_network() {
+    # curl コマンドの存在確認
+    if ! command -v curl >/dev/null 2>&1; then
+        log "⚠️  curl not found, skipping network check"
+        return 0  # curl がない場合は更新を続行
+    fi
+
     # 複数のエンドポイントを試行
     local targets=(
         "https://www.google.com"


### PR DESCRIPTION
## Summary

Issue #58 で報告されたネットワーク接続チェックの誤検知問題を修正しました。

## 問題の概要

従来の `ping` コマンドによる ICMP パケットを使用したネットワーク接続チェックは、ファイアウォールや環境設定により ICMP がブロックされている場合に誤検知する問題がありました。

## 主な変更点

### 修正内容

- **ping から curl への変更**: ICMP プロトコルの制約を回避し、HTTPS リクエストによるチェックに変更
- **複数エンドポイントの試行**: google.com と 1.1.1.1 を順に試行し、いずれか 1 つが成功すればネットワーク接続可能と判定
- **タイムアウト設定の追加**: `--connect-timeout 3` と `--max-time 5` を設定し、レスポンス遅延に対応
- **curl 依存チェックの追加**: コードレビュー指摘を受け、curl コマンドの存在確認を追加

### 修正前

```bash
check_network() {
    if ! ping -c 1 -W 2 8.8.8.8 >/dev/null 2>&1; then
        log "⚠️  No network connection, skipping update"
        exit 0
    fi
}
```

### 修正後

```bash
check_network() {
    # curl コマンドの存在確認
    if ! command -v curl >/dev/null 2>&1; then
        log "⚠️  curl not found, skipping network check"
        return 0  # curl がない場合は更新を続行
    fi

    # 複数のエンドポイントを試行
    local targets=(
        "https://www.google.com"
        "https://1.1.1.1"
    )

    for target in "${targets[@]}"; do
        if curl -s --connect-timeout 3 --max-time 5 "$target" >/dev/null 2>&1; then
            # いずれか 1 つが成功すれば OK
            return 0
        fi
    done

    # すべて失敗した場合
    log "⚠️  No network connection, skipping update"
    exit 0
}
```

## テスト結果

- ✅ 正常なネットワーク環境で動作確認済み
- ✅ ネットワーク接続チェックが正常に動作し、スクリプトが続行されることを確認
- ✅ curl の存在確認が正常に動作することを確認

## 影響範囲

- `home/bin/executable_update-ai-agents.sh` の `check_network()` 関数のみ
- 既存の他の機能には影響なし

## 既知の制限事項

- HTTPS エンドポイントを使用するため、証明書検証の問題やプロキシ環境で誤検知する可能性があります
- この制限は、Issue #58 で報告された ping の問題とのトレードオフです

- Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)