### PR TITLE
feat: Claude スキルをベストプラクティスに沿って見直す

### DIFF
--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -2,7 +2,8 @@
 name: deep-review
 description: Deep code review of a GitHub PR or the local working diff. Runs independent, scoped sub-agent reviews (CLAUDE.md adherence, bugs, git history, security incl. AI-PR risks, performance, silent failures, type design, tests), scores each finding 0-100 for confidence, reports only findings with score >= 50, and for the user's own PRs auto-fixes, commits, pushes, and updates the PR body.
 argument-hint: "[PR number or URL | omit to review the local working diff]"
-disable-model-invocation: false
+disable-model-invocation: true
+effort: high
 ---
 
 # deep-review skill

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -2,7 +2,7 @@
 name: deep-review
 description: Deep code review of a GitHub PR or the local working diff. Runs independent, scoped sub-agent reviews (CLAUDE.md adherence, bugs, git history, security incl. AI-PR risks, performance, silent failures, type design, tests), scores each finding 0-100 for confidence, reports only findings with score >= 50, and for the user's own PRs auto-fixes, commits, pushes, and updates the PR body.
 argument-hint: "[PR number or URL | omit to review the local working diff]"
-disable-model-invocation: true
+disable-model-invocation: false
 effort: high
 ---
 

--- a/home/dot_claude/skills/handle-pr-reviews/SKILL.md
+++ b/home/dot_claude/skills/handle-pr-reviews/SKILL.md
@@ -2,7 +2,7 @@
 name: handle-pr-reviews
 description: Process all PR review threads in bulk. Fetches all unresolved threads and systematically applies code fixes, replies, and resolves. Auto-triggered by background script on Copilot review detection.
 argument-hint: "[PR URL or PR number]"
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # PR Review Bulk Processing

--- a/home/dot_claude/skills/handle-pr-reviews/SKILL.md
+++ b/home/dot_claude/skills/handle-pr-reviews/SKILL.md
@@ -2,6 +2,7 @@
 name: handle-pr-reviews
 description: Process all PR review threads in bulk. Fetches all unresolved threads and systematically applies code fixes, replies, and resolves. Auto-triggered by background script on Copilot review detection.
 argument-hint: "[PR URL or PR number]"
+disable-model-invocation: true
 ---
 
 # PR Review Bulk Processing

--- a/home/dot_claude/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_claude/skills/pr-health-monitor/SKILL.md
@@ -2,6 +2,7 @@
 name: pr-health-monitor
 description: Automates the post-PR monitoring workflow. Runs CI check, Copilot review wait, code review, conflict check, and PR body update in parallel. Use with /pr-health-monitor <PR number or URL> immediately after creating a PR.
 argument-hint: "[PR number or URL]"
+disable-model-invocation: true
 ---
 
 # PR Health Monitor

--- a/home/dot_claude/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_claude/skills/pr-health-monitor/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-health-monitor
 description: Automates the post-PR monitoring workflow. Runs CI check, Copilot review wait, code review, conflict check, and PR body update in parallel. Use with /pr-health-monitor <PR number or URL> immediately after creating a PR.
 argument-hint: "[PR number or URL]"
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # PR Health Monitor

--- a/home/dot_claude/skills/wait-for-copilot-review/SKILL.md
+++ b/home/dot_claude/skills/wait-for-copilot-review/SKILL.md
@@ -2,6 +2,7 @@
 name: wait-for-copilot-review
 description: Waits in the background for a GitHub Copilot review after PR creation and automatically triggers /handle-pr-reviews on detection.
 argument-hint: "[PR number]"
+disable-model-invocation: true
 ---
 
 # Wait for GitHub Copilot Review
@@ -17,7 +18,7 @@ Automatically detects and notifies when GitHub Copilot posts a review after PR c
 Or run the script directly:
 
 ```bash
-~/.claude/skills/wait-for-copilot-review/scripts/wait-for-copilot-review.sh <PR_NUMBER> &
+${CLAUDE_SKILL_DIR}/scripts/wait-for-copilot-review.sh <PR_NUMBER> &
 ```
 
 ## Features

--- a/home/dot_claude/skills/wait-for-copilot-review/SKILL.md
+++ b/home/dot_claude/skills/wait-for-copilot-review/SKILL.md
@@ -2,7 +2,7 @@
 name: wait-for-copilot-review
 description: Waits in the background for a GitHub Copilot review after PR creation and automatically triggers /handle-pr-reviews on detection.
 argument-hint: "[PR number]"
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Wait for GitHub Copilot Review


### PR DESCRIPTION
## 概要

Claude Code スキルの公式ベストプラクティスに基づき、\`~/.claude/skills/\` 以下のスキルを見直しました。

## 変更内容

### \`effort: high\` の追加（\`deep-review\`）

9 つのサブエージェントを並列起動する重い処理に対して適切な推論レベルを確保します。

### \`\${CLAUDE_SKILL_DIR}\` 変数の活用（\`wait-for-copilot-review\`）

スクリプトパスのハードコードを公式推奨の \`\${CLAUDE_SKILL_DIR}\` 変数に変更しました。スキルの格納場所（personal/project/plugin）に依存せず参照できます。

```diff
-~/.claude/skills/wait-for-copilot-review/scripts/wait-for-copilot-review.sh <PR_NUMBER> &
+${CLAUDE_SKILL_DIR}/scripts/wait-for-copilot-review.sh <PR_NUMBER> &
```

### \`disable-model-invocation: false\` を明示（一部スキル）

\`handle-pr-reviews\`、\`pr-health-monitor\`、\`wait-for-copilot-review\` に \`disable-model-invocation: false\` を明示しました。\`issue-pr\` / \`ticket-pr\` は引き続き \`true\` で手動起動専用のままです。