### PR TITLE
docs: テストランナーに vitest も選択肢として追加

### DIFF
--- a/home/dot_claude/rules/coding-ts.md
+++ b/home/dot_claude/rules/coding-ts.md
@@ -80,5 +80,12 @@ Maintain the following strict options:
 ## Toolchain
 
 - Package manager: **pnpm** (`only-allow pnpm` guard)
-- Test runner: **jest**
+- Test runner: **jest** or **vitest** (see "Test Runner Selection" below)
 - Node version: pinned in `.node-version`
+
+## Test Runner Selection
+
+- If the project already uses jest or vitest, follow the existing choice — no confirmation needed
+- If introducing a test runner for the first time, present the trade-offs below and confirm the choice with the user before adopting one
+  - **jest**: mature ecosystem, abundant references/examples; transpilation (e.g. `ts-jest`) and ESM setup can be fiddly
+  - **vitest**: native to Vite/ESM, fast, lightweight config; newer with a smaller ecosystem than jest


### PR DESCRIPTION
## 概要

`home/dot_claude/rules/coding-ts.md` のテストランナー選定ルールを更新。jest 固定だった記述を、jest または vitest を選べるように変更し、選定方法を明記した。

## 変更内容

- Toolchain セクションの Test runner 記述を `**jest**` 固定から `**jest** or **vitest**` に変更
- 新設の `## Test Runner Selection` セクションに以下を記載
  - 既にテストランナーが導入済みのプロジェクトでは、確認せず既存の選択に従う
  - 新規導入時は jest / vitest のメリット・デメリットを提示し、ユーザーに確認を取る
  - 判断の一貫性のための簡潔な比較（jest: 実績豊富だがトランスパイル/ESM 設定が手間になりがち / vitest: Vite・ESM ネイティブで高速・軽量設定だがエコシステムが小さい）

## 影響範囲

`home/dot_claude/rules/coding-ts.md` の 1 ファイルのみ。他に jest を参照する箇所はなし（`grep -rni "jest|vitest" home/` で確認済み）。

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)