### PR TITLE
fix: respect project CLAUDE.md language for PR body

### DIFF
--- a/home/dot_agents/skills/issue-pr/SKILL.md
+++ b/home/dot_agents/skills/issue-pr/SKILL.md
@@ -44,11 +44,11 @@ Claude Code の `/issue-pr` 相当を Codex で扱うための skill です。
    - 最低限、変更内容に対応する syntax / unit / integration テストを実行する
    - dotfiles の場合は `tests/` と `chezmoi apply` 系確認を優先する
 7. コミットと push を行う。
-   - Conventional Commits を使い、説明は日本語にする
+   - Conventional Commits を使い、説明はプロジェクトの CLAUDE.md に従い、指定がない場合は日本語にする
 8. PR を作成する。
    - `gh-pr-target-repo.sh` で PR 作成先のリポジトリを解決する
    - `upstream` remote が存在する場合は、それを既定の PR 作成先にする
-   - PR 本文は日本語で、最新状態のみを記載する
+   - PR 本文はプロジェクトの CLAUDE.md に従い、指定がない場合は日本語で、最新状態のみを記載する
    - 更新履歴の羅列は含めない
 9. PR 作成後は直ちに `$pr-health-monitor` を使う。
    - 例: `$pr-health-monitor 456`

--- a/home/dot_agents/skills/ticket-pr/SKILL.md
+++ b/home/dot_agents/skills/ticket-pr/SKILL.md
@@ -64,11 +64,11 @@ Jira の課題タイプからブランチタイプを決定する:
    - 最低限、変更内容に対応する syntax / unit / integration テストを実行する
    - dotfiles の場合は `tests/` と `chezmoi apply` 系確認を優先する
 7. コミットと push を行う。
-   - Conventional Commits を使い、説明は日本語にする
+   - Conventional Commits を使い、説明はプロジェクトの CLAUDE.md に従い、指定がない場合は日本語にする
 8. PR を作成する。
    - `gh-pr-target-repo.sh` で PR 作成先のリポジトリを解決する
    - `upstream` remote が存在する場合は、それを既定の PR 作成先にする
-   - PR 本文は日本語で、最新状態のみを記載する
+   - PR 本文はプロジェクトの CLAUDE.md に従い、指定がない場合は日本語で、最新状態のみを記載する
    - 更新履歴の羅列は含めない
    - **重要**: PR のタイトル・本文には Jira チケットキーや Jira への言及を含めない
 9. Jira チケットに完了コメントを投稿する。

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -12,7 +12,7 @@
 ## Language
 
 - Final responses to the user must be in Japanese. For intermediate steps, use English except for key/important points, to reduce context size.
-- Code comments must be in Japanese. Error messages should be in English as a general rule.
+- Code comments: follow the project CLAUDE.md if it specifies one; otherwise Japanese. Error messages should be in English as a general rule.
 - Insert a half-width space between Japanese and alphanumeric characters.
 
 ## Environment Rules

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -17,7 +17,7 @@
 
 ## Environment Rules
 
-- Git commits must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). The `<description>` must be in Japanese.
+- Git commits must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). The `<description>` language: follow the project CLAUDE.md if it specifies one; otherwise Japanese.
 - Branches must follow [Conventional Branch](https://conventional-branch.github.io). Use short-form `<type>` (feat, fix).
 - When researching a GitHub repository, clone it to a temporary directory and search there.
 - Keep CLAUDE.md up to date.
@@ -72,7 +72,7 @@ Use the Todo tool to track all of the following without omission.
 
 ### Before Commit/Push
 
-1. Commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). `<description>` must be in Japanese.
+1. Commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). `<description>` language: follow the project CLAUDE.md if specified; otherwise Japanese.
 2. No sensitive information in the commit
 3. No Lint / Format errors
 4. Verify the change works as expected

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -89,7 +89,7 @@ Use the Todo tool to track all of the following without omission.
 Run `/pr-health-monitor <PR number>` to automate, or do the following manually:
 
 1. Verify no conflicts
-2. Update PR body with current state only (no history, in Japanese)
+2. Update PR body with current state only (no history). Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese
 3. Confirm CI with `gh pr checks <PR number> --watch`
 4. Request Copilot review and wait (`/wait-for-copilot-review`)
 5. Address review comments (`/handle-pr-reviews`)

--- a/home/dot_claude/rules/coding-py.md
+++ b/home/dot_claude/rules/coding-py.md
@@ -21,4 +21,4 @@ paths:
 
 ## Documentation
 
-- Write docstrings in Japanese for all functions and classes
+- Write docstrings for all functions and classes. Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese

--- a/home/dot_claude/rules/coding-sh.md
+++ b/home/dot_claude/rules/coding-sh.md
@@ -9,7 +9,7 @@ paths:
 
 ## Documentation
 
-- Write function description comments in Japanese
+- Write function description comments. Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese
 
 ## Error Messages
 

--- a/home/dot_claude/rules/coding-ts.md
+++ b/home/dot_claude/rules/coding-ts.md
@@ -16,7 +16,7 @@ paths:
 
 ## Documentation
 
-- Write and maintain JSDoc (docstring) in Japanese for all functions, interfaces, and classes
+- Write and maintain JSDoc (docstring) for all functions, interfaces, and classes. Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese
 
   ```typescript
   /**

--- a/home/dot_claude/skills/handle-pr-reviews/SKILL.md
+++ b/home/dot_claude/skills/handle-pr-reviews/SKILL.md
@@ -191,10 +191,11 @@ Only when `CHANGES_MADE=true`:
 # Check changed files
 git -C "$LOCAL_REPO_PATH" status
 
-# Commit following Conventional Commits (description in Japanese)
+# Commit following Conventional Commits
+# description language: follow the project CLAUDE.md if specified; otherwise Japanese
 # Explicitly stage edited files instead of using interactive add
 git -C "$LOCAL_REPO_PATH" add <list edited file paths>
-git -C "$LOCAL_REPO_PATH" commit -m "fix: レビューコメントに基づく修正"
+git -C "$LOCAL_REPO_PATH" commit -m "fix: <description in the project language>"
 
 # Push via SSH
 git -C "$LOCAL_REPO_PATH" push

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -135,7 +135,7 @@ In dotfiles, update chezmoi source files under `home/`.
 gh pr create --title "<title>" --body "<PR body>"
 ```
 
-PR body: in Japanese, current state only, no update history.
+PR body: follow the project CLAUDE.md language if specified; otherwise Japanese. Current state only, no update history.
 
 ### After PR Creation
 

--- a/home/dot_claude/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_claude/skills/pr-health-monitor/SKILL.md
@@ -85,7 +85,7 @@ If there are conflicts, merge the base branch to resolve them.
 
 ### Task D: Update PR Body
 
-Following CLAUDE.md rules, write the PR body with the current final state of the branch only — no history — in Japanese.
+Following CLAUDE.md rules, write the PR body with the current final state of the branch only — no history. Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese.
 
 ```bash
 gh pr edit "$PR_NUMBER" --body "$(cat <<'BODY'

--- a/home/dot_claude/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_claude/skills/pr-health-monitor/SKILL.md
@@ -89,13 +89,14 @@ Following CLAUDE.md rules, write the PR body with the current final state of the
 
 ```bash
 gh pr edit "$PR_NUMBER" --body "$(cat <<'BODY'
-## 概要
+## Summary
+(or ## 概要 if project language is Japanese)
+
 ...
 
-## 変更内容
-...
+## Changes
+(or ## 変更内容 if project language is Japanese)
 
-## 確認方法
 ...
 BODY
 )"

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -240,21 +240,21 @@ gh pr create ${REPO:+--repo "$REPO"} --title "<title>" --body "<PR body>"
 **Important**: do not include the Jira ticket key or any reference to Jira in the PR title or body.
 PR body: follow the project CLAUDE.md language if specified; otherwise Japanese. Current state only, no update history.
 
-Example PR body structure:
+Example PR body structure (section headings in the project language; Japanese shown as default):
 ```markdown
 ## 概要
 
-[summary of changes in the project language (default: Japanese)]
+[summary of changes]
 
 ## 変更内容
 
-- [変更点 1]
-- [変更点 2]
+- [change 1]
+- [change 2]
 
 ## 動作確認
 
-- [確認項目 1]
-- [確認項目 2]
+- [verification step 1]
+- [verification step 2]
 ```
 
 ### Completion Comment on Jira Ticket

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -225,7 +225,7 @@ git add <files>
 git commit -m "<type>: <Japanese description>"
 ```
 
-Follow Conventional Commits, with `<description>` written in Japanese.
+Follow Conventional Commits. `<description>` language: follow the project CLAUDE.md if specified; otherwise Japanese.
 
 ### Create PR
 
@@ -238,13 +238,13 @@ gh pr create ${REPO:+--repo "$REPO"} --title "<title>" --body "<PR body>"
 ```
 
 **Important**: do not include the Jira ticket key or any reference to Jira in the PR title or body.
-PR body: in Japanese, current state only, no update history.
+PR body: follow the project CLAUDE.md language if specified; otherwise Japanese. Current state only, no update history.
 
 Example PR body structure:
 ```markdown
 ## 概要
 
-[変更の概要を日本語で記載]
+[summary of changes in the project language (default: Japanese)]
 
 ## 変更内容
 


### PR DESCRIPTION
## 概要

PR 本文・コミット説明・コードコメント・JSDoc の言語指示が「日本語固定」になっており、プロジェクト側の CLAUDE.md で英語を指定しているリポジトリ（例: pixivts）でも日本語で出力されてしまう問題を修正する。

## 変更内容

- `home/dot_claude/CLAUDE.md`: 以下の言語指示を「プロジェクトの CLAUDE.md に従い、指定がない場合は日本語」に変更
  - コミット `<description>` の言語（環境ルール・Before Commit の両箇所）
  - コードコメントの言語
  - PR 本文の言語
- `home/dot_claude/rules/coding-ts.md`: JSDoc 言語指示を同様に変更
- `home/dot_claude/rules/coding-sh.md`: 関数コメント言語指示を同様に変更
- `home/dot_claude/rules/coding-py.md`: docstring 言語指示を同様に変更
- `home/dot_claude/skills/issue-pr/SKILL.md`: PR 本文言語指示を変更
- `home/dot_claude/skills/pr-health-monitor/SKILL.md`: PR 本文言語指示を変更、テンプレートを言語中立化
- `home/dot_claude/skills/handle-pr-reviews/SKILL.md`: コミット説明言語指示を変更、例文を汎用化
- `home/dot_claude/skills/ticket-pr/SKILL.md`: PR 本文・コミット説明言語指示を変更、テンプレートに注記を追加
- `home/dot_agents/skills/issue-pr/SKILL.md`: PR 本文・コミット説明言語指示を変更
- `home/dot_agents/skills/ticket-pr/SKILL.md`: PR 本文・コミット説明言語指示を変更