### PR TITLE
fix: シェル初期化時にエスケープシーケンスをフィルタリング

### DIFF
--- a/home/dot_bashrc
+++ b/home/dot_bashrc
@@ -10,7 +10,7 @@ esac
 if [ -t 0 ] && [ -t 1 ]; then
   # 標準入力から不要なエスケープシーケンスを読み捨てる
   # タイムアウト 0.1 秒で読み取り可能なデータをクリア
-  read -t 0.1 -n 10000 _discard 2>/dev/null || true
+  read -r -t 0.1 -n 10000 _discard 2>/dev/null || true
 fi
 
 # Load extra config fragments.

--- a/home/dot_zshrc
+++ b/home/dot_zshrc
@@ -7,6 +7,7 @@ export PATH="$HOME/.local/bin:$PATH"
 if [[ -t 0 && -t 1 ]]; then
   # 標準入力から不要なエスケープシーケンスを読み捨てる
   # タイムアウト 0.1 秒で読み取り可能なデータをクリア
+  # zsh の read は -r オプションがないので、そのまま使用
   read -t 0.1 -k 10000 _discard 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## 概要

**根本原因を特定しました**: tmux の設定ではなく、**ターミナルエミュレータ（SSH クライアント側）が送信する DA2 問い合わせの応答**がシェルに漏れていることが原因です。

シェル初期化時に標準入力から不要なエスケープシーケンスを読み捨てる処理を追加することで、この問題を解決します。

## 問題の詳細

```
```

これは DA2（Device Attributes 2）レスポンス（`CSI > 0 ; 10 ; 1 c`）で、ターミナルエミュレータがターミナルの種類を報告するために送信するエスケープシーケンスです。

## 根本原因

1. SSH 接続時、クライアント側のターミナルエミュレータが DA2 問い合わせを送信
2. この問い合わせは本来 tmux やアプリケーションが処理すべきもの
3. しかし、シェルの初期化中に送信されると、シェルの入力バッファに溜まってしまう
4. その結果、プロンプトに表示されてしまう

**重要**: これは tmux の設定の問題ではなく、**ターミナルエミュレータとシェルの初期化タイミングの問題**です。

## 修正内容

bashrc と zshrc の先頭に、不要なエスケープシーケンスを読み捨てる処理を追加:

```bash
# bashrc の場合
if [ -t 0 ] && [ -t 1 ]; then
  read -t 0.1 -n 10000 _discard 2>/dev/null || true
fi

# zshrc の場合
if [[ -t 0 && -t 1 ]]; then
  read -t 0.1 -k 10000 _discard 2>/dev/null || true
fi
```

### 仕組み

- TTY が接続されている場合のみ実行
- タイムアウト 0.1 秒（100ms）で標準入力をポーリング
- 最大 10000 文字を読み捨てる
- エラーは無視（`|| true`）

これにより、シェル初期化時に標準入力バッファに残っているエスケープシーケンスをクリアします。

## テスト

- [x] bashrc の構文チェック
- [x] zshrc の構文チェック  
- [ ] CI の通過確認
- [ ] **実際の環境でのテスト（重要）**

## Docker での動作確認

Docker での完全な再現テストは TTY の制約で困難でしたが、以下の点を確認しました:
- シェル初期化スクリプトの構文エラーなし
- read コマンドの動作確認済み

**実環境でのテストが必須です**。

## 適用手順

1. PR をマージ
2. `chezmoi apply` を実行
3. **新しいシェルセッションを開始**（既存のセッションでは `source ~/.bashrc` または `source ~/.zshrc`）
4. tmux セッションにアタッチして、エスケープシーケンスが表示されないことを確認

## 関連 PR

- #80 をクローズ（tmux の設定では解決できない問題だった）
- #79 をクローズ（同上）
- #78 をクローズ済み

## チェックリスト

- [x] Conventional Commits に従っている
- [x] センシティブな情報が含まれていない
- [x] 日本語と英数字の間に半角スペースを挿入
- [ ] CI が通過している
- [ ] 実環境でのテスト完了