### PR TITLE
feat: マシン固有の chezmoi 除外設定をローカル変数で制御

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -34,6 +34,6 @@
 .claude/scripts/limit-unlocked/data/
 
 # マシン固有の設定（ローカル設定で excludeCodexConfig = true のマシンのみ除外）
-{{- if .excludeCodexConfig }}
+{{- if index . "excludeCodexConfig" }}
 .codex/config.toml
 {{- end }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -32,3 +32,8 @@
 # Claude 関連スクリプトのローカル data
 .claude/scripts/completion-notify/data/
 .claude/scripts/limit-unlocked/data/
+
+# マシン固有の設定（ローカル設定で excludeCodexConfig = true のマシンのみ除外）
+{{- if .excludeCodexConfig }}
+.codex/config.toml
+{{- end }}


### PR DESCRIPTION
## 概要

`.chezmoiignore` でマシン固有ファイルを除外する際、ホスト名をべた書きしていた箇所を、ローカル設定ファイルのカスタム変数で制御するよう変更しました。

## 変更内容

### `home/.chezmoiignore`

- `~/.codex/config.toml` をマシン固有の除外対象として追加
- ホスト名ではなく、`~/.config/chezmoi/chezmoi.toml` の `excludeCodexConfig` 変数を参照する方式を採用

```toml
# 除外したいマシンの ~/.config/chezmoi/chezmoi.toml に追加
[data]
  excludeCodexConfig = true
```

## 背景

`.codex/config.toml` はマシン固有の設定（モデル、プロバイダ設定等）を含んでおり、特定マシンでは chezmoi による上書きを防ぎたい。ホスト名をリポジトリに残すとマシン名が露出するため、ローカル設定変数による制御に変更した。

他マシンでは変数が未定義（`false` 扱い）となり、引き続き管理対象のまま。

## テスト

- 本マシン（`excludeCodexConfig = true` 設定済み）で `chezmoi diff ~/.codex/config.toml` → `not managed` となることを確認済み