### PR TITLE
fix: Codex CLI の web_search 設定を更新

### DIFF
--- a/home/dot_codex/config.toml
+++ b/home/dot_codex/config.toml
@@ -1,0 +1,28 @@
+# Codex CLI 設定ファイル
+# chezmoi により ~/.codex/config.toml に適用されます
+
+# Web 検索設定（トップレベル）
+web_search = "live"
+
+# モデル設定
+model_reasoning_effort = "high"
+model_reasoning_summary = "auto"
+
+# プロジェクト設定
+project_doc_fallback_filenames = ["AGENTS.local.md"]
+
+# 通知設定
+notify = ["codex-wakatime"]
+
+# パーソナリティ設定
+personality = "pragmatic"
+
+# サンドボックス設定
+[sandbox_workspace_write]
+network_access = true
+
+# 機能フラグ
+[features]
+unified_exec = true
+shell_snapshot = true
+# 注: web_search_request は廃止されたため削除

--- a/home/dot_codex/config.toml
+++ b/home/dot_codex/config.toml
@@ -1,5 +1,4 @@
 # Codex CLI 設定ファイル
-# chezmoi により ~/.codex/config.toml に適用されます
 
 # Web 検索設定（トップレベル）
 web_search = "live"
@@ -25,4 +24,3 @@ network_access = true
 [features]
 unified_exec = true
 shell_snapshot = true
-# 注: web_search_request は廃止されたため削除


### PR DESCRIPTION
## Summary

Codex CLI v0.98.0 で廃止予定となった `[features].web_search_request` 設定を削除し、新しい `web_search` 設定（トップレベル）を追加します。

## 変更内容

- **廃止予定設定の削除**: `[features].web_search_request = true` を削除
- **新しい設定の追加**: `web_search = "live"` をトップレベルに追加
- **chezmoi 管理への追加**: `home/dot_codex/config.toml` を新規作成
- **環境固有設定の除外**: `[projects."..."]` セクションは含めない（各マシンで手動管理）
- **レビュー対応**: 不要なコメント行を削除（chezmoi 適用コメント、廃止設定の注釈）

## 設定値の選択

`web_search = "live"` を選択しました。これにより、リアルタイムのウェブ検索が有効化されます。

- **メリット**: 最新情報の取得が可能
- **デメリット**: ネットワークアクセスによる遅延の可能性（許容範囲内）

## 注意事項

- `[projects."..."]` セクションは dotfiles に含まれていません
- chezmoi apply 後、必要に応じて各マシンで手動で projects セクションを追記してください
- バックアップ: `~/.codex/config.toml.backup` に既存設定を保存済み

## Test plan

- [x] `home/dot_codex/config.toml` を作成
- [x] レビュー対応（不要なコメント行を削除）
- [ ] `chezmoi apply` で設定を適用
- [ ] `codex --help` で廃止予定警告が消えたことを確認
- [ ] `cat ~/.codex/config.toml` で設定内容を確認
- [ ] Codex CLI が正常に動作することを確認
- [ ] CI が成功することを確認

Resolves #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)