### PR TITLE
feat: /config で変更された settings.json の設定を同期

### DIFF
--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -9,20 +9,6 @@
     "IS_DEMO": "1"
   },
   "model": "opusplan",
-  "effortLevel": "medium",
-  "autoMemoryEnabled": false,
-  "feedbackSurveyRate": 0,
-  "showClearContextOnPlanAccept": true,
-  "awaySummaryEnabled": false,
-  "verbose": true,
-  "language": "Use Japanese for interaction with humans and creating plans. Write the Markdown below .claude in English.",
-  "preferredNotifChannel": "auto",
-  "teammateMode": "auto",
-  "inputNeededNotifEnabled": true,
-  "worktree": {
-    "baseRef": "fresh"
-  },
-  "enableWorkflows": true,
   "hooks": {
     "Stop": [
       {
@@ -112,17 +98,31 @@
       }
     ]
   },
+  "worktree": {
+    "baseRef": "fresh"
+  },
+  "enableWorkflows": true,
+  "statusLine": {
+    "type": "command",
+    "command": "npx -y ccstatusline@latest"
+  },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true
   },
-  "skipDangerousModePermissionPrompt": true,
+  "language": "Use Japanese for interaction with humans and creating plans. Write the Markdown below .claude in English.",
+  "feedbackSurveyRate": 0,
+  "effortLevel": "medium",
+  "awaySummaryEnabled": false,
+  "showClearContextOnPlanAccept": true,
+  "autoMemoryEnabled": false,
   "showThinkingSummaries": true,
+  "skipDangerousModePermissionPrompt": true,
+  "verbose": true,
+  "preferredNotifChannel": "auto",
+  "teammateMode": "auto",
+  "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
-  "remoteControlAtStartup": true,
-  "statusLine": {
-    "type": "command",
-    "command": "npx -y ccstatusline@latest"
-  }
+  "remoteControlAtStartup": true
 }

--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -14,6 +14,15 @@
   "feedbackSurveyRate": 0,
   "showClearContextOnPlanAccept": true,
   "awaySummaryEnabled": false,
+  "verbose": true,
+  "language": "Use Japanese for interaction with humans and creating plans. Write the Markdown below .claude in English.",
+  "preferredNotifChannel": "auto",
+  "teammateMode": "auto",
+  "inputNeededNotifEnabled": true,
+  "worktree": {
+    "baseRef": "fresh"
+  },
+  "enableWorkflows": true,
   "hooks": {
     "Stop": [
       {


### PR DESCRIPTION
## 概要

`/config` コマンドで変更された `~/.claude/settings.json` の内容を dotfiles に同期する。

## 変更内容

`home/dot_claude/private_settings.json` に以下の設定を追加：

| キー | 値 | 説明 |
|---|---|---|
| `verbose` | `true` | 詳細ログを有効化 |
| `language` | `Use Japanese...` | 応答言語の設定 |
| `preferredNotifChannel` | `auto` | 通知チャンネルの自動選択 |
| `teammateMode` | `auto` | チームメイトモードの自動設定 |
| `inputNeededNotifEnabled` | `true` | 入力待ち通知を有効化 |
| `worktree.baseRef` | `fresh` | ワークツリーのベース参照 |
| `enableWorkflows` | `true` | ワークフロー機能を有効化 |

## 確認事項

- センシティブな情報なし
- コンフリクトなし