### PR TITLE
feat: statusline でコンテキストウィンドウ使用率を常時表示

### DIFF
--- a/home/dot_claude/hooks/executable_statusline.sh
+++ b/home/dot_claude/hooks/executable_statusline.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Claude Code ステータスライン表示スクリプト
+# コンテキストウィンドウの使用状況をカラープログレスバーで表示する
+
+# stdin から JSON を読み込む
+INPUT=$(cat)
+
+# コンテキストウィンドウの使用率を取得する（事前計算済みフィールドを優先）
+USED_PCT=$(echo "$INPUT" | jq -r '.context_window.used_percentage // empty')
+
+# used_percentage が存在しない場合は percent_used にフォールバックする
+if [ -z "$USED_PCT" ]; then
+  USED_PCT=$(echo "$INPUT" | jq -r '.context_window.percent_used // empty')
+fi
+
+# 使用率が取得できない場合は何も表示せず終了する
+if [ -z "$USED_PCT" ]; then
+  exit 0
+fi
+
+# 使用率を整数に丸める
+USED_INT=$(printf "%.0f" "$USED_PCT")
+
+# 使用中のトークン数を取得する
+TOKENS_USED=$(echo "$INPUT" | jq -r '.context_window.tokens_used // 0')
+
+# コンテキストウィンドウの最大サイズを取得する
+CTX_MAX=$(echo "$INPUT" | jq -r '.context_window.context_window_size // .context_window.current_model_max // 0')
+
+# ANSI カラーコードの定義
+COLOR_RESET="\033[0m"
+COLOR_GREEN="\033[32m"
+COLOR_YELLOW="\033[33m"
+COLOR_RED="\033[31m"
+COLOR_DIM="\033[2m"
+
+# 使用率に応じてバーの色を選択する
+if [ "$USED_INT" -lt 50 ]; then
+  BAR_COLOR="$COLOR_GREEN"
+elif [ "$USED_INT" -le 80 ]; then
+  BAR_COLOR="$COLOR_YELLOW"
+else
+  BAR_COLOR="$COLOR_RED"
+fi
+
+# プログレスバーを生成する（合計 20 文字分）
+BAR_WIDTH=20
+FILLED=$(( USED_INT * BAR_WIDTH / 100 ))
+EMPTY=$(( BAR_WIDTH - FILLED ))
+
+BAR_FILLED=""
+for ((i = 0; i < FILLED; i++)); do
+  BAR_FILLED="${BAR_FILLED}█"
+done
+
+BAR_EMPTY=""
+for ((i = 0; i < EMPTY; i++)); do
+  BAR_EMPTY="${BAR_EMPTY}░"
+done
+
+# トークン数を K 単位で整形する（bc の代わりに awk を使用）
+format_tokens() {
+  local n="$1"
+  if [ "$n" -ge 1000 ]; then
+    awk "BEGIN { printf \"%.1fK\", $n / 1000 }"
+  else
+    printf "%d" "$n"
+  fi
+}
+
+TOKENS_USED_FMT=$(format_tokens "$TOKENS_USED")
+CTX_MAX_FMT=$(format_tokens "$CTX_MAX")
+
+# ステータスラインを出力する
+printf "${BAR_COLOR}[${BAR_FILLED}${COLOR_DIM}${BAR_EMPTY}${COLOR_RESET}${BAR_COLOR}]${COLOR_RESET} ${BAR_COLOR}${USED_INT}%%${COLOR_RESET} ${COLOR_DIM}(${TOKENS_USED_FMT}/${CTX_MAX_FMT})${COLOR_RESET}"

--- a/home/dot_claude/hooks/executable_statusline.sh
+++ b/home/dot_claude/hooks/executable_statusline.sh
@@ -46,6 +46,8 @@ fi
 # プログレスバーを生成する（合計 20 文字分）
 BAR_WIDTH=20
 FILLED=$(( USED_INT * BAR_WIDTH / 100 ))
+# 使用率が 100% を超えた場合はバー幅を上限にクランプする
+if [ "$FILLED" -gt "$BAR_WIDTH" ]; then FILLED=$BAR_WIDTH; fi
 EMPTY=$(( BAR_WIDTH - FILLED ))
 
 BAR_FILLED=""
@@ -58,7 +60,7 @@ for ((i = 0; i < EMPTY; i++)); do
   BAR_EMPTY="${BAR_EMPTY}░"
 done
 
-# トークン数を K 単位で整形する（bc の代わりに awk を使用）
+# トークン数を K 単位の文字列に変換する（1000 未満はそのまま整数表示）
 format_tokens() {
   local n="$1"
   if [ "$n" -ge 1000 ]; then

--- a/home/dot_claude/hooks/executable_statusline.sh
+++ b/home/dot_claude/hooks/executable_statusline.sh
@@ -5,27 +5,38 @@
 # stdin から JSON を読み込む
 INPUT=$(cat)
 
-# コンテキストウィンドウの使用率を取得する（事前計算済みフィールドを優先）
-USED_PCT=$(echo "$INPUT" | jq -r '.context_window.used_percentage // empty')
-
-# used_percentage が存在しない場合は percent_used にフォールバックする
-if [ -z "$USED_PCT" ]; then
-  USED_PCT=$(echo "$INPUT" | jq -r '.context_window.percent_used // empty')
-fi
+# jq を 1 回だけ呼び出して必要なフィールドをまとめて取得する（オーバーヘッド削減）
+read -r USED_PCT TOKENS_USED CTX_MAX <<< "$(
+  echo "$INPUT" | jq -r '
+    [
+      (.context_window.used_percentage // .context_window.percent_used // ""),
+      (.context_window.tokens_used // 0 | tostring),
+      (.context_window.context_window_size // .context_window.current_model_max // 0 | tostring)
+    ] | join("\t")
+  ' 2>/dev/null
+)"
 
 # 使用率が取得できない場合は何も表示せず終了する
 if [ -z "$USED_PCT" ]; then
   exit 0
 fi
 
-# 使用率を整数に丸める
-USED_INT=$(printf "%.0f" "$USED_PCT")
+# 使用率を整数に丸める（非数値入力時は 0 にフォールバック）
+USED_INT=$(printf "%.0f" "$USED_PCT" 2>/dev/null || printf "0")
 
-# 使用中のトークン数を取得する
-TOKENS_USED=$(echo "$INPUT" | jq -r '.context_window.tokens_used // 0')
+# 丸め結果が不正な値の場合は 0 に補正する
+case "$USED_INT" in
+  ''|*[!0-9-]*)
+    USED_INT=0
+    ;;
+esac
 
-# コンテキストウィンドウの最大サイズを取得する
-CTX_MAX=$(echo "$INPUT" | jq -r '.context_window.context_window_size // .context_window.current_model_max // 0')
+# プログレスバー算出前に 0〜100 にクランプする
+if [ "$USED_INT" -lt 0 ]; then
+  USED_INT=0
+elif [ "$USED_INT" -gt 100 ]; then
+  USED_INT=100
+fi
 
 # ANSI カラーコードの定義
 COLOR_RESET="\033[0m"
@@ -46,8 +57,6 @@ fi
 # プログレスバーを生成する（合計 20 文字分）
 BAR_WIDTH=20
 FILLED=$(( USED_INT * BAR_WIDTH / 100 ))
-# 使用率が 100% を超えた場合はバー幅を上限にクランプする
-if [ "$FILLED" -gt "$BAR_WIDTH" ]; then FILLED=$BAR_WIDTH; fi
 EMPTY=$(( BAR_WIDTH - FILLED ))
 
 BAR_FILLED=""
@@ -63,10 +72,17 @@ done
 # トークン数を K 単位の文字列に変換する（1000 未満はそのまま整数表示）
 format_tokens() {
   local n="$1"
-  if [ "$n" -ge 1000 ]; then
-    awk "BEGIN { printf \"%.1fK\", $n / 1000 }"
+  # 数値以外は 0 として扱う
+  case "$n" in
+    ''|*[!0-9.]*|*.*.*)
+      n=0
+      ;;
+  esac
+  if [ "${n%.*}" -ge 1000 ] 2>/dev/null; then
+    # -v で値を渡してシェル展開によるコード注入を防ぐ
+    awk -v n="$n" 'BEGIN { printf "%.1fK", n / 1000 }'
   else
-    printf "%d" "$n"
+    printf "%d" "${n%.*}"
   fi
 }
 

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -121,5 +121,9 @@
     }
   },
   "skipDangerousModePermissionPrompt": true,
-  "showThinkingSummaries": true
+  "showThinkingSummaries": true,
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/hooks/statusline.sh"
+  }
 }


### PR DESCRIPTION
## Summary

Claude Code のステータスラインにコンテキストウィンドウ使用率を常時表示する機能を追加します。

## 変更内容

### 追加ファイル

**`home/dot_claude/hooks/executable_statusline.sh`**

- Claude Code から stdin で受け取った JSON セッションデータを解析し、コンテキスト使用状況をステータスラインに出力するスクリプト
- 使用率に応じたカラープログレスバー（ANSI カラー使用）
  - 緑: 使用率 50% 未満
  - 黄: 使用率 50〜80%
  - 赤: 使用率 80% 超
- 幅 20 文字のブロック文字プログレスバー（`█` / `░`）
- トークン数を K 単位で表示（例: `49.2K/200.0K`）
- `bc` の代わりに `awk -v` を使用（環境依存・コード注入を回避）
- `jq` を 1 回呼び出しにまとめてオーバーヘッドを削減
- 不正 JSON / 空入力時はエラーを抑制して静かに終了
- `USED_INT` を 0〜100 にクランプ（負値・100 超・非数値入力に対応）

### 変更ファイル

**`home/dot_claude/settings.json`**

- `statusLine` 設定を追加
  ```json
  "statusLine": {
    "type": "command",
    "command": "~/.claude/hooks/statusline.sh"
  }
  ```
  - パスは chezmoi デプロイ後のパス（`executable_` プレフィックスなし）
- `showThinkingSummaries: true` を追加（upstream PR #125 の変更を反映）

## 動作確認

```bash
# 25% (緑)
echo '{"context_window":{"tokens_used":49200,"percent_used":24.6,"current_model_max":200000}}' | bash home/dot_claude/hooks/executable_statusline.sh

# 60% (黄)
echo '{"context_window":{"tokens_used":120000,"percent_used":60.0,"current_model_max":200000}}' | bash home/dot_claude/hooks/executable_statusline.sh

# 90% (赤)
echo '{"context_window":{"tokens_used":180000,"percent_used":90.0,"current_model_max":200000}}' | bash home/dot_claude/hooks/executable_statusline.sh

# 105% (赤、クランプ動作確認)
echo '{"context_window":{"tokens_used":210000,"percent_used":105.0,"current_model_max":200000}}' | bash home/dot_claude/hooks/executable_statusline.sh

# 不正 JSON（何も出力されない）
echo "invalid json" | bash home/dot_claude/hooks/executable_statusline.sh
```

- Closes #116