### PR TITLE
fix(chezmoi): update.sh の実行頻度を 24 時間に 1 回に制限

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,3 +1,21 @@
 #!/bin/bash
+# chezmoi の自動更新スクリプト
+# 24 時間以内に実行済みの場合はスキップする
+
+CACHE_DIR="$HOME/.cache/chezmoi-update"
+TIMESTAMP_FILE="$CACHE_DIR/last-update"
+
+mkdir -p "$CACHE_DIR"
+
+if [[ -f "$TIMESTAMP_FILE" ]]; then
+  last_update=$(cat "$TIMESTAMP_FILE" 2>/dev/null || echo 0)
+  elapsed=$(( $(date +%s) - last_update ))
+  if [[ $elapsed -lt 86400 ]]; then
+    exit 0
+  fi
+fi
+
 cd "$HOME" || exit
-sh -c "$(curl -fsSL get.chezmoi.io)" -- update
+if sh -c "$(curl -fsSL get.chezmoi.io)" -- update; then
+  date +%s > "$TIMESTAMP_FILE"
+fi

--- a/update.sh
+++ b/update.sh
@@ -8,7 +8,9 @@ TIMESTAMP_FILE="$CACHE_DIR/last-update"
 mkdir -p "$CACHE_DIR"
 
 if [[ -f "$TIMESTAMP_FILE" ]]; then
-  last_update=$(cat "$TIMESTAMP_FILE" 2>/dev/null || echo 0)
+  last_update=$(cat "$TIMESTAMP_FILE" 2>/dev/null || echo "")
+  # 非数値・空の場合は 0 扱いにして算術展開エラーを防ぐ
+  [[ "$last_update" =~ ^[0-9]+$ ]] || last_update=0
   elapsed=$(( $(date +%s) - last_update ))
   if [[ $elapsed -lt 86400 ]]; then
     exit 0
@@ -16,6 +18,9 @@ if [[ -f "$TIMESTAMP_FILE" ]]; then
 fi
 
 cd "$HOME" || exit
-if sh -c "$(curl -fsSL get.chezmoi.io)" -- update; then
-  date +%s > "$TIMESTAMP_FILE"
+# curl の失敗を検知するため先にインストーラを取得し、成功した場合のみ実行する
+if installer=$(curl -fsSL get.chezmoi.io); then
+  if sh -c "$installer" -- update; then
+    date +%s > "$TIMESTAMP_FILE"
+  fi
 fi


### PR DESCRIPTION
## 概要

`claude` / `codex` / `gemini` / `copilot` / `happy` コマンドを実行するたびに `~/.local/share/chezmoi/update.sh` が呼び出されており、毎回以下の処理が走っていた。

1. `get.chezmoi.io` から最新 chezmoi バイナリをダウンロード・インストール
2. `chezmoi update` → `git pull --autostash --rebase` を実行

この設計により、以下の問題が発生していた：

- コマンド起動のたびにネットワーク通信が発生しレスポンスが遅延する
- `git pull --autostash --rebase` が頻繁に実行され、git の状態によっては `fatal: Cannot rebase onto multiple branches.` エラーが発生する（実際に発生が確認された）

## 変更内容

`update.sh` に 24 時間のタイムスタンプチェックと堅牢性向上を追加した。

### 頻度制限

- `~/.cache/chezmoi-update/last-update` にタイムスタンプを保存
- 前回の実行から 24 時間未満の場合はスキップ（即時 exit 0）
- chezmoi update が成功した場合のみタイムスタンプを更新

### 堅牢性向上（Copilot レビュー対応）

- `last_update` が空・非数値の場合の算術展開エラーを防止: 正規表現 `^[0-9]+$` で検証し、無効値は `0` にフォールバック
- curl 失敗時にタイムスタンプだけ更新される問題を修正: インストーラを先に変数へ取得し（`installer=$(curl ...)`）、curl 成功時のみ `sh -c "$installer"` を実行することで終了コードを正しく伝播

## テスト観点

- 初回実行: タイムスタンプファイルが存在しないため chezmoi update が実行される
- 24 時間以内の再実行: スキップされる
- 24 時間経過後の再実行: chezmoi update が再び実行される
- chezmoi update 失敗時: タイムスタンプは更新されず次回も実行される
- タイムスタンプファイルが破損・空の場合: 0 にフォールバックし chezmoi update が実行される
- ネットワーク不調で curl が失敗した場合: タイムスタンプは更新されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)