### PR TITLE
feat: npm グローバルパッケージのパスを追加

### DIFF
--- a/home/dot_bashrc.d/executable_00-path.sh
+++ b/home/dot_bashrc.d/executable_00-path.sh
@@ -1,3 +1,6 @@
 # PATHの設定
 # $HOME/.local/bin をPATHの先頭に追加し、ユーザーごとのコマンドを優先的に実行できるようにします。
 export PATH="$HOME/.local/bin:$PATH"
+
+# npm グローバルパッケージのパス
+export PATH="$HOME/.npm-global/bin:$PATH"

--- a/home/dot_zshrc.d/executable_00-path.zsh
+++ b/home/dot_zshrc.d/executable_00-path.zsh
@@ -1,0 +1,6 @@
+# PATH の設定
+# $HOME/.local/bin をPATHの先頭に追加し、ユーザーごとのコマンドを優先的に実行できるようにする
+export PATH="$HOME/.local/bin:$PATH"
+
+# npm グローバルパッケージのパス
+export PATH="$HOME/.npm-global/bin:$PATH"


### PR DESCRIPTION
## 概要

npm のグローバルプレフィックスを `~/.npm-global` に変更したことに伴い、`~/.npm-global/bin` を PATH に追加する設定を dotfiles に反映する。

## 変更内容

- `home/dot_bashrc.d/executable_00-path.sh`: `~/.npm-global/bin` を PATH に追加
- `home/dot_zshrc.d/executable_00-path.zsh`: zsh 用の PATH 設定ファイルを新規作成（`~/.local/bin` および `~/.npm-global/bin` を追加）

## 背景

`npm config set prefix ~/.npm-global` により npm のグローバルプレフィックスを変更し、`~/.local/bin` との競合（`claude doctor` による二重インストール警告）を解消した。これに伴い、`gemini` / `codex` などの npm グローバルパッケージを `~/.npm-global` へ再インストールしたため、PATH への追加が必要となった。