### PR TITLE
fix: fix statusline field names and IFS separator

### DIFF
--- a/home/dot_claude/hooks/executable_statusline.sh
+++ b/home/dot_claude/hooks/executable_statusline.sh
@@ -6,13 +6,14 @@
 INPUT=$(cat)
 
 # jq を 1 回だけ呼び出して必要なフィールドをまとめて取得する（オーバーヘッド削減）
-read -r USED_PCT TOKENS_USED CTX_MAX <<< "$(
+# セパレータに | を使う（タブだと used_percentage が null のとき read の IFS 処理でフィールドがずれるため）
+IFS='|' read -r USED_PCT TOKENS_USED CTX_MAX <<< "$(
   echo "$INPUT" | jq -r '
     [
-      (.context_window.used_percentage // .context_window.percent_used // ""),
-      (.context_window.tokens_used // 0 | tostring),
-      (.context_window.context_window_size // .context_window.current_model_max // 0 | tostring)
-    ] | join("\t")
+      (.context_window.used_percentage // ""),
+      (.context_window.total_input_tokens // 0 | tostring),
+      (.context_window.context_window_size // 0 | tostring)
+    ] | join("|")
   ' 2>/dev/null
 )"
 

--- a/home/dot_claude/hooks/executable_statusline.sh
+++ b/home/dot_claude/hooks/executable_statusline.sh
@@ -7,7 +7,7 @@ INPUT=$(cat)
 
 # jq を 1 回だけ呼び出して必要なフィールドをまとめて取得する（オーバーヘッド削減）
 # セパレータに | を使う（タブだと used_percentage が null のとき read の IFS 処理でフィールドがずれるため）
-IFS='|' read -r USED_PCT TOKENS_USED CTX_MAX <<< "$(
+IFS='|' read -r USED_PCT TOTAL_INPUT_TOKENS CTX_MAX <<< "$(
   echo "$INPUT" | jq -r '
     [
       (.context_window.used_percentage // ""),
@@ -87,8 +87,8 @@ format_tokens() {
   fi
 }
 
-TOKENS_USED_FMT=$(format_tokens "$TOKENS_USED")
+TOTAL_INPUT_TOKENS_FMT=$(format_tokens "$TOTAL_INPUT_TOKENS")
 CTX_MAX_FMT=$(format_tokens "$CTX_MAX")
 
 # ステータスラインを出力する
-printf "${BAR_COLOR}[${BAR_FILLED}${COLOR_DIM}${BAR_EMPTY}${COLOR_RESET}${BAR_COLOR}]${COLOR_RESET} ${BAR_COLOR}${USED_INT}%%${COLOR_RESET} ${COLOR_DIM}(${TOKENS_USED_FMT}/${CTX_MAX_FMT})${COLOR_RESET}"
+printf "${BAR_COLOR}[${BAR_FILLED}${COLOR_DIM}${BAR_EMPTY}${COLOR_RESET}${BAR_COLOR}]${COLOR_RESET} ${BAR_COLOR}${USED_INT}%%${COLOR_RESET} ${COLOR_DIM}(${TOTAL_INPUT_TOKENS_FMT}/${CTX_MAX_FMT})${COLOR_RESET}"


### PR DESCRIPTION
## 概要

statusline フック スクリプトの 2 つのバグを修正する。

## 修正内容

### 1. `tokens_used` → `total_input_tokens` フィールド名の修正

Claude Code が出力する JSON の正しいフィールド名は `total_input_tokens` であるにもかかわらず、`tokens_used` を参照していたため、常に空値となっていた。

### 2. タブ区切り → パイプ区切りへの変更と `IFS='|'` の設定

`read` コマンドのフィールド分割にタブ区切りを使用していたが、`used_percentage` が null の場合にフィールドがずれる問題があった。区切り文字をパイプ（`|`）に変更し、`IFS='|'` を明示的に設定することで、null フィールドが含まれる場合でも正しく分割されるよう修正した。
