### PR TITLE
fix: claude alias を関数化して remote-control サブコマンドを修正

### DIFF
--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -1,7 +1,23 @@
 # AI CLI ツールのエイリアス設定
 # --dangerously-skip-permissions や --yolo は、確認プロンプトをスキップして実行するためのオプションです。
 # AI エージェントの自動更新 (update-ai-agents.sh --quick --only <agent>) を各 CLI 実行前に実行します。
-alias claude='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only claude; ~/.local/share/chezmoi/update.sh; claude --dangerously-skip-permissions'
+# claude コマンドのラッパー関数。
+# AI エージェント・chezmoi の更新を行い、--dangerously-skip-permissions を付与して実行する。
+# ただし remote-control サブコマンドはフラグを付与しない。
+# （--dangerously-skip-permissions が前置されると process.argv[2] が "remote-control" でなくなり、
+#   コマンドディスパッチが失敗して "Unknown argument: remote-control" エラーが発生するため）
+# 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
+unalias claude 2>/dev/null
+claude() {
+  [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only claude
+  ~/.local/share/chezmoi/update.sh
+  case "$1" in
+    remote-control|rc)
+      command claude "$@" ;;
+    *)
+      command claude --dangerously-skip-permissions "$@" ;;
+  esac
+}
 alias codex='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only codex; ~/.local/share/chezmoi/update.sh; codex --yolo'
 alias gemini='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only gemini; ~/.local/share/chezmoi/update.sh; gemini --yolo'
 # copilot コマンドのラッパー関数。

--- a/home/dot_zshrc.d/executable_90-ai-alias.zsh
+++ b/home/dot_zshrc.d/executable_90-ai-alias.zsh
@@ -1,7 +1,22 @@
 # AI CLI ツールのエイリアス設定
 # --dangerously-skip-permissions や --yolo は、確認プロンプトをスキップして実行するためのオプションです。
 # AI エージェントの自動更新 (update-ai-agents.sh --quick) を各 CLI 実行前に実行します。
-alias claude='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick; claude --dangerously-skip-permissions'
+# claude コマンドのラッパー関数。
+# AI エージェントの更新を行い、--dangerously-skip-permissions を付与して実行する。
+# ただし remote-control サブコマンドはフラグを付与しない。
+# （--dangerously-skip-permissions が前置されると process.argv[2] が "remote-control" でなくなり、
+#   コマンドディスパッチが失敗して "Unknown argument: remote-control" エラーが発生するため）
+# 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
+unalias claude 2>/dev/null
+claude() {
+  [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick
+  case "$1" in
+    remote-control|rc)
+      command claude "$@" ;;
+    *)
+      command claude --dangerously-skip-permissions "$@" ;;
+  esac
+}
 alias codex='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick; codex --yolo'
 alias gemini='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick; gemini --yolo'
 # copilot コマンドのラッパー関数。


### PR DESCRIPTION
## 問題

`claude remote-control` を実行すると以下のエラーが発生していた。

```
Error: Unknown argument: remote-control
Run 'claude remote-control --help' for usage.
```

## 原因

`~/.bashrc.d/90-ai-alias.sh` および `~/.zshrc.d/90-ai-alias.zsh` の `claude` alias が以下のように定義されていた。

```bash
alias claude='... claude --dangerously-skip-permissions'
```

`claude remote-control` を実行すると alias 展開後に以下のコマンドになる。

```bash
claude --dangerously-skip-permissions remote-control
```

Claude Code の `remote-control` コマンドは Commander.js ではなく `process.argv[2]` の直接比較でディスパッチされる。`--dangerously-skip-permissions` が前置されると `process.argv[2]` が `"remote-control"` でなくなるため、ディスパッチが失敗する。その結果、`remote-control` サブコマンドのパーサーに `"remote-control"` が未知の引数として渡され、上記エラーが発生していた。

## 修正内容

`claude` alias を `copilot` と同様の関数形式に変更し、`remote-control` / `rc` サブコマンドのみ `--dangerously-skip-permissions` を付与しないよう `case` 分岐を追加した。

### bash (`home/dot_bashrc.d/executable_90-ai-alias.sh`)

```bash
unalias claude 2>/dev/null
claude() {
  [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only claude
  ~/.local/share/chezmoi/update.sh
  case "$1" in
    remote-control|rc)
      command claude "$@" ;;
    *)
      command claude --dangerously-skip-permissions "$@" ;;
  esac
}
```

### zsh (`home/dot_zshrc.d/executable_90-ai-alias.zsh`)

zsh 版は変更前の alias と同様、`--only claude` および `chezmoi/update.sh` を持たない構成を維持している。

```zsh
unalias claude 2>/dev/null
claude() {
  [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick
  case "$1" in
    remote-control|rc)
      command claude "$@" ;;
    *)
      command claude --dangerously-skip-permissions "$@" ;;
  esac
}
```

## テスト

```bash
# 修正前: エラー
claude --dangerously-skip-permissions remote-control
# → Error: Unknown argument: remote-control

# 修正後: 正常動作
command claude remote-control
# → Error: Workspace not trusted. (コマンドは認識される)
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)