### PR TITLE
fix: tmux セッションアタッチ時にエスケープシーケンスが表示される問題を修正

### DIFF
--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -14,7 +14,9 @@ bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft=
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
 # デフォルトターミナルを設定（tmux 内部で使用される TERM 値）
-set -g default-terminal "tmux-256color"
+# screen-256color を使用（広く互換性があり、ほぼ全ての環境で terminfo が存在する）
+# tmux-256color は一部環境で terminfo が存在せず、vim や less が動作しない問題があるため使用しない
+set -g default-terminal "screen-256color"
 
 # true color (24-bit color) サポートを有効化
 # terminal-overrides を使用して、ターミナルエミュレータの機能を適切に設定

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -13,10 +13,15 @@ set -g status-interval 5
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
-# true color (24-bit color) サポートのみを有効化
-# extensive フラグは OSC シーケンス（色定義など）を出力するため、
-# 一部のターミナルエミュレータで問題が発生する可能性がある
-set -as terminal-features ',xterm-256color:RGB'
+# デフォルトターミナルを設定（tmux 内部で使用される TERM 値）
+set -g default-terminal "tmux-256color"
+
+# true color (24-bit color) サポートを有効化
+# terminal-overrides を使用して、ターミナルエミュレータの機能を適切に設定
+# RGB フラグで 24-bit カラーを有効化
+set -as terminal-overrides ',xterm*:RGB'
+set -as terminal-overrides ',screen*:RGB'
+set -as terminal-overrides ',tmux*:RGB'
 
 # クライアント側の PATH を tmux サーバに同期する
 # これにより、クライアントが tmux セッションにアタッチする際に最新の PATH が使用される


### PR DESCRIPTION
## 概要

tmux セッションにアタッチした際に、エスケープシーケンスが画面に表示されてしまう問題を修正しました。

## 問題の詳細

アタッチ時に以下のようなエスケープシーケンスが表示される:
```
```

## 原因

`terminal-features` の設定が不適切で、tmux がターミナルエミュレータの能力を問い合わせた際の応答（DECRQM や DA2 などのエスケープシーケンス）がシェルに入力として解釈されていました。

## 修正内容

- `terminal-features` から `terminal-overrides` に変更
- `default-terminal` を `screen-256color` に設定（広く互換性があり、terminfo が存在しない環境でも動作）
- 複数のターミナルタイプ (`xterm*`, `screen*`, `tmux*`) に対して RGB フラグを設定

## コードレビュー対応

### Codex レビュー

- ✅ P2: `tmux-256color` の代わりに `screen-256color` を使用するように修正（commit: de7f8b1）
  - `tmux-256color` の terminfo が存在しない環境では vim や less が動作しない問題を回避

## テスト

- [x] tmux 設定ファイルの構文チェック
- [x] CI の通過確認
- [ ] 実際の環境でのアタッチテスト

## チェックリスト

- [x] Conventional Commits に従っている
- [x] センシティブな情報が含まれていない
- [x] 日本語と英数字の間に半角スペースを挿入
- [x] CI が通過している
- [x] Codex のコードレビュー対応完了