### PR TITLE
feat: session retentionの更新

### DIFF
--- a/home/dot_gemini/settings.json
+++ b/home/dot_gemini/settings.json
@@ -24,7 +24,9 @@
   "general": {
     "previewFeatures": true,
     "sessionRetention": {
-      "enabled": true
+      "enabled": true,
+      "maxAge": "30d",
+      "warningAcknowledged": true
     }
   },
   "ui": {


### PR DESCRIPTION
## 概要

Gemini の session retention 設定に `maxAge` と `warningAcknowledged` フィールドを追加しました。

## 変更内容

- `home/dot_gemini/settings.json`
  - `maxAge: "30d"` を追加（セッション保持の最大期間を 30 日に設定）
  - `warningAcknowledged: true` を追加（警告への確認済みフラグ）

## 変更ファイル

- `home/dot_gemini/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)