### PR TITLE
feat: claude コマンド実行時にカレントディレクトリを workspace trust 済みにする

### DIFF
--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -8,6 +8,19 @@
 #   コマンドディスパッチが失敗して "Unknown argument: remote-control" エラーが発生するため）
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias claude 2>/dev/null
+# カレントディレクトリを Claude Code のワークスペース信頼済みディレクトリとして
+# ~/.claude.json に登録する。
+# --dangerously-skip-permissions 環境では Workspace Trust dialog が機能せず
+# hasTrustDialogAccepted が永続化されないため、statusLine や hooks が無音で
+# スキップされてしまう問題への対策。
+_claude_trust_cwd() {
+  local config="$HOME/.claude.json"
+  [ -f "$config" ] || return 0
+  command -v jq > /dev/null 2>&1 || return 0
+  if [ "$(jq -r --arg p "$PWD" '.projects[$p].hasTrustDialogAccepted // false' "$config" 2> /dev/null)" != "true" ]; then
+    jq --arg p "$PWD" '.projects[$p] = ((.projects[$p] // {}) + {hasTrustDialogAccepted: true})' "$config" > "$config.tmp" && mv "$config.tmp" "$config"
+  fi
+}
 claude() {
   [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only claude
   ~/.local/share/chezmoi/update.sh
@@ -15,6 +28,7 @@ claude() {
     remote-control|rc)
       command claude "$@" ;;
     *)
+      _claude_trust_cwd
       command claude --dangerously-skip-permissions "$@" ;;
   esac
 }

--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -18,7 +18,16 @@ _claude_trust_cwd() {
   [ -f "$config" ] || return 0
   command -v jq > /dev/null 2>&1 || return 0
   if [ "$(jq -r --arg p "$PWD" '.projects[$p].hasTrustDialogAccepted // false' "$config" 2> /dev/null)" != "true" ]; then
-    jq --arg p "$PWD" '.projects[$p] = ((.projects[$p] // {}) + {hasTrustDialogAccepted: true})' "$config" > "$config.tmp" && mv "$config.tmp" "$config"
+    local tmp perm
+    tmp=$(mktemp "${config}.XXXXXX") || return 0
+    # 元ファイルのパーミッションを一時ファイルに反映する (GNU stat / BSD stat の両方に対応)
+    perm=$(stat -c '%a' "$config" 2> /dev/null || stat -f '%Lp' "$config" 2> /dev/null)
+    [ -n "$perm" ] && chmod "$perm" "$tmp"
+    if jq --arg p "$PWD" '.projects[$p] = ((.projects[$p] // {}) + {hasTrustDialogAccepted: true})' "$config" > "$tmp"; then
+      mv "$tmp" "$config"
+    else
+      rm -f "$tmp"
+    fi
   fi
 }
 claude() {

--- a/home/dot_zshrc.d/executable_90-ai-alias.zsh
+++ b/home/dot_zshrc.d/executable_90-ai-alias.zsh
@@ -18,7 +18,16 @@ _claude_trust_cwd() {
   [ -f "$config" ] || return 0
   command -v jq > /dev/null 2>&1 || return 0
   if [ "$(jq -r --arg p "$PWD" '.projects[$p].hasTrustDialogAccepted // false' "$config" 2> /dev/null)" != "true" ]; then
-    jq --arg p "$PWD" '.projects[$p] = ((.projects[$p] // {}) + {hasTrustDialogAccepted: true})' "$config" > "$config.tmp" && mv "$config.tmp" "$config"
+    local tmp perm
+    tmp=$(mktemp "${config}.XXXXXX") || return 0
+    # 元ファイルのパーミッションを一時ファイルに反映する (GNU stat / BSD stat の両方に対応)
+    perm=$(stat -c '%a' "$config" 2> /dev/null || stat -f '%Lp' "$config" 2> /dev/null)
+    [ -n "$perm" ] && chmod "$perm" "$tmp"
+    if jq --arg p "$PWD" '.projects[$p] = ((.projects[$p] // {}) + {hasTrustDialogAccepted: true})' "$config" > "$tmp"; then
+      mv "$tmp" "$config"
+    else
+      rm -f "$tmp"
+    fi
   fi
 }
 claude() {

--- a/home/dot_zshrc.d/executable_90-ai-alias.zsh
+++ b/home/dot_zshrc.d/executable_90-ai-alias.zsh
@@ -8,12 +8,26 @@
 #   コマンドディスパッチが失敗して "Unknown argument: remote-control" エラーが発生するため）
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias claude 2>/dev/null
+# カレントディレクトリを Claude Code のワークスペース信頼済みディレクトリとして
+# ~/.claude.json に登録する。
+# --dangerously-skip-permissions 環境では Workspace Trust dialog が機能せず
+# hasTrustDialogAccepted が永続化されないため、statusLine や hooks が無音で
+# スキップされてしまう問題への対策。
+_claude_trust_cwd() {
+  local config="$HOME/.claude.json"
+  [ -f "$config" ] || return 0
+  command -v jq > /dev/null 2>&1 || return 0
+  if [ "$(jq -r --arg p "$PWD" '.projects[$p].hasTrustDialogAccepted // false' "$config" 2> /dev/null)" != "true" ]; then
+    jq --arg p "$PWD" '.projects[$p] = ((.projects[$p] // {}) + {hasTrustDialogAccepted: true})' "$config" > "$config.tmp" && mv "$config.tmp" "$config"
+  fi
+}
 claude() {
   [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick
   case "$1" in
     remote-control|rc)
       command claude "$@" ;;
     *)
+      _claude_trust_cwd
       command claude --dangerously-skip-permissions "$@" ;;
   esac
 }


### PR DESCRIPTION
## 概要

`claude` コマンドのラッパー関数 (`.bashrc.d/90-ai-alias.sh`, `.zshrc.d/90-ai-alias.zsh`) に、実行前にカレントディレクトリを Claude Code の workspace trust 済みディレクトリとして `~/.claude.json` に登録する処理 (`_claude_trust_cwd`) を追加。

## 背景

`--dangerously-skip-permissions` を常用していると Workspace Trust dialog が機能せず、`hasTrustDialogAccepted` が `~/.claude.json` に永続化されない。結果として statusLine や hooks が workspace trust 未承認として無音でスキップされる。

## 変更内容

- `_claude_trust_cwd` 関数を追加し、`claude` 実行 (remote-control を除く) 前にカレントディレクトリの `hasTrustDialogAccepted` を `jq` で `true` に設定
- `~/.claude.json` が存在しない、または `jq` が無い場合は何もしない (no-op)
- 既に `true` の場合は書き込みをスキップ

## 動作確認

- 新規ディレクトリで `_claude_trust_cwd` を実行し、`~/.claude.json` の該当エントリが `absent` → `true` になることを確認
- 既存の他フィールドが merge により保持されることを確認
- 2回目の実行で no-op (exit 0) になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)