### PR TITLE
feat: AI エージェント更新を実行対象のみに限定する --only オプションを追加

### DIFF
--- a/home/bin/executable_update-ai-agents.sh
+++ b/home/bin/executable_update-ai-agents.sh
@@ -233,11 +233,36 @@ update_gemini() {
 
 # メイン処理
 main() {
+    # オプション解析
+    local quick=0
+    local only_agent=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --quick) quick=1 ;;
+            --only)
+                if [[ -z "${2:-}" ]]; then
+                    echo "❌ --only requires an agent name (claude|copilot|codex|gemini)" >&2
+                    exit 1
+                fi
+                only_agent="$2"
+                shift
+                ;;
+            *) ;;
+        esac
+        shift
+    done
+
+    # エージェントが指定された場合はタイムスタンプ・ロックファイルを個別に設定
+    if [[ -n "$only_agent" ]]; then
+        TIMESTAMP_FILE="$CACHE_DIR/last-update-${only_agent}"
+        LOCK_FILE="$CACHE_DIR/update-${only_agent}.lock"
+    fi
+
     # ログローテーション
     rotate_log
 
     # --quick オプションの処理
-    if [[ "${1:-}" == "--quick" ]]; then
+    if [[ $quick -eq 1 ]]; then
         check_timestamp
     fi
 
@@ -245,7 +270,7 @@ main() {
     acquire_lock
 
     log "================================================"
-    log "🚀 Starting AI agents update check"
+    log "🚀 Starting AI agents update check${only_agent:+ (only: ${only_agent})}"
     log "================================================"
 
     # 環境チェック
@@ -255,11 +280,22 @@ main() {
 
     local exit_code=0
 
-    # 各エージェントを個別に更新 (1 つ失敗しても続行)
-    update_claude || exit_code=1
-    update_copilot || exit_code=1
-    update_codex || exit_code=1
-    update_gemini || exit_code=1
+    # 更新対象の選択 (--only 指定時は対象エージェントのみ更新)
+    if [[ -n "$only_agent" ]]; then
+        case "$only_agent" in
+            claude)  update_claude  || exit_code=1 ;;
+            copilot) update_copilot || exit_code=1 ;;
+            codex)   update_codex   || exit_code=1 ;;
+            gemini)  update_gemini  || exit_code=1 ;;
+            *) log "⏭️  No update function for: ${only_agent}" ;;
+        esac
+    else
+        # 各エージェントを個別に更新 (1 つ失敗しても続行)
+        update_claude   || exit_code=1
+        update_copilot  || exit_code=1
+        update_codex    || exit_code=1
+        update_gemini   || exit_code=1
+    fi
 
     # タイムスタンプ更新 (成功時のみ)
     if [[ $exit_code -eq 0 ]]; then
@@ -267,7 +303,7 @@ main() {
     fi
 
     log "================================================"
-    log "✅ Update check completed (exit code: $exit_code)"
+    log "✅ Update check completed (exit code: ${exit_code})"
     log "================================================"
 
     exit "$exit_code"

--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -1,17 +1,17 @@
 # AI CLI ツールのエイリアス設定
 # --dangerously-skip-permissions や --yolo は、確認プロンプトをスキップして実行するためのオプションです。
-# AI エージェントの自動更新 (update-ai-agents.sh --quick) を各 CLI 実行前に実行します。
-alias claude='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick; ~/.local/share/chezmoi/update.sh; claude --dangerously-skip-permissions'
-alias codex='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick; ~/.local/share/chezmoi/update.sh; codex --yolo'
-alias gemini='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick; ~/.local/share/chezmoi/update.sh; gemini --yolo'
+# AI エージェントの自動更新 (update-ai-agents.sh --quick --only <agent>) を各 CLI 実行前に実行します。
+alias claude='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only claude; ~/.local/share/chezmoi/update.sh; claude --dangerously-skip-permissions'
+alias codex='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only codex; ~/.local/share/chezmoi/update.sh; codex --yolo'
+alias gemini='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only gemini; ~/.local/share/chezmoi/update.sh; gemini --yolo'
 # copilot コマンドのラッパー関数。
 # AI エージェント・chezmoi の更新を行い、カレントディレクトリに .copilot/mcp-config.json が
 # 存在する場合は --additional-mcp-config オプションを付与して実行する。
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias copilot 2>/dev/null
 copilot() {
-  # AI エージェントの更新と chezmoi の更新を実行
-  [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick
+  # copilot のみアップデートチェック・chezmoi の更新を実行
+  [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only copilot
   ~/.local/share/chezmoi/update.sh
   # カレントディレクトリに .copilot/mcp-config.json が存在する場合は追加引数を設定
   if [ -f ".copilot/mcp-config.json" ]; then
@@ -20,4 +20,4 @@ copilot() {
     command copilot --yolo "$@"
   fi
 }
-alias happy='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick; ~/.local/share/chezmoi/update.sh; happy --dangerously-skip-permissions'
+alias happy='~/.local/share/chezmoi/update.sh; happy --dangerously-skip-permissions'


### PR DESCRIPTION
## 概要

`update-ai-agents.sh` に `--only <agent>` オプションを追加し、各 AI エージェントの CLI エイリアスから呼び出す際に実行対象のエージェントのみ更新チェック・更新を行うように変更しました。

## 変更内容

### `home/bin/executable_update-ai-agents.sh`

- `--only <agent>` オプションを追加
  - 指定したエージェント (`claude` / `copilot` / `codex` / `gemini`) のみ更新関数を実行
  - 引数なしで `--only` を指定した場合はエラー終了する
- タイムスタンプファイルをエージェントごとに個別管理
  - 従来: `~/.cache/update-ai-agents/last-update` (全エージェント共通)
  - 変更後: `~/.cache/update-ai-agents/last-update-<agent>` (エージェント別)
- ロックファイルもエージェントごとに個別管理
  - 従来: `~/.cache/update-ai-agents/update.lock` (共有)
  - 変更後: `~/.cache/update-ai-agents/update-<agent>.lock` (エージェント別)
  - これにより異なるエージェントを同時起動した場合に互いのロックで更新がブロックされなくなる

### `home/dot_bashrc.d/executable_90-ai-alias.sh`

各エイリアスに `--only <agent>` を追加:

| コマンド | 更新対象 |
|---------|---------|
| `claude` | Claude Code のみ |
| `codex` | Codex CLI のみ |
| `gemini` | Gemini CLI のみ |
| `copilot` | Copilot CLI のみ |
| `happy` | `update-ai-agents.sh` 呼び出しを削除（対応する更新関数なし） |

## 動作の変化

- **変更前**: `claude` を実行すると全 AI エージェント (Claude / Copilot / Codex / Gemini) の更新チェックが走る
- **変更後**: `claude` を実行すると Claude Code のみ更新チェックが走る