### PR TITLE
fix: tmux デフォルトシェルを bash に変更、git ignore に .claude/settings.local.json を追加

### DIFF
--- a/home/dot_config/git/ignore
+++ b/home/dot_config/git/ignore
@@ -19,3 +19,5 @@ venv/
 Thumbs.db
 __pycache__/
 *.pyc
+
+**/.claude/settings.local.json

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -26,6 +26,9 @@ set -g focus-events off
 set -ga terminal-overrides ",*256col*:Tc"
 set -ga terminal-overrides ",xterm*:Tc"
 
+# デフォルトシェルを bash に設定する
+set -g default-shell /bin/bash
+
 # クライアント側の PATH を tmux サーバに同期する
 # これにより、クライアントが tmux セッションにアタッチする際に最新の PATH が使用される
 set -ga update-environment "PATH"


### PR DESCRIPTION
## 変更内容

### `~/.tmux.conf`
- tmux のデフォルトシェルを `bash` に設定 (`set -g default-shell /bin/bash`)
  - デフォルトシェルが `sh` になっていたため、`.bashrc` が読み込まれず NVM の PATH が設定されなかった問題を修正
  - これにより `npx` コマンドが見つからず、chrome-devtools MCP が起動できない問題が発生していた

### `~/.config/git/ignore`
- `**/.claude/settings.local.json` をグローバル gitignore に追加
  - Claude Code のプロジェクト固有のローカル設定ファイルを誤ってコミットしないようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)