### PR TITLE
docs: <<'EOF' ヒアドキュメント内のバックティック記述ルールを追加

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -33,6 +33,7 @@
 - このプロジェクトでは Serena が使用できます。
 - Renovate が作成した既存のプルリクエストに対して、追加コミットや更新を行ってはなりません。
 - バックグラウンドでの監視を行う際、監視終了時や異常時に、Claude Code が動作している tmux セッションに send-keys でメッセージを送り、Claude Code が自動的に動作できるようにしてください。セッション名は tmux display-message -p '#{session_name}' で取得でき、コマンド例は tmux send-keys -t "$SESSION" "メッセージ" && sleep 3 && tmux send-keys -t "$SESSION" Enter です。メッセージと Enter の間に sleep 3 を入れないと、Claude Code が入力を認識する前に Enter が送られ、改行として処理されてしまいます。
+- `<<'EOF'` ヒアドキュメント（シングルクォートデリミタ）内では `\` はエスケープ文字として機能しないため、バックティック (`` ` ``) は `\`` とせずそのまま `` ` `` と記述する。`\`` と書くと 2 文字がそのまま出力され、GitHub Markdown でバックスラッシュ付きで表示されてしまう。
 
 ## Agent Teams
 


### PR DESCRIPTION
## Summary

`<<'EOF'` ヒアドキュメント（シングルクォートデリミタ）内ではバックスラッシュがエスケープ文字として機能しないため、バックティック (`` ` ``) を `\`` と書くと 2 文字がそのまま出力されてしまいます。これにより GitHub Markdown でバックスラッシュ付き（`\``）で表示される問題が発生していたため、正しい記述方法をルールとして追記しました。

## 変更内容

- `home/dot_claude/CLAUDE.md` の「環境のルール」セクションに `<<'EOF'` ヒアドキュメント内でのバックティック記述ルールを追加

## 背景

`gh pr create` や `gh pr edit` の `--body` 引数に `<<'EOF'` ヒアドキュメントを使用して PR 本文を記述する際、バックティックをエスケープしようとして `\`` と記述すると、シングルクォートデリミタ内ではバックスラッシュが特殊文字として機能しないため、`\`` という 2 文字がそのまま GitHub API に送信されてしまう。GitHub Markdown ではこれがバックスラッシュ付きのバックティックとして描画される。

正しくは `<<'EOF'` ヒアドキュメント内では ` `` ` をそのまま記述すれば良い（シングルクォートデリミタ内ではすべての文字がリテラルとして扱われるため）。