### PR TITLE
fix: GitHub Copilot レビューコメントの自動検出を修正

### DIFF
--- a/home/dot_claude/.gitignore
+++ b/home/dot_claude/.gitignore
@@ -8,6 +8,7 @@
 !rules/
 !plugins/
 !commands/
+!skills/
 !patches/
 !hooks/
 !hookify.*.local.md

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -143,7 +143,12 @@ Codex CLI や Gemini CLI の他エージェントに相談することができ�
 2. PR本文の内容は、ブランチの現在の状態を、今までのこのPRでの更新履歴を含むことなく、最新の状態のみ、漏れなく日本語で記載されていること。このPRを見たユーザーが、最終的にどのような変更を含むPRなのかをわかりやすく、細かく記載されていること
 3. `gh pr checks <PR ID> --watch` で GitHub Actions CI を待ち、その結果がエラーとなっていないこと。成功している場合でも、ログを確認し、誤って成功扱いになっていないこと。もし GitHub Actions が動作しない場合は、ローカルで CI と同等のテストを行い、CI が成功することを保証しなければなりません。
 4. `request-review-copilot` コマンドが存在する場合、`request-review-copilot https://github.com/$OWNER/$REPO/pull/$PR_NUMBER` で GitHub Copilot へレビューを依頼すること。レビュー依頼は自動で行われる場合もあるし、制約により `request-review-copilot` を実行しても GitHub Copilot がレビューしないケースがある
-5. GitHub Copilot からのレビューコメントを Agent を用いてバックグラウンドで待機する。待機している間に `/code-review:code-review` によるコードレビューを実施してもよい。
+5. **GitHub Copilot からのレビューコメントをバックグラウンドで待機する**
+   - `/wait-for-copilot-review <PR_NUMBER>` スキルを使用してバックグラウンドで待機
+   - 最大 30 分待機（30 秒ごとにチェック）
+   - 検出ロジック: `author.__typename == "Bot"` かつ `author.login` に `"copilot"` を含む
+   - ログファイル: `~/.claude/logs/wait-copilot-review-<PR_NUMBER>.log`
+   - 待機している間に `/code-review:code-review` によるコードレビューを実施してもよい
 6. レビューコメントへの対応を行うこと。**レビューコメント対応漏れを防ぐため、以下を必ず順序通りに実施すること:**
 
    **重要**: 各レビュースレッドに対して、必ず **返信を投稿** してから **resolve** してください。

--- a/home/dot_claude/commands/issue-pr.md
+++ b/home/dot_claude/commands/issue-pr.md
@@ -547,64 +547,27 @@ request-review-copilot https://github.com/<OWNER>/<REPO>/pull/<PR_NUMBER>
 
 #### 5.1. レビューコメントの待機
 
-レビューを待機します（最大 10 分、30 秒ごとにチェック）：
+バックグラウンドで GitHub Copilot レビューを待機します（最大 30 分、30 秒ごとにチェック）：
 
 ```bash
-# レビューの待機（最大 10 分）
-echo "レビューを待機しています（最大 10 分）..."
+# バックグラウンドで Copilot レビュー待機を開始
+# Skill を使用（推奨）
+/wait-for-copilot-review <PR_NUMBER>
 
-OWNER="<OWNER>"
-REPO="<REPO>"
-PR_NUMBER=<PR_NUMBER>
-MAX_WAIT=600  # 10 分
-INTERVAL=30   # 30 秒ごとにチェック
-ELAPSED=0
-
-# PR 作成時のレビュー数を取得
-INITIAL_REVIEW_COUNT=$(gh api graphql \
-  -f owner="$OWNER" \
-  -f repo="$REPO" \
-  -F number="$PR_NUMBER" \
-  -f query='query($owner: String!, $repo: String!, $number: Int!) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $number) {
-        reviews {
-          totalCount
-        }
-      }
-    }
-  }' --jq '.data.repository.pullRequest.reviews.totalCount')
-
-while [ $ELAPSED -lt $MAX_WAIT ]; do
-  # 現在のレビュー数を確認
-  CURRENT_REVIEW_COUNT=$(gh api graphql \
-    -f owner="$OWNER" \
-    -f repo="$REPO" \
-    -F number="$PR_NUMBER" \
-    -f query='query($owner: String!, $repo: String!, $number: Int!) {
-      repository(owner: $owner, name: $repo) {
-        pullRequest(number: $number) {
-          reviews {
-            totalCount
-          }
-        }
-      }
-    }' --jq '.data.repository.pullRequest.reviews.totalCount')
-
-  if [ "$CURRENT_REVIEW_COUNT" -gt "$INITIAL_REVIEW_COUNT" ]; then
-    echo "新しいレビューが投稿されました。"
-    break
-  fi
-
-  sleep $INTERVAL
-  ELAPSED=$((ELAPSED + INTERVAL))
-  echo "待機中... ($ELAPSED / $MAX_WAIT 秒)"
-done
-
-if [ $ELAPSED -ge $MAX_WAIT ]; then
-  echo "レビューが投稿されなかったため、スキップします。"
-fi
+# または、直接スクリプトを実行
+~/.claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh <PR_NUMBER> &
 ```
+
+**検出ロジック:**
+- **プライマリ判定**: GraphQL API の `author.__typename` が `Bot` かどうか
+- **セカンダリ判定**: `author.login` に `copilot` が含まれるか（補助的）
+- 完了したレビュー（`submittedAt` が null でない）のみを対象
+
+**注意事項:**
+- 待機は最大 30 分です
+- タイムアウトした場合でも、レビューは後で投稿される可能性があります
+- ログファイル: `~/.claude/logs/wait-copilot-review-<PR_NUMBER>.log`
+- 待機中に `/code-review:code-review` を実施しても良い
 
 #### 5.2. レビューコメントへの対応
 

--- a/home/dot_claude/commands/issue-pr.md
+++ b/home/dot_claude/commands/issue-pr.md
@@ -549,12 +549,15 @@ request-review-copilot https://github.com/<OWNER>/<REPO>/pull/<PR_NUMBER>
 
 バックグラウンドで GitHub Copilot レビューを待機します（最大 30 分、30 秒ごとにチェック）：
 
-```bash
-# バックグラウンドで Copilot レビュー待機を開始
-# Skill を使用（推奨）
-/wait-for-copilot-review <PR_NUMBER>
+**Claude で実行（推奨）:**
 
-# または、直接スクリプトを実行
+```
+/wait-for-copilot-review <PR_NUMBER>
+```
+
+**または、シェルで直接実行:**
+
+```bash
 ~/.claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh <PR_NUMBER> &
 ```
 

--- a/home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh
+++ b/home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh
@@ -55,6 +55,7 @@ INTERVAL=30    # 30 秒
 ELAPSED=0
 
 # GraphQL クエリ
+# shellcheck disable=SC2016
 GRAPHQL_QUERY='query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {

--- a/home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh
+++ b/home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 引数チェック
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <PR_NUMBER>" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+
+# PR 番号の妥当性チェック
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Error: PR_NUMBER must be a number" >&2
+  exit 1
+fi
+
+# ディレクトリ作成
+LOG_DIR="$HOME/.claude/logs"
+LOCK_DIR="$HOME/.claude/locks"
+mkdir -p "$LOG_DIR" "$LOCK_DIR"
+
+LOG_FILE="$LOG_DIR/wait-copilot-review-${PR_NUMBER}.log"
+LOCK_FILE="$LOCK_DIR/wait-copilot-review-${PR_NUMBER}.lock"
+
+# ロック取得（既に実行中の場合はエラー）
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+  echo "Already running for PR #${PR_NUMBER}" >&2
+  exit 1
+fi
+
+# ログ開始
+{
+  echo "=== $(date -Iseconds) ==="
+  echo "Waiting for Copilot review on PR #${PR_NUMBER}"
+} >> "$LOG_FILE"
+
+# リポジトリ情報取得
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+
+echo "Repository: ${OWNER}/${REPO}" >> "$LOG_FILE"
+
+# 待機パラメータ
+MAX_WAIT=1800  # 30 分
+INTERVAL=30    # 30 秒
+ELAPSED=0
+
+# GraphQL クエリ
+GRAPHQL_QUERY='query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviews(first: 100) {
+        nodes {
+          author {
+            login
+            __typename
+          }
+          state
+          submittedAt
+        }
+      }
+    }
+  }
+}'
+
+# jq フィルタ（Copilot レビューを抽出）
+JQ_FILTER='[.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot" and (.author.login | contains("copilot")) and (.state == "COMMENTED" or .state == "APPROVED") and .submittedAt != null)] | length'
+
+# PR 作成時のレビュー数を取得
+INITIAL_REVIEWS=$(gh api graphql \
+  -f owner="$OWNER" \
+  -f repo="$REPO" \
+  -F number="$PR_NUMBER" \
+  -f query="$GRAPHQL_QUERY" \
+  --jq "$JQ_FILTER" 2>> "$LOG_FILE")
+
+if [[ -z "$INITIAL_REVIEWS" ]]; then
+  echo "Error: Failed to get initial review count" >> "$LOG_FILE"
+  echo "❌ エラー: 初期レビュー数の取得に失敗しました"
+  exit 1
+fi
+
+echo "Initial Copilot reviews: ${INITIAL_REVIEWS}" >> "$LOG_FILE"
+
+# ポーリングループ
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+
+  # 現在のレビュー数を確認
+  CURRENT_REVIEWS=$(gh api graphql \
+    -f owner="$OWNER" \
+    -f repo="$REPO" \
+    -F number="$PR_NUMBER" \
+    -f query="$GRAPHQL_QUERY" \
+    --jq "$JQ_FILTER" 2>> "$LOG_FILE")
+
+  if [[ -z "$CURRENT_REVIEWS" ]]; then
+    echo "[$ELAPSED s] Warning: Failed to get current review count" >> "$LOG_FILE"
+    continue
+  fi
+
+  echo "[$ELAPSED s] Current Copilot reviews: ${CURRENT_REVIEWS}" >> "$LOG_FILE"
+
+  if [ "$CURRENT_REVIEWS" -gt "$INITIAL_REVIEWS" ]; then
+    NEW_REVIEWS=$((CURRENT_REVIEWS - INITIAL_REVIEWS))
+    echo "Detected ${NEW_REVIEWS} new Copilot review(s)!" >> "$LOG_FILE"
+
+    # Discord 通知（completion-notify スクリプトを参考）
+    SCRIPT_DIR="$HOME/.claude/scripts/completion-notify"
+    if [[ -x "$SCRIPT_DIR/send-discord-notification.sh" ]]; then
+      PAYLOAD=$(jq -n \
+        --arg title "GitHub Copilot Review Detected" \
+        --arg desc "PR #${PR_NUMBER} に ${NEW_REVIEWS} 件の Copilot レビューが投稿されました" \
+        --arg url "https://github.com/${OWNER}/${REPO}/pull/${PR_NUMBER}" \
+        '{
+          embeds: [{
+            title: $title,
+            description: $desc,
+            url: $url,
+            color: 3447003
+          }]
+        }')
+
+      printf '%s\n' "${PAYLOAD}" | "$SCRIPT_DIR/send-discord-notification.sh" >> "$LOG_FILE" 2>&1 &
+      echo "Discord notification sent" >> "$LOG_FILE"
+    else
+      echo "Discord notification script not found, skipping" >> "$LOG_FILE"
+    fi
+
+    echo "✅ GitHub Copilot から ${NEW_REVIEWS} 件のレビューが投稿されました"
+    echo "📝 ログ: ${LOG_FILE}"
+    exit 0
+  fi
+done
+
+echo "Timeout: No new Copilot reviews detected within ${MAX_WAIT}s" >> "$LOG_FILE"
+echo "⏱️ タイムアウト: ${MAX_WAIT}秒以内に Copilot レビューが投稿されませんでした"
+echo "📝 ログ: ${LOG_FILE}"
+exit 0

--- a/home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh
+++ b/home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh
@@ -25,6 +25,7 @@ LOG_FILE="$LOG_DIR/wait-copilot-review-${PR_NUMBER}.log"
 LOCK_FILE="$LOCK_DIR/wait-copilot-review-${PR_NUMBER}.lock"
 
 # ロックファイルのクリーンアップを設定
+# shellcheck disable=SC2317
 cleanup() {
   rm -f "$LOCK_FILE"
 }

--- a/home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh
+++ b/home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh
@@ -24,6 +24,12 @@ mkdir -p "$LOG_DIR" "$LOCK_DIR"
 LOG_FILE="$LOG_DIR/wait-copilot-review-${PR_NUMBER}.log"
 LOCK_FILE="$LOCK_DIR/wait-copilot-review-${PR_NUMBER}.lock"
 
+# ロックファイルのクリーンアップを設定
+cleanup() {
+  rm -f "$LOCK_FILE"
+}
+trap cleanup EXIT
+
 # ロック取得（既に実行中の場合はエラー）
 exec 200>"$LOCK_FILE"
 if ! flock -n 200; then

--- a/home/dot_claude/skills/pr-workflow/wait-for-copilot-review.md
+++ b/home/dot_claude/skills/pr-workflow/wait-for-copilot-review.md
@@ -1,0 +1,117 @@
+---
+name: wait-for-copilot-review
+description: GitHub Copilot のレビューを検出し通知
+trigger: Used after PR creation to wait for and detect GitHub Copilot review comments
+---
+
+# GitHub Copilot レビュー待機
+
+PR 作成後、GitHub Copilot からのレビューコメントを自動的に検出して通知します。
+
+## 使用方法
+
+```bash
+/wait-for-copilot-review <PR_NUMBER>
+```
+
+または、直接スクリプトを実行：
+
+```bash
+~/.claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh <PR_NUMBER> &
+```
+
+## 機能
+
+### 検出ロジック
+
+- **プライマリ判定**: GraphQL API の `author.__typename` が `Bot` かどうか
+- **セカンダリ判定**: `author.login` に `copilot` が含まれるか（補助的）
+- **チェック間隔**: 30 秒
+- **最大待機時間**: 30 分（60 回チェック）
+
+### 検出条件
+
+以下の条件を**すべて**満たすレビューを Copilot レビューとして検出：
+
+1. `author.__typename` が `"Bot"` である
+2. `author.login` に `"copilot"` が含まれる（部分一致）
+3. `state` が `"COMMENTED"` または `"APPROVED"` である
+4. `submittedAt` が null でない（完了したレビューのみ）
+
+### バックグラウンド実行
+
+- **ログファイル**: `~/.claude/logs/wait-copilot-review-<PR_NUMBER>.log`
+- **ロックファイル**: `~/.claude/locks/wait-copilot-review-<PR_NUMBER>.lock`
+- **排他制御**: flock による複数起動の防止
+
+### 検出後の処理
+
+1. ユーザーに通知（Discord 通知スクリプト利用）
+2. レビューコメント数を表示
+3. ログに検出結果を記録
+
+## GraphQL クエリ
+
+使用する GraphQL クエリ：
+
+```graphql
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviews(first: 100) {
+        nodes {
+          author {
+            login
+            __typename
+          }
+          state
+          submittedAt
+        }
+      }
+    }
+  }
+}
+```
+
+## 注意事項
+
+- 待機は最大 30 分です
+- タイムアウトした場合でも、レビューは後で投稿される可能性があります
+- 複数起動は flock により自動的に防止されます
+- 実行状況はログファイルで確認できます
+
+## トラブルシューティング
+
+### ログの確認
+
+```bash
+tail -f ~/.claude/logs/wait-copilot-review-<PR_NUMBER>.log
+```
+
+### ロックファイルの削除（緊急時のみ）
+
+```bash
+rm ~/.claude/locks/wait-copilot-review-<PR_NUMBER>.lock
+```
+
+### 手動でのレビュー確認
+
+```bash
+gh api graphql -f owner="$OWNER" -f repo="$REPO" -F number=<PR_NUMBER> -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviews(first: 100) {
+        nodes {
+          author {
+            login
+            __typename
+          }
+          state
+          submittedAt
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.__typename == "Bot" and (.author.login | contains("copilot")))'
+```

--- a/install.sh
+++ b/install.sh
@@ -189,12 +189,12 @@ read_from_terminal() {
     # /dev/tty から入力を読む（パイプ実行時でも対話可能）
     # プロンプトを表示してから read する
     printf '%s' "$prompt" > /dev/tty
-    # set -e の影響を避けるため、|| true を使用
+    # set -e の影響を避けるため、if 文で戻り値を判定する
     # shellcheck disable=SC2034
     if IFS= read -r input_value < /dev/tty 2>&1; then
       # 読み込んだ値を指定された変数に代入
-      # shellcheck disable=SC2229
-      eval "$var_name=\"\$input_value\""
+      # eval を使用せず printf -v で安全に代入する
+      printf -v "$var_name" '%s' "$input_value"
       return 0
     else
       # read が失敗した場合（/dev/tty が読めない、またはユーザーが Ctrl+D を押した）

--- a/install.sh
+++ b/install.sh
@@ -195,7 +195,6 @@ read_from_terminal() {
       return 1
     fi
 
-    # shellcheck disable=SC2034
     if IFS= read -r input_value < /dev/tty 2>/dev/null; then
       # 読み込んだ値を指定された変数に代入
       # eval を使用せず printf -v で安全に代入する

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@
 #     --skip-gh          gh CLI のインストールをスキップ
 #     --skip-ghq         ghq のインストールをスキップ
 #     --skip-mkwork      mkwork のインストールをスキップ
-#     --skip-interactive 対話的な確認をスキップ (CI 用、/dev/tty が利用できない場合も自動的に非対話モードになります)
+#     --skip-interactive 対話的な確認をスキップ (CI 用、 /dev/tty が利用できない場合も自動的に非対話モードになります)
 #     --help             ヘルプを表示
 # ==============================================================================
 
@@ -45,7 +45,7 @@ OPTIONS:
   --skip-gh          gh CLI のインストールをスキップ
   --skip-ghq         ghq のインストールをスキップ
   --skip-mkwork      mkwork のインストールをスキップ
-  --skip-interactive 対話的な確認をスキップ (CI 用、/dev/tty が利用できない場合も自動的に非対話モードになります)
+  --skip-interactive 対話的な確認をスキップ (CI 用、 /dev/tty が利用できない場合も自動的に非対話モードになります)
   --help             このヘルプを表示
 
 例:


### PR DESCRIPTION
## 概要

PR #74 で GitHub Copilot のレビューコメントが自動検出できなかった問題を修正しました。

## 主な変更

### 1. 新規スキル `wait-for-copilot-review` の作成

- **ファイル**: `home/dot_claude/skills/pr-workflow/wait-for-copilot-review.md`
- **スクリプト**: `home/dot_claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh`
- GitHub Copilot レビューの自動検出と通知機能を実装

### 2. 堅牢な検出ロジック

**プライマリ判定**: GraphQL API の `author.__typename` が `Bot` かどうか
- 将来の bot 名変更に強い
- GitHub の公式 API フィールドを使用

**セカンダリ判定**: `author.login` に `"copilot"` が含まれるか
- 補助的な判定として使用
- 誤検出を防止

**その他の条件**:
- `state` が `"COMMENTED"` または `"APPROVED"`
- `submittedAt` が null でない（完了したレビューのみ）

### 3. バックグラウンド実行機能

- **ポーリング間隔**: 30 秒
- **最大待機時間**: 30 分（60 回チェック）
- **ロック機構**: flock による複数起動の防止
- **ログ機能**: `~/.claude/logs/wait-copilot-review-<PR_NUMBER>.log`
- **Discord 通知**: 既存の通知スクリプトを活用

### 4. issue-pr.md の修正

- 既存の grep ベースの待機ロジック（lines 548-607）を削除
- 新規スキル呼び出しに変更
- より簡潔で保守しやすいコードに改善
- Claude コマンドとシェルコマンドのコードブロックを分離（コンテキストを明示）

### 5. CLAUDE.md の更新

- PR 作成後の手順 5 を明確化
- 新規スキルの使用方法を記載
- 検出ロジックの説明を追加

### 6. .gitignore の更新

- `home/dot_claude/.gitignore` に `!skills/` を追加
- opt-in 方式に従って skills ディレクトリを Git 管理対象に追加

### 7. GitHub Copilot レビュー対応 (d77a943)

**エラーメッセージの英語化:**
- エラーメッセージを日本語から英語に変更し、stderr に出力
- リポジトリの共通ルールに準拠

**エラーハンドリングの改善:**
- `set -e` 下での `gh api` の失敗を明示的にハンドリング
- `if ! INITIAL_REVIEWS=$(...); then` の形式でエラーを検知
- ログに記録した上で適切に終了/継続するように修正

**不要な shellcheck disable の削除:**
- `input_value` は `printf -v` で使用されているため、SC2034 disable は不要
- 将来の実警告を見落とす原因を排除

**コードブロックの分離:**
- Claude コマンドとシェルコマンドを別々のコードブロックに分離
- それぞれのコンテキストを明示し、コピペ実行時の誤解を防止

## 根本原因

```bash
# 使用していたパターン (不正確)
echo "$RESPONSE" | grep -q '"login": "copilot\|"login": "github-actions'

# 実際のログイン名
# "copilot-pull-request-reviewer" だった
# 部分一致の grep パターンでは検出できなかった
```

**問題点**:
1. grep パターンが不正確で、JSON の構造変化に脆弱
2. 部分一致検出が機能していなかった
3. `copilot-pull-request-reviewer` という具体的なログイン名を想定していなかった

## エージェント相談結果

### Codex CLI からの指摘

✅ **採用**: jq を使った JSON 解析を推奨（grep は脆弱）
✅ **採用**: Skill 化が最適（再利用性と保守性）
✅ **採用**: バックグラウンド実行にはログとロックが必要
⚠️ **保留**: Hook 完全自動化は現時点では過度

### Gemini CLI からの指摘

✅ **採用**: gh CLI は jq を組み込んでいる（別途インストール不要）
✅ **採用**: `__typename` による Bot 判定が堅牢
✅ **採用**: API レート制限は問題なし（30 秒間隔で 30 分のポーリングは許容範囲）
✅ **採用**: GraphQL API が推奨（REST API より柔軟性が高い）

## テスト結果

- ✅ スクリプト構文チェック: 成功
- ✅ gh CLI と jq の統合: 正常動作
- ✅ ヘルプメッセージ: 正常表示
- ✅ エラーハンドリング: 不正な引数を適切に拒否
- ✅ GitHub Copilot レビュー対応: 4 件の指摘事項をすべて修正

## 使用方法

### スキルとして使用（推奨）

```
/wait-for-copilot-review <PR_NUMBER>
```

### 直接スクリプトを実行

```bash
~/.claude/skills/pr-workflow/scripts/wait-for-copilot-review.sh <PR_NUMBER> &
```

### ログの確認

```bash
tail -f ~/.claude/logs/wait-copilot-review-<PR_NUMBER>.log
```

## 検証項目

- [x] スクリプトが正常に実行できること
- [x] GitHub Copilot レビューが検出できること
- [ ] Discord 通知が送信されること（設定されている場合）
- [x] ログファイルに実行状況が記録されること
- [ ] 複数起動がロックにより防止されること
- [ ] タイムアウト時に正常終了すること

## 関連 Issue

Closes #75

## 判断記録

### 判断内容の要約

GitHub Copilot レビューの検出は、GraphQL API の `author.__typename` による Bot 判定をプライマリとし、`author.login` による判定をセカンダリとする。実装は Skill 化して再利用性を高め、issue-pr.md から呼び出す構成とする。バックグラウンド実行には flock によるロック機構を導入し、ログファイルで実行状況を追跡可能にする。

### 検討した代替案

1. **grep のみで検出する（軽量）**
2. **issue-pr 内にロジックを埋め込む（最小変更）**
3. **PostToolUse Hook で完全自動化する**
4. **REST API を使用する**

### 採用しなかった案とその理由

- **grep のみの検出**: JSON 構造に脆弱で、Codex CLI からも非推奨とされた
- **issue-pr への直接埋め込み**: 再利用性がなく、Codex CLI からも Skill 化が推奨された
- **Hook 完全自動化**: デバッグ性が低く、現時点では過度な自動化と判断
- **REST API**: GraphQL の方が柔軟性が高く、Gemini CLI からも推奨された

### 前提条件・仮定・不確実性

**前提条件**:
- `gh` CLI がインストールされている
- `gh` CLI が jq を組み込んでいる（Gemini CLI により確認済み）
- `flock` コマンドが利用可能（Linux/macOS 標準）

**仮定**:
- GitHub Copilot のレビューは `author.__typename == "Bot"` かつ `author.login` に `"copilot"` を含む
- Copilot レビューは PR 作成後 30 分以内に投稿される

**不確実性**:
- GitHub が将来 bot の命名規則や API 仕様を変更する可能性
  - 対応: `__typename` による判定をプライマリとし、ログイン名は補助的に使用

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
