### PR TITLE
fix: idle_prompt 通知の重複送信を防止

### DIFF
--- a/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
@@ -109,22 +109,40 @@ if [[ "$NOTIFICATION_TYPE" == "idle_prompt" ]]; then
   else
     # セッション ID ごとに最後の通知タイムスタンプを記録
     LAST_IDLE_NOTIFY_FILE="$DATA_DIR/last-idle-notify-${SESSION_ID}.txt"
+    LOCK_DIR="$DATA_DIR/last-idle-notify-${SESSION_ID}.lock"
     COOLDOWN_SECONDS=60  # 60 秒以内の重複通知をスキップ
 
-    # 最後の通知時刻を取得
-    if [[ -f "$LAST_IDLE_NOTIFY_FILE" ]]; then
-      LAST_NOTIFY_TIME=$(cat "$LAST_IDLE_NOTIFY_FILE")
-      CURRENT_TIME=$(date +%s)
-      ELAPSED=$((CURRENT_TIME - LAST_NOTIFY_TIME))
+    # ロック取得を試行（mkdir はアトミック操作）
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      # ロック取得に成功した場合のみ処理を続行
+      trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT
 
-      if [[ $ELAPSED -lt $COOLDOWN_SECONDS ]]; then
-        echo "⏱️ Skipping idle_prompt notification (cooldown: ${ELAPSED}s < ${COOLDOWN_SECONDS}s)" >&2
-        exit 0
+      # 最後の通知時刻を取得
+      if [[ -f "$LAST_IDLE_NOTIFY_FILE" ]]; then
+        LAST_NOTIFY_TIME=$(cat "$LAST_IDLE_NOTIFY_FILE")
+
+        # 数値検証（既存コードの send-discord-notification.sh と同じパターン）
+        if [[ "$LAST_NOTIFY_TIME" =~ ^[0-9]+$ ]]; then
+          CURRENT_TIME=$(date +%s)
+          ELAPSED=$((CURRENT_TIME - LAST_NOTIFY_TIME))
+
+          if [[ $ELAPSED -lt $COOLDOWN_SECONDS ]]; then
+            echo "⏱️ Skipping idle_prompt notification (cooldown: ${ELAPSED}s < ${COOLDOWN_SECONDS}s)" >&2
+            rmdir "$LOCK_DIR" 2>/dev/null
+            exit 0
+          fi
+        else
+          echo "⚠️ LAST_NOTIFY_TIME is invalid, skipping cooldown check" >&2
+        fi
       fi
-    fi
 
-    # 現在時刻を記録
-    date +%s > "$LAST_IDLE_NOTIFY_FILE"
+      # 現在時刻を記録
+      date +%s > "$LAST_IDLE_NOTIFY_FILE"
+      rmdir "$LOCK_DIR" 2>/dev/null
+    else
+      # ロック取得に失敗した場合は別プロセスが処理中なのでスキップ
+      echo "⏸️ Another process is checking idle_prompt cooldown, skipping" >&2
+    fi
   fi
 fi
 

--- a/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
@@ -103,24 +103,29 @@ mkdir -p "$DATA_DIR"
 
 # idle_prompt の重複送信防止ロジック
 if [[ "$NOTIFICATION_TYPE" == "idle_prompt" ]]; then
-  # セッション ID ごとに最後の通知タイムスタンプを記録
-  LAST_IDLE_NOTIFY_FILE="$DATA_DIR/last-idle-notify-${SESSION_ID}.txt"
-  COOLDOWN_SECONDS=60  # 60 秒以内の重複通知をスキップ
+  # SESSION_ID が空の場合はスキップ（セッション単位の管理ができない）
+  if [[ -z "$SESSION_ID" ]]; then
+    echo "⚠️ SESSION_ID is empty, skipping cooldown check" >&2
+  else
+    # セッション ID ごとに最後の通知タイムスタンプを記録
+    LAST_IDLE_NOTIFY_FILE="$DATA_DIR/last-idle-notify-${SESSION_ID}.txt"
+    COOLDOWN_SECONDS=60  # 60 秒以内の重複通知をスキップ
 
-  # 最後の通知時刻を取得
-  if [[ -f "$LAST_IDLE_NOTIFY_FILE" ]]; then
-    LAST_NOTIFY_TIME=$(cat "$LAST_IDLE_NOTIFY_FILE")
-    CURRENT_TIME=$(date +%s)
-    ELAPSED=$((CURRENT_TIME - LAST_NOTIFY_TIME))
+    # 最後の通知時刻を取得
+    if [[ -f "$LAST_IDLE_NOTIFY_FILE" ]]; then
+      LAST_NOTIFY_TIME=$(cat "$LAST_IDLE_NOTIFY_FILE")
+      CURRENT_TIME=$(date +%s)
+      ELAPSED=$((CURRENT_TIME - LAST_NOTIFY_TIME))
 
-    if [[ $ELAPSED -lt $COOLDOWN_SECONDS ]]; then
-      echo "⏱️ Skipping idle_prompt notification (cooldown: ${ELAPSED}s < ${COOLDOWN_SECONDS}s)" >&2
-      exit 0
+      if [[ $ELAPSED -lt $COOLDOWN_SECONDS ]]; then
+        echo "⏱️ Skipping idle_prompt notification (cooldown: ${ELAPSED}s < ${COOLDOWN_SECONDS}s)" >&2
+        exit 0
+      fi
     fi
-  fi
 
-  # 現在時刻を記録
-  date +%s > "$LAST_IDLE_NOTIFY_FILE"
+    # 現在時刻を記録
+    date +%s > "$LAST_IDLE_NOTIFY_FILE"
+  fi
 fi
 
 # 現在時刻の取得

--- a/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-notification.sh
@@ -142,6 +142,7 @@ if [[ "$NOTIFICATION_TYPE" == "idle_prompt" ]]; then
     else
       # ロック取得に失敗した場合は別プロセスが処理中なのでスキップ
       echo "⏸️ Another process is checking idle_prompt cooldown, skipping" >&2
+      exit 0
     fi
   fi
 fi

--- a/home/dot_claude/scripts/completion-notify/executable_notify-user-prompt-submit.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-user-prompt-submit.sh
@@ -18,9 +18,12 @@ source ./.env
 DATA_DIR="$HOME/.claude/scripts/completion-notify/data"
 mkdir -p "$DATA_DIR"
 
-# 入力 JSON を読み取る（使用しないが標準入力を消費する）
+# 入力 JSON を読み取り
 # shellcheck disable=SC2034
 INPUT_JSON=$(cat)
+
+# セッション ID を取得
+SESSION_ID=$(echo "$INPUT_JSON" | jq -r '.session_id // empty')
 
 # 現在時刻を Unix timestamp で記録
 CURRENT_TIME=$(date +%s)
@@ -28,5 +31,14 @@ echo "$CURRENT_TIME" > "$DATA_DIR/last-prompt-time.txt"
 
 # 通知キャンセルフラグを作成（既存の通知をキャンセル）
 touch "$DATA_DIR/cancel-notify.flag"
+
+# idle_prompt のクールダウンをリセット（セッション ID に対応するファイルを削除）
+if [[ -n "$SESSION_ID" ]]; then
+  LAST_IDLE_NOTIFY_FILE="$DATA_DIR/last-idle-notify-${SESSION_ID}.txt"
+  if [[ -f "$LAST_IDLE_NOTIFY_FILE" ]]; then
+    rm -f "$LAST_IDLE_NOTIFY_FILE"
+    echo "🔄 Reset idle_prompt cooldown for session: $SESSION_ID" >&2
+  fi
+fi
 
 exit 0

--- a/home/dot_claude/scripts/completion-notify/executable_notify-user-prompt-submit.sh
+++ b/home/dot_claude/scripts/completion-notify/executable_notify-user-prompt-submit.sh
@@ -41,4 +41,10 @@ if [[ -n "$SESSION_ID" ]]; then
   fi
 fi
 
+# 古い idle_prompt クールダウンファイルをクリーンアップ（7 日以上経過したファイル）
+# find コマンドが利用可能な場合のみ実行
+if command -v find >/dev/null 2>&1; then
+  find "$DATA_DIR" -name "last-idle-notify-*.txt" -type f -mtime +7 -delete 2>/dev/null || true
+fi
+
 exit 0


### PR DESCRIPTION
## 概要

Issue #57 で報告された `idle_prompt` 通知が何度も送信される問題を修正しました。

## 問題の詳細

mkwork のセッションで `idle_prompt` 通知が短時間に複数回送信されていました。原因は以下の通りです:

- Claude Code が `idle_prompt` イベントを継続的に発火する仕様
- 既存の通知スクリプトには重複送信を防止する仕組みがなかった

## 解決方法

Codex CLI と相談した結果、**セッション単位のクールダウン + UserPromptSubmit でリセット** という方針を採用しました。

### 実装内容

#### 1. `executable_notify-notification.sh` の修正

- `idle_prompt` の場合、セッション ID ごとに最後の通知タイムスタンプを記録
- 60 秒以内の重複通知をスキップ
- クールダウン中の通知はログに記録

#### 2. `executable_notify-user-prompt-submit.sh` の修正

- UserPromptSubmit 時に、セッション ID に対応するクールダウンファイルを削除
- ユーザーが操作した後は、再度 `idle_prompt` 通知を送信できるようにリセット

### クールダウン間隔

**60 秒** に設定しました。

- 既存の `send-discord-notification.sh` が 60 秒待機するため、それに合わせた
- 長時間アイドルの場合、60 秒ごとにリマインド通知が送信される

## 技術的な判断

### Codex CLI からの指摘と対応

#### 指摘 1: 既存コードベースとの整合性（重要度：高）
- **内容**: 既存の `~/.claude/scripts/completion-notify/data` にファイルベースの状態管理があり、「セッション単位のクールダウン + UserPromptSubmit でリセット」が最も整合性が高い
- **対応**: **採用** - 既存の設計パターンに従うことで、保守性と理解しやすさが向上する

#### 指摘 2: 重複防止のアプローチ（重要度：高）
- **内容**: 
  1. セッション単位のクールダウン + UserPromptSubmit でリセット（推奨）
  2. 回数制限は運用上の期待とズレやすい
- **対応**: **採用（1）** - 既存の設計に沿った実装で、柔軟性が高い

#### 指摘 3: idle_prompt が何度も発生する原因（重要度：中）
- **内容**: 
  - Claude Code がアイドル状態を継続的に通知する仕様の可能性
  - `send-discord-notification.sh` がバックグラウンドで 60 秒後に送信するため、短時間に複数 idle イベントが来ると複数通知が飛ぶ
- **対応**: **採用** - 根本原因を理解した上で、クールダウンロジックで対処する

#### 指摘 4: 改善提案（重要度：高）
- **内容**: 
  - `idle_prompt` 専用の抑止ロジックを `executable_notify-notification.sh` に追加
  - デバッグログで実測するのも有効
- **対応**: **採用** - 最小変更で効果が高い

### 採用しなかった案とその理由

- **回数制限**: 長時間アイドルでも 3 回以上通知が来なくなるため、運用上の期待とズレる
- **Notification matcher の分割**: 最小変更で効果が得られるため、後回しにする

### 前提条件・仮定・不確実性

**前提条件:**
- 既存の `data/` ディレクトリを状態管理に使用できる
- `send-discord-notification.sh` が 60 秒待機する仕様は変更しない

**仮定:**
- 60 秒のクールダウンで、ユーザーは適切なリマインド頻度と感じる
- セッション ID は一意で、ファイル名として使用できる

**不確実性:**
- 実際の `idle_prompt` 発生頻度が不明（デバッグログで確認することを推奨）
- 複数の `settings.json` が読み込まれている可能性（未確認）

## テスト方法

1. Claude Code を起動し、長時間アイドル状態にする
2. 60 秒以内に複数の `idle_prompt` 通知が送信されないことを確認
3. ユーザーが操作した後、再度アイドル状態にして通知が送信されることを確認

## 関連 Issue

- Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## コードレビュー対応

コードレビューで指摘された 2 つの問題に対応しました (commit: 8d311f2):

### 1. SESSION_ID の検証追加（スコア: 75）

**問題**: SESSION_ID が空の場合、複数のセッションが同じクールダウンファイル `last-idle-notify-.txt` を共有してしまう

**対応**: `executable_notify-notification.sh` に SESSION_ID の検証を追加し、空の場合はクールダウンチェックをスキップするようにしました。

### 2. ファイルクリーンアップ機構の追加（スコア: 50）

**問題**: 古いセッションのタイムスタンプファイルが蓄積される

**対応**: `executable_notify-user-prompt-submit.sh` に、7 日以上経過した `last-idle-notify-*.txt` ファイルを自動削除するクリーンアップロジックを追加しました。

---

## 2 回目のコードレビュー対応

コードレビューで指摘された 2 つの問題に対応しました (commit: b70e80d):

### 1. LAST_NOTIFY_TIME の数値検証追加（スコア: 75）

**問題**: LAST_NOTIFY_TIME の数値検証が欠落しており、ファイル破損時に bash 算術エラーが発生する

**対応**: 既存コード (`send-discord-notification.sh:44`) と同じパターンで `[[ "$LAST_NOTIFY_TIME" =~ ^[0-9]+$ ]]` による数値検証を追加しました。

### 2. レースコンディションの修正（スコア: 70）

**問題**: read-check-write パターンにアトミック性がなく、複数プロセスが同時実行時に両方が通知を送信する可能性がある

**対応**: `mkdir` によるアトミックロックを実装し、レースコンディションを防止しました。ロック取得に失敗した場合は、別プロセスが処理中と判断してスキップします。

---

## 3 回目のコードレビュー対応

コードレビューで指摘された重大な問題に対応しました (commit: 2e4625a):

### 1. ロック取得失敗時の exit 追加（スコア: 85）

**問題**: ロック取得に失敗した場合（別プロセスがロック保持中）、else ブロックで警告メッセージを出力するだけで処理が継続され、レースコンディション対策が無効化されていました

**対応**: else ブロックに `exit 0` を追加し、ロック取得失敗時にスクリプトを終了するようにしました。これにより、レースコンディション対策が正しく機能するようになります。