### PR TITLE
fix: tmux の terminal-features を extensive から RGB に変更

### DIFF
--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -19,7 +19,7 @@ bind -n WheelDownPane select-pane -t= \; send-keys -M
 set -as terminal-features ',xterm-256color:RGB'
 
 # クライアント側の PATH を tmux サーバに同期する
-# これにより、tmux セッション内の新しいウィンドウ/ペインで最新の PATH が使用される
+# これにより、クライアントが tmux セッションにアタッチする際に最新の PATH が使用される
 set -ga update-environment "PATH"
 
 # rキーで設定ファイルをリロードする

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -13,7 +13,10 @@ set -g status-interval 5
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
-set -as terminal-features ',xterm-256color:extensive'
+# true color (24-bit color) サポートのみを有効化
+# extensive フラグは OSC シーケンス（色定義など）を出力するため、
+# 一部のターミナルエミュレータで問題が発生する可能性がある
+set -as terminal-features ',xterm-256color:RGB'
 
 # クライアント側の PATH を tmux サーバに同期する
 # これにより、tmux セッション内の新しいウィンドウ/ペインで最新の PATH が使用される


### PR DESCRIPTION
## 概要

tmux セレクターで新規セッションを作成した際、OSC エスケープシーケンスの一部がコマンドラインに入力状態で残る問題を修正しました。

## 問題の詳細

### 症状

新規セッション作成時、以下のような文字列がコマンドラインに表示されていました：

```
^[]11;rgb:0c0c/0c0c/0c0c^[\tomachi@cinnamon-ubuntucc:~$ 11;rgb:0c0c/0c0c/0c0cc
```

プロンプトの後に `11;rgb:0c0c/0c0c/0c0cc` が入力状態で残っています。

### 原因

tmux の `terminal-features` で `extensive` フラグが有効になっており、新規セッション作成時に tmux が OSC シーケンス（色定義）を出力していました。gnome-terminal/xterm がこのシーケンスを適切に処理できず、一部がコマンドラインに残っていました。

## 変更内容

### 主な変更

- `home/dot_tmux.conf` の line 16 を修正
- `extensive` フラグを `RGB` フラグに変更
- コメントの技術的な不正確性を修正（コードレビュー対応）

### 修正前

```bash
set -as terminal-features ',xterm-256color:extensive'
```

### 修正後

```bash
# true color (24-bit color) サポートのみを有効化
# extensive フラグは OSC シーケンス（色定義など）を出力するため、
# 一部のターミナルエミュレータで問題が発生する可能性がある
set -as terminal-features ',xterm-256color:RGB'
```

### コメント修正

コードレビューで指摘された `update-environment` のコメントの不正確性も修正しました：

**修正前**:
```bash
# これにより、tmux セッション内の新しいウィンドウ/ペインで最新の PATH が使用される
```

**修正後**:
```bash
# これにより、クライアントが tmux セッションにアタッチする際に最新の PATH が使用される
```

## 期待される効果

1. 新規セッション作成時にコマンドラインにエスケープシーケンスが表示されない
2. true color (24-bit color) サポートは維持される
3. powerline の色表示に問題がない
4. コメントが技術的に正確

## テスト方法

### 1. 設定の確認

```bash
grep terminal-features ~/.tmux.conf
# 期待結果: set -as terminal-features ',xterm-256color:RGB'
```

### 2. 実動確認

1. chezmoi で変更を適用
2. tmux セレクターを実行して新規セッションを作成
3. コマンドラインにエスケープシーケンスの残骸が表示されないことを確認

### 3. powerline の色表示確認

tmux セッション内でステータスバーの色が正常に表示されることを確認

### 4. true color のテスト

```bash
printf '\x1b[38;2;255;100;0mTRUECOLOR\x1b[0m\n'
# オレンジ色で "TRUECOLOR" が表示されることを期待
```

## 関連 Issue

- Closes #67

## チェックリスト

- [x] Conventional Commits に従ったコミットメッセージ
- [x] センシティブな情報が含まれていないことを確認
- [x] 日本語と英数字の間に半角スペースを挿入
- [x] コメントを日本語で記載
- [x] CI が成功することを確認
- [x] Codex CLI によるコードレビュー対応
- [ ] GitHub Copilot によるレビュー対応（待機中）