### PR TITLE
feat: 決定論的ハーネスのベストプラクティスを適用

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -1,100 +1,51 @@
-## Guardrails / Rules
+## Guardrails
 
-- Do not make unauthorized changes (disabling hooks, closing PRs, changing settings, etc.) without explicit user approval. If something is blocking progress, ask the user instead of silently working around it.
-- Even for large-scale research or refactoring, do not cut corners — work carefully, methodically, and thoroughly. This is a mandatory requirement that applies in all cases.
+- No unauthorized changes (hooks, settings, PRs) without explicit approval — ask if blocked.
+- Work carefully and thoroughly, no shortcuts regardless of scale.
 - **Do not merge PRs until explicitly instructed.**
 
 ## Behavior
 
-- Do not flatter me. Always engage with critical thinking; push back if you think I'm wrong.
-- Skip phrases like "Great suggestion!" or "You're absolutely right!" — get to the point concisely.
+- No flattery. Push back when warranted. Be concise.
 
 ## Language
 
-- Final responses to the user must be in Japanese. For intermediate steps, use English except for key/important points, to reduce context size.
-- Code comments: follow the project CLAUDE.md if it specifies one; otherwise Japanese. Error messages should be in English as a general rule.
-- Insert a half-width space between Japanese and alphanumeric characters.
-- **All Markdown files under `~/.claude/` must be written in English** (CLAUDE.md, skills, rules, etc.).
+- Respond in Japanese. Intermediate steps in English to save context.
+- Code comments: follow project CLAUDE.md; default Japanese. Error messages: English.
+- Half-width space between Japanese and alphanumeric characters.
+- **All Markdown under `~/.claude/` must be written in English.**
 
-## Environment Rules
+## Git
 
-- Git commits must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). The `<description>` language: follow the project CLAUDE.md if it specifies one; otherwise Japanese.
-- Branches must follow [Conventional Branch](https://conventional-branch.github.io). Use short-form `<type>` (feat, fix).
-- When researching a GitHub repository, clone it to a temporary directory and search there.
-- Keep CLAUDE.md up to date.
-- Do not add commits or updates to existing Renovate-created PRs.
-- For background monitoring, when monitoring ends or on error, send a message to the tmux session running Claude Code via send-keys so Claude Code can act automatically. Get the session name with `tmux display-message -p '#{session_name}'`. Example: `tmux send-keys -t "$SESSION" "message" && sleep 3 && tmux send-keys -t "$SESSION" Enter`. Without `sleep 3` between the message and Enter, Enter is sent before Claude Code recognizes the input and is treated as a newline.
-- In `<<'EOF'` heredocs (single-quote delimiter), `\` does not function as an escape character, so backticks (`` ` ``) must be written as `` ` `` directly, not as `` \` ``. Writing `` \` `` outputs two characters and renders with a backslash in GitHub Markdown.
+- Push via **SSH** only. Handle auth autonomously.
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/) — description language follows project CLAUDE.md, otherwise Japanese.
+- Branches: [Conventional Branch](https://conventional-branch.github.io) short-form (`feat`, `fix`, …).
+- Do not modify `GH_CONFIG_DIR`, `GIT_*`, or `GIT_SSH_COMMAND` env vars without permission.
+- No `git config` username/email changes.
+- No commits to Renovate-created PRs.
+- Clone repos to a temp dir for research.
 
-## Git Operations
-
-Always use **SSH** (not HTTPS) for git push. Do not ask the user to fix git authentication manually. Handle it autonomously.
-
-If the environment variables GH_CONFIG_DIR, GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL, or GIT_SSH_COMMAND are set, they must not be modified without permission.  
-If you do not have access to the target repository, do not make assumptions; ask the user how to proceed.
-
-Furthermore, you must not use the git config command to change the username or email address.
-
-## PR / Issue Workflow
-
-Use the following skills to run the workflow:
+## Skills
 
 | Skill | Purpose |
 |---|---|
-| `/issue-pr <issue number>` | From issue to implementation and PR creation |
-| `/ticket-pr <ticket key OR URL>` | From Jira ticket to implementation and PR creation |
-| `/pr-health-monitor <PR number>` | Post-PR monitoring, CI, and review handling |
-| `/handle-pr-reviews <PR URL>` | Reply to and resolve review threads |
-| `/wait-for-copilot-review <PR number>` | Background wait for Copilot review |
+| `/issue-pr <number>` | Issue → implementation → PR |
+| `/ticket-pr <key or URL>` | Jira ticket → implementation → PR |
+| `/pr-health-monitor <number>` | Post-PR: CI, Copilot review, conflicts |
+| `/handle-pr-reviews <URL>` | Reply and resolve review threads |
+| `/wait-for-copilot-review <number>` | Background wait for Copilot review |
 
-See each skill (`/handle-pr-reviews`, `/pr-health-monitor`) for detailed steps and GraphQL queries.
+See @rules/workflow.md for checklists and Jira rules.
 
-## Issue / Ticket management
+## Tracking
 
-- As a general rule, use GitHub Issues for issues and tickets. GitHub Issues should be managed using the gh command
-- If a user explicitly requests the use of Jira, interact with Jira via MCP
-- Search for and identify the Jira space by the project name. If the relevant space does not exist, confirm with the user
-- Jira ticket titles and descriptions must be written in Japanese. When posting, set `contentFormat: "markdown"` and write line breaks as actual newline characters (not the literal `\n`) to avoid line-break issues
-- When starting implementation, please change the Jira ticket status to "In Progress". Once the PR is created, there are no conflicts, CI has passed, Copilot Review is complete, and the PR is ready to be merged, please comment to that effect on the ticket and change the status to "Resolved".
-- When checking content or changing status, please also consider the child tickets. In Business (simplified) projects, child issues are created as the "Task" type and are not listed in the parent's `subtasks` field — use the JQL `parent = <ISSUE_KEY>` to fetch them (see the ticket-pr skill for details).
-- Do not mention Jira on GitHub Issues or pull requests
+Use the Todo tool for all multi-step work without omission.
 
-## Must Do
+## Gotchas
 
-Use the Todo tool to track all of the following without omission.
-
-### Before New Work
-
-1. Thoroughly explore and understand the project
-2. Verify the working branch is appropriate — not a branch with a closed PR
-3. Verify it is a new branch based on the latest remote branch
-4. Verify that closed/unnecessary branches have been deleted
-5. Install dependencies using the project's specified package manager
-
-### Before Commit/Push
-
-1. Commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). `<description>` language: follow the project CLAUDE.md if specified; otherwise Japanese.
-2. No sensitive information in the commit
-3. No Lint / Format errors
-4. Verify the change works as expected
-
-### Before Creating a PR
-
-1. Confirm the user has requested a PR
-2. No sensitive information in the commit
-3. No risk of conflicts
-4. Run `/deep-review` (local diff mode — no argument) and **address all findings with score ≥ 50** before proceeding to PR creation
-
-### After Creating a PR
-
-Run `/pr-health-monitor <PR number>` to automate, or do the following manually:
-
-1. Verify no conflicts
-2. Update PR body with current state only (no history). Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese
-3. Confirm CI with `gh pr checks <PR number> --watch`
-4. Request Copilot review and wait (`/wait-for-copilot-review`)
-5. Address review comments (`/handle-pr-reviews`)
+- Background monitoring: notify tmux on end/error — `tmux send-keys -t "$SESSION" "msg" && sleep 3 && tmux send-keys -t "$SESSION" Enter`
+- `<<'EOF'` heredocs: backticks must be literal `` ` `` — `\`` outputs two characters in GitHub Markdown.
+- chezmoi: `executable_` prefix is stripped at deploy — reference scripts without it in settings/configs.
 
 @CLAUDE.local.md
-
 @RTK.md

--- a/home/dot_claude/hooks/executable_deep-review-immediate-fix.sh
+++ b/home/dot_claude/hooks/executable_deep-review-immediate-fix.sh
@@ -45,7 +45,8 @@ done
 
 # ステートファイルに結果を書き出す（Stop hook が使用）
 # ディレクトリはオーナーのみアクセス可能 (700) で作成する
-mkdir -p -m 700 "$STATE_DIR"
+# mkdir -p と -m の組み合わせは最深ディレクトリにしか適用されないため分割する（SC2174）
+mkdir -p "$STATE_DIR" && chmod 700 "$STATE_DIR"
 if ! jq -n \
     --arg session_id "$SESSION_ID" \
     --argjson high_score_count "$HIGH_SCORE_COUNT" \

--- a/home/dot_claude/hooks/executable_deep-review-immediate-fix.sh
+++ b/home/dot_claude/hooks/executable_deep-review-immediate-fix.sh
@@ -28,8 +28,9 @@ fi
 SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
 
 # tool_response からスコアを抽出する
+# grep -oP（PCRE）は macOS の BSD grep では動かないため grep -E + sed で代替する
 TOOL_RESPONSE=$(printf '%s' "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null)
-mapfile -t SCORES < <(printf '%s' "$TOOL_RESPONSE" | grep -oP 'Score:\s*\K\d+' 2>/dev/null)
+mapfile -t SCORES < <(printf '%s' "$TOOL_RESPONSE" | grep -E 'Score:[[:space:]]*[0-9]+' | sed 's/.*Score:[[:space:]]*//' | grep -E '^[0-9]+')
 
 # スコア 50 以上の指摘をカウントする
 HIGH_SCORE_COUNT=0

--- a/home/dot_claude/hooks/executable_deep-review-immediate-fix.sh
+++ b/home/dot_claude/hooks/executable_deep-review-immediate-fix.sh
@@ -1,41 +1,67 @@
 #!/bin/bash
 
-# deep-review スキル実行後に指摘事項の対応を促す PostToolUse フック
-# スコア 50 以上の指摘が残っている場合に Claude の処理をブロックする
+# PostToolUse hook: deep-review スキル実行後に指摘事項の対応を促す。
+# スコア 50 以上の指摘が残っている場合に Claude の処理をブロックする。
+# 副作用として findings を ~/.claude/data/deep-review-state.json に書き出す。
+# これにより Stop hook (deep-review-require-fixes.sh) がトランスクリプトを
+# パースせずステートファイルから確実に判定できる。
+
+STATE_DIR="$HOME/.claude/data"
+STATE_FILE="$STATE_DIR/deep-review-state.json"
 
 # stdin から JSON を読み込む（公式フック契約: stdin JSON）
 INPUT=$(cat)
 
 # Skill ツールの実行か確認する
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
 if [[ "$TOOL_NAME" != "Skill" ]]; then
-    echo '{}'
     exit 0
 fi
 
 # deep-review スキル以外はスキップする
-# skill_name と skill の両方を試みて互換性を確保する
-SKILL=$(printf '%s' "$INPUT" | jq -r '.tool_input.skill_name // .tool_input.skill // ""' 2>/dev/null || echo "")
+SKILL=$(printf '%s' "$INPUT" | jq -r '.tool_input.skill_name // .tool_input.skill // ""' 2>/dev/null)
 if [[ "$SKILL" != "deep-review" ]]; then
-    echo '{}'
     exit 0
 fi
 
+# セッション ID を取得する
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+
 # tool_response からスコアを抽出する
-TOOL_RESPONSE=$(printf '%s' "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null || echo "")
-SCORES=$(printf '%s' "$TOOL_RESPONSE" | grep -oP 'Score:\s*\K\d+' 2>/dev/null || echo "")
+TOOL_RESPONSE=$(printf '%s' "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null)
+mapfile -t SCORES < <(printf '%s' "$TOOL_RESPONSE" | grep -oP 'Score:\s*\K\d+' 2>/dev/null)
 
 # スコア 50 以上の指摘をカウントする
 HIGH_SCORE_COUNT=0
 MAX_SCORE=0
-while IFS= read -r score; do
+for score in "${SCORES[@]}"; do
     if [[ -n "$score" && "$score" -ge 50 ]]; then
         HIGH_SCORE_COUNT=$((HIGH_SCORE_COUNT + 1))
         if [[ "$score" -gt "$MAX_SCORE" ]]; then
             MAX_SCORE="$score"
         fi
     fi
-done <<< "$SCORES"
+done
+
+# ステートファイルに結果を書き出す（Stop hook が使用）
+# ディレクトリはオーナーのみアクセス可能 (700) で作成する
+mkdir -p -m 700 "$STATE_DIR"
+if ! jq -n \
+    --arg session_id "$SESSION_ID" \
+    --argjson high_score_count "$HIGH_SCORE_COUNT" \
+    --argjson max_score "$MAX_SCORE" \
+    --argjson timestamp "$(date +%s)" \
+    '{
+        session_id: $session_id,
+        timestamp: $timestamp,
+        high_score_count: $high_score_count,
+        max_score: $max_score
+    }' > "$STATE_FILE"; then
+    echo "ERROR: Failed to write deep-review state to $STATE_FILE" >&2
+    # PostToolUse ブロックは機能しているため続行する。Stop hook での再検証はスキップされる。
+fi
+# ステートファイルはオーナーのみ読み書き可能 (600) にする
+chmod 600 "$STATE_FILE" 2>/dev/null
 
 # スコア 50 以上の指摘がある場合はブロックして対応を促す
 if [[ "$HIGH_SCORE_COUNT" -gt 0 ]]; then
@@ -56,19 +82,10 @@ CLAUDE.md の規則により、スコア 50 以上の指摘事項に必ず対応
 fi
 
 # スコア情報はあるが全件 50 未満の場合
-if [[ -n "$SCORES" ]]; then
-    TOTAL=$(printf '%s' "$SCORES" | grep -c '^' 2>/dev/null || echo 0)
-    jq -n --arg total "$TOTAL" '{"decision":"approve","reason":("deep-review: " + $total + " 件の指摘がありましたが、すべてスコア 50 未満です。")}'
+TOTAL="${#SCORES[@]}"
+if [[ "$TOTAL" -gt 0 ]]; then
+    jq -n --argjson total "$TOTAL" '{"decision":"approve","reason":("deep-review: " + ($total | tostring) + " 件の指摘がありましたが、すべてスコア 50 未満です。")}'
     exit 0
 fi
 
-# スコア情報がない場合は "Found X issue(s)" 形式から件数を取得する
-TOTAL_ISSUES=$(printf '%s' "$TOOL_RESPONSE" | grep -oP 'Found \K\d+(?= issues?)' 2>/dev/null || echo "")
-if [[ -n "$TOTAL_ISSUES" && "$TOTAL_ISSUES" -gt 0 ]]; then
-    jq -n --arg total "$TOTAL_ISSUES" '{"decision":"approve","reason":("deep-review: " + $total + " 件の指摘がありました（スコア情報なし）。必要に応じて対応を検討してください。")}'
-    exit 0
-fi
-
-# 問題なし
-echo '{}'
 exit 0

--- a/home/dot_claude/hooks/executable_deep-review-require-fixes.sh
+++ b/home/dot_claude/hooks/executable_deep-review-require-fixes.sh
@@ -20,12 +20,21 @@ fi
 
 # ステートファイルを読み込む
 STATE_SESSION=$(jq -r '.session_id // ""' "$STATE_FILE" 2>/dev/null)
+STATE_TIMESTAMP=$(jq -r '.timestamp // 0' "$STATE_FILE" 2>/dev/null)
 HIGH_SCORE_COUNT=$(jq -r '.high_score_count // 0' "$STATE_FILE" 2>/dev/null)
 MAX_SCORE=$(jq -r '.max_score // 0' "$STATE_FILE" 2>/dev/null)
 
-# セッション ID が一致しない → 別セッションの古いデータ → ブロックしない
+# ステートファイルの有効期限（24時間）
+STATE_TTL=86400
+CURRENT_TIME=$(date +%s)
+STATE_AGE=$(( CURRENT_TIME - STATE_TIMESTAMP ))
+
+# セッション ID が不一致かつ TTL 超過 → 別セッションの古いデータ → ブロックしない
+# セッション ID が一致する、または TTL 以内なら現在のセッションのデータとして扱う
 if [[ -n "$SESSION_ID" && -n "$STATE_SESSION" && "$SESSION_ID" != "$STATE_SESSION" ]]; then
-    exit 0
+    if [[ "$STATE_AGE" -gt "$STATE_TTL" ]]; then
+        exit 0
+    fi
 fi
 
 # スコア 50 以上の指摘が残っている場合はセッション終了をブロックする

--- a/home/dot_claude/hooks/executable_deep-review-require-fixes.sh
+++ b/home/dot_claude/hooks/executable_deep-review-require-fixes.sh
@@ -1,56 +1,38 @@
 #!/bin/bash
 
-# Stop hook: block session end if deep-review found unresolved high-score issues.
-# Triggers when /deep-review was run in this session and Score: 50+ findings remain.
+# Stop hook: セッション終了時に deep-review の未対応指摘が残っていないか検証する。
+# トランスクリプトのテキストパースには頼らず、PostToolUse フックが書き出した
+# ステートファイル (~/.claude/data/deep-review-state.json) を優先参照する。
+# ステートファイルが存在しない場合はブロックしない（セッション内で deep-review 未実行）。
 
-# Read JSON from stdin (official hook contract: stdin JSON)
+STATE_FILE="$HOME/.claude/data/deep-review-state.json"
+
+# stdin から JSON を読み込む（公式フック契約: stdin JSON）
 INPUT=$(cat)
 
-# Get transcript path from stdin JSON
-TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")
+# 現在のセッション ID を取得する
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
 
-# transcript ファイルが存在しない場合はブロックしない
-if [[ -z "$TRANSCRIPT_PATH" ]] || [[ ! -f "$TRANSCRIPT_PATH" ]]; then
-    echo '{}'
+# ステートファイルが存在しない → このセッションで deep-review 未実行 → ブロックしない
+if [[ ! -f "$STATE_FILE" ]]; then
     exit 0
 fi
 
-# deep-review スキルの実行有無を確認する
-if ! grep -q 'deep-review' "$TRANSCRIPT_PATH"; then
-    echo '{}'
+# ステートファイルを読み込む
+STATE_SESSION=$(jq -r '.session_id // ""' "$STATE_FILE" 2>/dev/null)
+HIGH_SCORE_COUNT=$(jq -r '.high_score_count // 0' "$STATE_FILE" 2>/dev/null)
+MAX_SCORE=$(jq -r '.max_score // 0' "$STATE_FILE" 2>/dev/null)
+
+# セッション ID が一致しない → 別セッションの古いデータ → ブロックしない
+if [[ -n "$SESSION_ID" && -n "$STATE_SESSION" && "$SESSION_ID" != "$STATE_SESSION" ]]; then
     exit 0
 fi
-
-# 最後の deep-review 実行以降のスコアのみを対象にする
-# これにより、過去のセッションで修正済みの指摘が残り続けてブロックし続けることを防ぐ
-LAST_LINE=$(grep -n 'deep-review' "$TRANSCRIPT_PATH" | tail -1 | cut -d: -f1)
-if [[ -n "$LAST_LINE" ]]; then
-    SCORES=$(tail -n "+$LAST_LINE" "$TRANSCRIPT_PATH" | grep -oP 'Score:\s*\K\d+' 2>/dev/null || echo "")
-else
-    SCORES=""
-fi
-
-# スコア 50 以上の指摘をカウントする
-HIGH_SCORE_COUNT=0
-MAX_SCORE=0
-while IFS= read -r score; do
-    if [[ -n "$score" && "$score" -ge 50 ]]; then
-        HIGH_SCORE_COUNT=$((HIGH_SCORE_COUNT + 1))
-        if [[ "$score" -gt "$MAX_SCORE" ]]; then
-            MAX_SCORE="$score"
-        fi
-    fi
-done <<< "$SCORES"
 
 # スコア 50 以上の指摘が残っている場合はセッション終了をブロックする
 if [[ "$HIGH_SCORE_COUNT" -gt 0 ]]; then
     REASON="⚠️ deep-review で ${HIGH_SCORE_COUNT} 件の重要な指摘事項が見つかりました（最高スコア: ${MAX_SCORE}）。
 
 CLAUDE.md のルールに従い、スコア 50 以上の指摘事項に対応してから終了してください。
-
-対応が必要な理由:
-- スコア 50 以上の指摘は、機能や品質に直接影響する重要な問題です。
-- これらの問題を放置すると、後で重大なバグや保守性の低下につながる可能性があります。
 
 対応手順:
 1. スコア 50 以上の指摘をすべて確認する
@@ -63,5 +45,4 @@ CLAUDE.md のルールに従い、スコア 50 以上の指摘事項に対応し
 fi
 
 # 対応済みまたは指摘なし
-echo '{}'
 exit 0

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -15,7 +15,6 @@ STATE_FILE="$HOME/.claude/data/session-state.json"
 
 # stdin から JSON を読み込む
 INPUT=$(cat)
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
 TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
 
 # --- PR URL 解決 ---

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -1,76 +1,79 @@
 #!/bin/bash
 
-# PR レビュースレッド対応漏れ防止フック
-# セッション終了時に未解決レビュースレッドをチェックし、対応を促す
+# Stop hook: セッション終了時に未解決レビュースレッドをチェックし、対応を促す。
+# PR 番号の取得優先順:
+#   1. ~/.claude/data/session-state.json（issue-pr / ticket-pr スキルが書き出す）
+#   2. transcript の JSONL パース（フォールバック）
+# JSONL パースによりプレーンテキスト grep より確実に PR URL を抽出する。
 
 # スキップ機能（緊急時や誤検知時）
 if [[ "${SKIP_REVIEW_CHECK:-}" == "1" ]]; then
-  echo '{"block":false}'
-  exit 0
+    exit 0
 fi
 
-# 環境変数から transcript パスを取得
-TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
+STATE_FILE="$HOME/.claude/data/session-state.json"
 
-# transcript ファイルが存在しない場合
-if [[ -z "$TRANSCRIPT_PATH" ]] || [[ ! -f "$TRANSCRIPT_PATH" ]]; then
-  echo '{"block":false}'
-  exit 0
+# stdin から JSON を読み込む
+INPUT=$(cat)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
+
+# --- PR URL 解決 ---
+
+PR_URL=""
+
+# 優先 1: ステートファイル（スキルが書き出した構造化データ）
+if [[ -f "$STATE_FILE" ]]; then
+    STATE_SESSION=$(jq -r '.session_id // ""' "$STATE_FILE" 2>/dev/null)
+    if [[ -z "$SESSION_ID" || "$SESSION_ID" == "$STATE_SESSION" ]]; then
+        PR_URL=$(jq -r '.pr_url // ""' "$STATE_FILE" 2>/dev/null)
+    fi
 fi
 
-# PR 番号を抽出（複数パターンで試行）
-PR_NUMBER=""
-
-# パターン1: gh pr create の出力から URL を抽出
-PR_URL=$(grep -oP 'https://github\.com/[^/]+/[^/]+/pull/\d+' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1)
-if [[ -n "$PR_URL" ]]; then
-  PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K\d+' 2>/dev/null)
+# 優先 2: transcript の JSONL パース（プレーンテキスト grep より確実）
+if [[ -z "$PR_URL" && -n "$TRANSCRIPT_PATH" && -f "$TRANSCRIPT_PATH" ]]; then
+    PR_URL=$(jq -r '
+        select(type == "object") |
+        select(.type == "assistant") |
+        .message.content[]? |
+        if type == "string" then . else "" end |
+        scan("https://github\\.com/[^/\\s]+/[^/\\s]+/pull/[0-9]+")
+    ' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1)
 fi
 
-# パターン2: request-review-copilot の引数から URL を抽出
+# PR URL が取得できない場合はブロックしない（誤検知回避）
+if [[ -z "$PR_URL" ]]; then
+    exit 0
+fi
+
+# PR 番号を抽出する
+PR_NUMBER=$(printf '%s' "$PR_URL" | grep -oP '/pull/\K\d+' 2>/dev/null)
 if [[ -z "$PR_NUMBER" ]]; then
-  PR_URL=$(grep -oP 'request-review-copilot\s+https://github\.com/[^/]+/[^/]+/pull/\d+' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1 | grep -oP 'https://[^\s]+')
-  if [[ -n "$PR_URL" ]]; then
-    PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K\d+' 2>/dev/null)
-  fi
+    exit 0
 fi
 
-# パターン3: transcript 内の /pull/NUMBER から抽出
-if [[ -z "$PR_NUMBER" ]]; then
-  PR_NUMBER=$(grep -oP '/pull/\K\d+' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1)
-fi
+# --- owner/repo 解決 ---
 
-# PR 番号が取得できない場合はブロックしない（誤検知回避）
-if [[ -z "$PR_NUMBER" ]]; then
-  echo '{"block":false}'
-  exit 0
-fi
-
-# git remote から owner/repo を抽出
 REMOTE_URL=$(git remote get-url origin 2>/dev/null)
 if [[ -z "$REMOTE_URL" ]]; then
-  echo '{"block":false}'
-  exit 0
+    exit 0
 fi
 
-# HTTPS URL の場合: https://github.com/owner/repo.git
-# SSH URL の場合: git@github.com:owner/repo.git
 if [[ "$REMOTE_URL" =~ github\.com[:/]([^/]+)/([^/\.]+) ]]; then
-  OWNER="${BASH_REMATCH[1]}"
-  REPO="${BASH_REMATCH[2]}"
+    OWNER="${BASH_REMATCH[1]}"
+    REPO="${BASH_REMATCH[2]}"
 else
-  echo '{"block":false}'
-  exit 0
+    exit 0
 fi
 
-# GraphQL API で未解決レビュースレッドを取得
-# セキュリティのため、変数をパラメータ化して使用
+# --- GraphQL で未解決レビュースレッドを取得 ---
+
 # shellcheck disable=SC2016
 GRAPHQL_RESPONSE=$(gh api graphql \
-  -f owner="$OWNER" \
-  -f repo="$REPO" \
-  -F number="$PR_NUMBER" \
-  -f query='
+    -f owner="$OWNER" \
+    -f repo="$REPO" \
+    -F number="$PR_NUMBER" \
+    -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
@@ -82,104 +85,6 @@ query($owner: String!, $repo: String!, $number: Int!) {
           line
           comments(first: 1) {
             nodes {
-              author {
-                login
-              }
-              body
-            }
-          }
-        }
-      }
-    }
-  }
-}
-' 2>/dev/null)
-
-# GraphQL API エラーの場合はブロックしない
-if [[ -z "$GRAPHQL_RESPONSE" ]]; then
-  echo '{"block":false}'
-  exit 0
-fi
-
-# 未解決スレッドを抽出
-UNRESOLVED_THREADS=$(echo "$GRAPHQL_RESPONSE" | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)' 2>/dev/null)
-
-# 未解決スレッドがない場合はブロックしない
-if [[ -z "$UNRESOLVED_THREADS" ]]; then
-  echo '{"block":false}'
-  exit 0
-fi
-
-# 未解決スレッド数をカウント
-UNRESOLVED_COUNT=$(echo "$UNRESOLVED_THREADS" | jq -s 'length' 2>/dev/null)
-
-# 未解決スレッド一覧を生成（最初の 5 件まで）
-THREAD_LIST=""
-THREAD_INDEX=1
-while IFS= read -r thread; do
-  if [[ $THREAD_INDEX -gt 5 ]]; then
-    THREAD_LIST="${THREAD_LIST}\n[...他 $((UNRESOLVED_COUNT - 5)) 件のスレッド]"
-    break
-  fi
-
-  # shellcheck disable=SC2034
-  THREAD_ID=$(echo "$thread" | jq -r '.id' 2>/dev/null)
-  THREAD_PATH=$(echo "$thread" | jq -r '.path // "unknown"' 2>/dev/null)
-  THREAD_LINE=$(echo "$thread" | jq -r '.line // "N/A"' 2>/dev/null)
-  AUTHOR_LOGIN=$(echo "$thread" | jq -r '.comments.nodes[0].author.login // "unknown"' 2>/dev/null)
-  COMMENT_BODY=$(echo "$thread" | jq -r '.comments.nodes[0].body // ""' 2>/dev/null)
-
-  # コメント冒頭 100 文字
-  COMMENT_PREVIEW=$(echo "$COMMENT_BODY" | head -c 100)
-  if [[ ${#COMMENT_BODY} -gt 100 ]]; then
-    COMMENT_PREVIEW="${COMMENT_PREVIEW}..."
-  fi
-
-  THREAD_LIST="${THREAD_LIST}\n[スレッド $THREAD_INDEX] @$AUTHOR_LOGIN - $THREAD_PATH:$THREAD_LINE\n  \"$COMMENT_PREVIEW\""
-  THREAD_INDEX=$((THREAD_INDEX + 1))
-done < <(echo "$GRAPHQL_RESPONSE" | jq -c '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)' 2>/dev/null)
-
-# ブロックメッセージを生成
-MESSAGE="⚠️ **PR に $UNRESOLVED_COUNT 件の未解決レビュースレッドが残っています**
-
-CLAUDE.md のルールに従い、**すべての未解決レビュースレッド**に対して必ず対応してから終了してください。
-
-## 未解決スレッド一覧
-$THREAD_LIST
-
-## 対応が必要な理由
-
-- 未解決レビューコメントを放置すると、コードの品質や保守性に影響が出る可能性があります
-- レビューコメントは重要なフィードバックであり、対応漏れは避けるべきです
-- GitHub Copilot や他のレビュアーからのコメントはすべて対応が必要です
-
-## 対応手順（重要：必ず順序通りに実施してください）
-
-### 0. レビューコメントをブラウザで確認（推奨）
-
-\`\`\`bash
-gh pr view $PR_NUMBER --web
-\`\`\`
-
-または、CLI で未解決スレッドを確認:
-
-\`\`\`bash
-OWNER=\"$OWNER\"
-REPO=\"$REPO\"
-PR_NUMBER=$PR_NUMBER
-
-gh api graphql -f query='
-query {
-  repository(owner: \"'\$OWNER'\", name: \"'\$REPO'\") {
-    pullRequest(number: '\$PR_NUMBER') {
-      reviewThreads(first: 100) {
-        nodes {
-          id
-          isResolved
-          path
-          line
-          comments(first: 10) {
-            nodes {
               author { login }
               body
             }
@@ -188,77 +93,74 @@ query {
       }
     }
   }
-}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)'
-\`\`\`
+}' 2>/dev/null)
 
-### 1. 各レビュースレッドに対して対応
+if [[ -z "$GRAPHQL_RESPONSE" ]]; then
+    exit 0
+fi
 
-**各スレッドごとに以下を実施:**
+# 未解決スレッド数を確認する
+UNRESOLVED_COUNT=$(printf '%s' "$GRAPHQL_RESPONSE" | \
+    jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null)
 
-a. レビューコメントの内容を確認し、対応が必要か判断
-b. 対応が必要な場合は適切な修正を実施
-c. 修正内容をコミット・プッシュ（必要に応じて）
+if [[ -z "$UNRESOLVED_COUNT" || "$UNRESOLVED_COUNT" -eq 0 ]]; then
+    exit 0
+fi
 
-### 2. 各レビュースレッドに返信を投稿（重要）
+# 未解決スレッド一覧を生成する（最初の 5 件まで）
+THREAD_LIST=$(printf '%s' "$GRAPHQL_RESPONSE" | jq -r '
+    [.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] |
+    to_entries[:5] |
+    .[] |
+    "[スレッド \(.key + 1)] @\(.value.comments.nodes[0].author.login // "unknown") - \(.value.path // "unknown"):\(.value.line // "N/A")\n  \"\(.value.comments.nodes[0].body // "" | .[0:100])\(if (.value.comments.nodes[0].body // "" | length) > 100 then "..." else "" end)\""
+' 2>/dev/null | tr '\n' '\n')
 
-**注意**: 通常のコメント（issue コメント）として投稿してはいけません。
-**必ず** \`addPullRequestReviewThreadReply\` mutation を使用してスレッドに返信してください。
+if [[ "$UNRESOLVED_COUNT" -gt 5 ]]; then
+    THREAD_LIST="${THREAD_LIST}
+[...他 $((UNRESOLVED_COUNT - 5)) 件のスレッド]"
+fi
 
-\`\`\`bash
-# 各レビュースレッド ID に対して実行
-THREAD_ID=\"取得したスレッド ID\"
-gh api graphql -f query='
-mutation {
-  addPullRequestReviewThreadReply(input: {
-    pullRequestReviewThreadId: \"'\$THREAD_ID'\"
-    body: \"対応内容を記載（修正した内容、理由、または現状維持の判断など）\"
-  }) {
-    comment { id }
-  }
-}'
-\`\`\`
+# ブロックメッセージを生成する
+MESSAGE="⚠️ **PR に ${UNRESOLVED_COUNT} 件の未解決レビュースレッドが残っています**
 
-### 3. 対応が完了したレビュースレッドを resolve
+CLAUDE.md のルールに従い、**すべての未解決レビュースレッド**に対して必ず対応してから終了してください。
 
-**注意**: 返信を投稿した後、**必ず** resolve してください。
+## 未解決スレッド一覧
 
-\`\`\`bash
-# 各レビュースレッド ID に対して実行
-gh api graphql -f query='
-mutation {
-  resolveReviewThread(input: {threadId: \"'\$THREAD_ID'\"}) {
-    thread {
-      id
-      isResolved
-    }
-  }
-}'
-\`\`\`
+${THREAD_LIST}
 
-### 4. 再度すべての未解決レビュースレッドを確認
+## 対応手順（順序通りに実施してください）
 
-手順 0 のコマンドを再度実行し、すべてのスレッドが resolved になっていることを確認してください。
-
-### 5. セッション終了を再試行
-
-すべてのスレッドが resolved になったら、セッションを終了してください。フックが再度実行され、今度は通過するはずです。
-
-## 緊急時のスキップ方法
-
-どうしてもレビューコメントへの対応を後回しにしたい場合（誤検知など）:
+### 1. 各スレッドを確認・修正
 
 \`\`\`bash
-SKIP_REVIEW_CHECK=1 # フックをスキップ
+gh pr view ${PR_NUMBER} --web
 \`\`\`
 
-**注意**: この方法は緊急時のみ使用し、後で必ず対応してください。
+### 2. スレッドへ返信（issue コメントではなく thread reply を使用）
+
+\`\`\`bash
+gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: \"<THREAD_ID>\" body: \"対応内容\" }) { comment { id } } }'
+\`\`\`
+
+### 3. スレッドを resolve
+
+\`\`\`bash
+gh api graphql -f query='mutation { resolveReviewThread(input: { threadId: \"<THREAD_ID>\" }) { thread { id isResolved } } }'
+\`\`\`
+
+### 4. 全スレッド解決後にセッション終了を再試行
 
 ## よくある間違い
 
-❌ 通常のコメント（issue コメント）として投稿している → **\`addPullRequestReviewThreadReply\` を使用してください**
-❌ 返信を投稿したが resolve していない → **返信後は必ず \`resolveReviewThread\` を実行してください**
-❌ 一部のスレッドだけ対応している → **すべてのスレッドに対応してください**
-❌ レビューがまだ来ていないのにセッションを終了しようとしている → **レビューが来るまで待つか、後で確認してください**"
+- ❌ issue コメントとして投稿 → \`addPullRequestReviewThreadReply\` を使用してください
+- ❌ 返信後に resolve していない → 返信後は必ず \`resolveReviewThread\` を実行してください
 
-jq -n --arg msg "$MESSAGE" '{"block":true,"message":$msg}'
+## 緊急スキップ
+
+\`\`\`bash
+SKIP_REVIEW_CHECK=1
+\`\`\`"
+
+jq -n --arg msg "$MESSAGE" '{"decision":"block","reason":$msg}'
 exit 0

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -21,11 +21,16 @@ TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/n
 # --- PR URL 解決 ---
 
 PR_URL=""
+# セッション状態ファイルの有効期限（24時間）
+STATE_TTL=86400
 
 # 優先 1: ステートファイル（スキルが書き出した構造化データ）
+# セッション ID が一致、またはタイムスタンプが TTL 以内であれば有効と見なす
 if [[ -f "$STATE_FILE" ]]; then
-    STATE_SESSION=$(jq -r '.session_id // ""' "$STATE_FILE" 2>/dev/null)
-    if [[ -z "$SESSION_ID" || "$SESSION_ID" == "$STATE_SESSION" ]]; then
+    STATE_TIMESTAMP=$(jq -r '.timestamp // 0' "$STATE_FILE" 2>/dev/null)
+    CURRENT_TIME=$(date +%s)
+    STATE_AGE=$(( CURRENT_TIME - STATE_TIMESTAMP ))
+    if [[ "$STATE_AGE" -le "$STATE_TTL" ]]; then
         PR_URL=$(jq -r '.pr_url // ""' "$STATE_FILE" 2>/dev/null)
     fi
 fi
@@ -46,9 +51,10 @@ if [[ -z "$PR_URL" ]]; then
     exit 0
 fi
 
-# PR 番号を抽出する
-PR_NUMBER=$(printf '%s' "$PR_URL" | grep -oP '/pull/\K\d+' 2>/dev/null)
-if [[ -z "$PR_NUMBER" ]]; then
+# PR 番号を抽出する（Bash 正規表現で PCRE 非依存）
+if [[ "$PR_URL" =~ /pull/([0-9]+) ]]; then
+    PR_NUMBER="${BASH_REMATCH[1]}"
+else
     exit 0
 fi
 

--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -16,15 +16,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/scripts/completion-notify/notify-completion.sh"
+            "command": "~/.claude/scripts/completion-notify/notify-completion.sh",
+            "onFailure": "ignore"
           },
           {
             "type": "command",
-            "command": "bash ~/.claude/hooks/deep-review-require-fixes.sh"
+            "command": "bash ~/.claude/hooks/deep-review-require-fixes.sh",
+            "onFailure": "fail"
           },
           {
             "type": "command",
-            "command": "bash ~/.claude/hooks/require-review-thread-fixes.sh"
+            "command": "bash ~/.claude/hooks/require-review-thread-fixes.sh",
+            "onFailure": "fail"
           }
         ]
       }
@@ -35,7 +38,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/scripts/completion-notify/notify-askuserquestion.sh"
+            "command": "~/.claude/scripts/completion-notify/notify-askuserquestion.sh",
+            "onFailure": "ignore"
           }
         ]
       },
@@ -44,7 +48,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/rtk-rewrite.sh"
+            "command": "~/.claude/hooks/rtk-rewrite.sh",
+            "onFailure": "ignore"
           }
         ]
       }
@@ -55,11 +60,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ~/.claude/hooks/deep-review-immediate-fix.sh"
+            "command": "bash ~/.claude/hooks/deep-review-immediate-fix.sh",
+            "onFailure": "ignore"
           },
           {
             "type": "command",
-            "command": "~/.claude/scripts/completion-notify/notify-post-tool-use.sh"
+            "command": "~/.claude/scripts/completion-notify/notify-post-tool-use.sh",
+            "onFailure": "ignore"
           }
         ]
       }
@@ -70,7 +77,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/scripts/completion-notify/notify-permission-request.sh"
+            "command": "~/.claude/scripts/completion-notify/notify-permission-request.sh",
+            "onFailure": "ignore"
           }
         ]
       }
@@ -81,7 +89,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/scripts/completion-notify/notify-notification.sh"
+            "command": "~/.claude/scripts/completion-notify/notify-notification.sh",
+            "onFailure": "ignore"
           }
         ]
       }
@@ -92,7 +101,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/scripts/completion-notify/notify-user-prompt-submit.sh"
+            "command": "~/.claude/scripts/completion-notify/notify-user-prompt-submit.sh",
+            "onFailure": "ignore"
           }
         ]
       }

--- a/home/dot_claude/rules/security.md
+++ b/home/dot_claude/rules/security.md
@@ -1,0 +1,42 @@
+# Security Rules
+
+Security guardrails enforced across all projects.
+
+---
+
+## Secrets and credentials
+
+- Never commit API keys, tokens, passwords, or internal URLs.
+- Store secrets in `~/.env` or `~/.gitconfig.local` (outside chezmoi management).
+- If a secret is accidentally staged, abort immediately and rotate it.
+- Never log credential values, even in debug output.
+
+## Dangerous shell commands
+
+- Avoid `rm -rf` without explicit user approval and a stated recovery plan.
+- Never run destructive DB commands (`DROP TABLE`, `DELETE FROM` without `WHERE`, `TRUNCATE`) without a schema backup confirmed first.
+- Prefer dry-run flags (`--dry-run`, `-n`) when available before executing destructive operations.
+
+## Dependencies
+
+- Do not add dependencies with known critical CVEs.
+- Pin versions in lockfiles; do not use floating ranges for production dependencies.
+- Prefer well-maintained packages (last commit < 1 year, active issue tracker).
+
+## Code injection
+
+- Sanitize all user-controlled input before passing to shell commands, SQL, or eval.
+- Avoid `eval` and dynamic `require`/`import` with user-supplied strings.
+- Template strings that include user input must be parameterized (prepared statements, not concatenation).
+
+## Authentication and authorization
+
+- Never implement custom crypto — use established libraries.
+- Enforce authorization checks server-side; do not rely solely on client-side gating.
+- OAuth/OIDC tokens must not be stored in `localStorage` or cookies without `HttpOnly` + `Secure`.
+
+## Prompt injection (AI-specific)
+
+- Treat any user-supplied text that reaches an LLM prompt as untrusted.
+- Do not include file contents or external data in system prompts without sanitization.
+- Never store tool call results containing user input in persistent system context without review.

--- a/home/dot_claude/rules/workflow-sub-agents.md
+++ b/home/dot_claude/rules/workflow-sub-agents.md
@@ -1,276 +1,69 @@
 # Sub-Agent Delegation Strategy
 
-This document defines when and how to delegate tasks to sub-agents (via the `task` tool). Based on research from multi-agent AI systems, Anthropic best practices, and empirical findings from production workflows.
-
-## Core Principle
-
-**Default to direct action.** Only delegate to sub-agents when the overhead is justified by genuine complexity or parallelism benefits.
+**Default: direct action.** Delegate only when overhead is justified.
 
 ---
 
-## Task Complexity Assessment
-
-Before delegating, assess task complexity:
-
-| Complexity | Characteristics | Recommended Approach |
-|------------|-----------------|---------------------|
-| **Simple** | 1-5 tool calls, single file/module, well-defined scope | Direct execution (grep/glob/view/edit/bash) |
-| **Medium** | 6-10 tool calls, multiple related files, requires investigation | Direct execution with structured approach |
-| **Complex** | 10+ tool calls, multiple independent areas, benefits from specialization | Consider sub-agent delegation |
-
-### Complexity Indicators
-
-**Simple tasks (do yourself):**
-- Reading 1-3 known files
-- Single file edits
-- Straightforward grep/glob searches
-- Running a single command
-- Applying a well-defined pattern
-
-**Complex tasks (consider delegation):**
-- Investigating multiple independent modules in parallel
-- Tasks requiring specialized evaluation (security review, performance analysis)
-- Long-running operations where you have other independent work
-- Multi-step workflows with distinct phases (plan → implement → test)
-
----
-
-## When to Use Sub-Agents
-
-### ✅ Delegate When
-
-1. **True Parallelism Exists**
-   - You have independent work to do while the sub-agent runs
-   - Multiple independent research threads can run simultaneously
-   - Example: Analyze 5 unrelated services in parallel
-
-2. **Specialized Expertise Needed**
-   - Security review requiring deep analysis
-   - Code review with high signal-to-noise ratio
-   - Performance profiling across multiple components
-
-3. **Large-Scale Investigation**
-   - Cross-cutting concerns across many modules in a large codebase
-   - Tracing complex data flows through multiple layers
-   - Researching unfamiliar legacy systems
-
-4. **Context Isolation Beneficial**
-   - Testing or building with verbose output (use `task` agent to keep main context clean)
-   - Experimental approaches that might pollute main conversation
-   - Multiple alternative solution explorations
-
-### Pattern: Planner-Generator-Evaluator
-
-For truly complex features, the **planner → generator → evaluator** pattern is effective:
+## Decision framework
 
 ```
-1. Planner: Break down requirements into detailed subtasks
-2. Generator: Implement each subtask
-3. Evaluator: Verify correctness, security, performance
-4. [Iterate if needed]
-```
-
-**When to use this pattern:**
-- Features spanning 5+ files
-- Features requiring architectural decisions
-- Features with multiple integration points
-- Security-critical implementations
-
-**Implementation:**
-- Launch `general-purpose` agent as planner
-- Use your own tools as generator (or delegate to another agent)
-- Launch `security-review` or `code-review` agent as evaluator
-
----
-
-## When NOT to Use Sub-Agents
-
-### ❌ Do NOT Delegate When
-
-1. **Task is Simple**
-   - Accomplishable in 2-5 direct tool calls
-   - Single file or module scope
-   - Well-understood pattern application
-
-2. **No Real Parallelism**
-   - You're just waiting for sub-agent results
-   - No independent work to do during delegation
-   - Polling defeats the purpose (use sync mode if you must wait)
-
-3. **High Context Dependency**
-   - Subtask requires full understanding of current conversation
-   - Frequent back-and-forth with existing context needed
-   - State must be synchronized continuously
-
-4. **Trivial Operations**
-   - Formatting, logging, simple transformations
-   - One-liner fixes or adjustments
-   - Style-only changes
-
-5. **One-Off Tasks**
-   - Unlikely to recur
-   - No reusability benefit
-   - No clear modularity advantage
-
-### Example: Simple Discover-Read-Edit (Do It Yourself)
-
-```
-❌ Bad: Launch explore agent to find config file
-✅ Good: Use grep/glob directly, read file, make edit
-
-# Direct approach (3 tool calls, ~10 seconds):
-1. glob pattern="**/config*.json"
-2. view path="/found/config.json"
-3. edit path="/found/config.json" old_str="..." new_str="..."
-```
-
----
-
-## Anti-Patterns
-
-### 1. Micro-Delegation
-**Problem:** Delegating tiny tasks where overhead exceeds benefit.
-```
-❌ Bad: Launch agent to read a single file
-❌ Bad: Launch agent to run one grep command
-✅ Good: Do it yourself in one tool call
-```
-
-### 2. Premature Sub-Agentization
-**Problem:** Breaking up tasks too early, causing unnecessary complexity.
-```
-❌ Bad: Create 5 agents for a 10-line change across 2 files
-✅ Good: Make the change directly
-```
-
-### 3. Excessive Context Passing
-**Problem:** Shuttling large context between agents repeatedly.
-```
-❌ Bad: Pass 200KB of code to agent, get results, pass 200KB to next agent
-✅ Good: Keep large context in main conversation, delegate only independent pieces
-```
-
-### 4. Background Polling
-**Problem:** Launch background agent then immediately poll with read_agent.
-```
-❌ Bad:
-  1. task(..., mode="background") → agent_id
-  2. read_agent(agent_id, wait=true)  # This defeats background purpose
-
-✅ Good (background):
-  1. task(..., mode="background") → agent_id
-  2. Continue your own independent work (grep, view, edit)
-  3. Agent completes automatically, notification arrives
-  4. read_agent(agent_id) to retrieve results
-
-✅ Good (if no parallel work):
-  1. task(..., mode="sync")  # Just block, it's faster
-```
-
-### 5. Delegation for Simple Searches
-**Problem:** Using explore agent for straightforward code lookup.
-```
-❌ Bad: Launch explore agent to "find the User model"
-✅ Good: grep pattern="class User" or glob pattern="**/User.{ts,js,py}"
-```
-
-### 6. Untraceable Delegation Chains
-**Problem:** Sub-agents delegating to sub-agents, creating debugging nightmares.
-```
-❌ Bad: Agent A → Agent B → Agent C → Agent D (tracing failures is impossible)
-✅ Good: Keep delegation depth ≤ 2 levels
-```
-
----
-
-## Decision Framework
-
-Use this decision tree:
-
-```
-Can I do this in ≤5 tool calls?
+Can I do this in ≤ 5 tool calls?
 ├─ YES → Do it yourself
-└─ NO → Is there genuine parallelism or specialization benefit?
-    ├─ YES → Consider delegation
-    │   ├─ Do I have other independent work? → Use background mode
-    │   └─ No other work? → Use sync mode (or just do it yourself)
-    └─ NO → Do it yourself
+└─ NO  → Genuine parallelism or specialization benefit?
+    ├─ YES → Delegate
+    │   ├─ Other independent work to do? → background mode
+    │   └─ No other work?               → sync mode (or just do it yourself)
+    └─ NO  → Do it yourself
 ```
 
-### Quick Reference
+## Quick reference
 
-| Task Type | Tool Calls | Recommendation |
-|-----------|-----------|----------------|
-| File read | 1-2 | Direct (view) |
-| Simple edit | 2-3 | Direct (view + edit) |
-| Single search | 1-2 | Direct (grep/glob) |
-| Multi-file analysis | 5-10 | Direct with structured approach |
-| Cross-module investigation | 10-15 | Consider explore agent if parallel work exists |
-| Full feature implementation | 15+ | Consider general-purpose agent with planning |
-| Security review | Any | Consider security-review agent (specialized) |
-| Code review of changes | Any | Consider code-review agent (high signal) |
+| Task type | Tool calls | Recommendation |
+|---|---|---|
+| File read | 1–2 | Direct |
+| Simple edit | 2–3 | Direct |
+| Single search | 1–2 | Direct |
+| Multi-file analysis | 5–10 | Direct with structured approach |
+| Cross-module investigation | 10–15 | Explore agent if parallel work exists |
+| Full feature implementation | 15+ | general-purpose agent with planning |
+| Security / code review | Any | Specialized agent (high signal-to-noise) |
 
----
+## When to delegate ✅
 
-## Performance Comparison
+1. **True parallelism** — independent threads that can run simultaneously.
+2. **Specialized expertise** — security review, performance profiling.
+3. **Large-scale investigation** — cross-cutting concerns across many modules.
+4. **Context isolation** — verbose output or experimental approaches that would pollute main context.
 
-Based on research and empirical data:
+## When NOT to delegate ❌
 
-### Iterative Refinement (Single Agent)
-- **Speed:** Fast for simple/linear problems
-- **Quality (simple tasks):** High
-- **Quality (complex tasks):** Medium
-- **Setup overhead:** Low
-- **Best for:** Prototyping, bug fixes, straightforward features
+1. Task accomplishable in ≤ 5 direct tool calls.
+2. No real parallel work to do while waiting.
+3. High context dependency — frequent back-and-forth with current state.
+4. One-off trivial operations (formatting, one-liner fixes).
 
-### Multi-Agent Planning/Evaluation Loop
-- **Speed:** Medium (coordination overhead)
-- **Quality (simple tasks):** High (but overkill)
-- **Quality (complex tasks):** High
-- **Setup overhead:** High
-- **Best for:** Production features, architecture-heavy projects, security-critical code
+## Anti-patterns
 
-### Delegation Overhead
+| Anti-pattern | Bad | Good |
+|---|---|---|
+| Micro-delegation | Launch agent to read one file | `view` directly |
+| Background polling | launch background → immediately `read_agent(wait=true)` | Continue own work; retrieve on notification |
+| Deep chains | A → B → C → D | Keep depth ≤ 2 levels |
+| Excessive context passing | Shuttle 200 KB between agents | Keep large context in main, delegate only independent pieces |
 
-Each delegation incurs:
-- Context serialization/deserialization
-- Agent initialization
-- Communication round-trips
-- Result aggregation
+## Planner–Generator–Evaluator pattern
 
-**Rule of thumb:** Delegation overhead ≈ 3-5 tool calls equivalent.  
-Only delegate if the task is 10+ tool calls AND benefits from specialization/parallelism.
+For features spanning 5+ files or with security-critical paths:
 
----
+1. **Planner** (`general-purpose`): break down requirements into subtasks.
+2. **Generator** (main agent or worker): implement each subtask.
+3. **Evaluator** (`security-review` / `code-review`): verify correctness, security, performance.
 
-## Practical Guidelines
+## Sub-agent model selection
 
-### For Simple Tasks (90% of work)
-1. Use grep/glob/view/edit/bash directly
-2. Batch independent reads in parallel (multiple view calls in one response)
-3. Chain related bash commands with `&&`
-4. Keep it simple, keep it fast
-
-### For Complex Tasks (10% of work)
-1. Assess: Is this truly complex? Can I break it down myself?
-2. Plan: What are the independent pieces?
-3. Delegate: Only the pieces that benefit from separate context
-4. Verify: Check results, iterate if needed
-
-### For Background Agents
-1. Only use when you have OTHER independent work to do
-2. After launching, immediately continue with your own tools
-3. Do NOT poll - wait for automatic notification
-4. Retrieve results with read_agent after notification
-
----
-
-## Summary
-
-- **Default to direct action** - 90% of tasks are simple enough
-- **Delegate strategically** - Only for genuine complexity or parallelism
-- **Avoid anti-patterns** - No micro-delegation, no polling, no excessive context passing
-- **Measure complexity** - Use the decision framework
-- **Prefer sync over background** - Unless you have real parallel work
-
-The goal is **effective task completion**, not agent orchestration for its own sake.
+| Role | Model | Tools |
+|---|---|---|
+| Coordinator | Opus | All |
+| Implementation worker | Sonnet | Write, Edit, Bash |
+| Verification worker | Opus | Read, Grep, Bash |
+| Discovery worker | Haiku | Read, Grep |

--- a/home/dot_claude/rules/workflow.md
+++ b/home/dot_claude/rules/workflow.md
@@ -1,0 +1,73 @@
+# Workflow Rules
+
+Rules and checklists for the full development workflow.
+
+---
+
+## ADR-001: GitHub Issues as primary tracker
+
+**Decision**: Use GitHub Issues (via `gh` CLI) as the primary issue tracker.  
+**Alternatives considered**: Jira-only, GitHub Projects.  
+**Rationale**: Closest to the code, minimal context-switching.  
+**Exception**: Use Jira when the user explicitly requests it (MCP integration).
+
+## ADR-002: PR reviews must be fully resolved before session end
+
+**Decision**: The Stop hook blocks session end when unresolved review threads exist.  
+**Rationale**: Unresolved threads silently block merge and create follow-up debt.  
+**Escape**: `SKIP_REVIEW_CHECK=1` for genuine false positives only.
+
+## ADR-003: deep-review score ≥ 50 findings must be fixed before PR creation
+
+**Decision**: `/deep-review` must pass (no score ≥ 50 findings) before creating a PR.  
+**Rationale**: Catches correctness bugs, security issues, and CLAUDE.md violations early.  
+**Implementation**: PostToolUse and Stop hooks enforce this automatically.
+
+---
+
+## Pre-work checklist
+
+1. Understand the project structure.
+2. Confirm the working branch is not a closed-PR branch.
+3. Branch from the latest remote default branch.
+4. Delete stale local branches.
+5. Install dependencies if required by the project.
+
+## Pre-commit checklist
+
+1. Commit message follows Conventional Commits. Description language: project CLAUDE.md → otherwise Japanese.
+2. No sensitive information (tokens, passwords, internal URLs).
+3. No lint / format errors.
+4. Change works as expected.
+
+## Pre-PR checklist
+
+1. User has requested PR creation.
+2. No sensitive information.
+3. No conflict risk.
+4. Run `/deep-review` (local diff mode) — fix all score ≥ 50 findings.
+
+## Post-PR checklist
+
+Run `/pr-health-monitor <PR number>` to automate, or manually:
+
+1. Verify no merge conflicts.
+2. Update PR body with current state only (no history). Language follows project CLAUDE.md, otherwise Japanese.
+3. `gh pr checks <PR number> --watch` — confirm CI passes.
+4. Request Copilot review, wait (`/wait-for-copilot-review`).
+5. Address review comments (`/handle-pr-reviews`).
+
+---
+
+## GitHub Issues
+
+- Manage via `gh` CLI.
+
+## Jira (when explicitly requested)
+
+- Interact via MCP. Identify the space by project name; confirm with user if absent.
+- Ticket titles and descriptions: Japanese. Set `contentFormat: "markdown"`, use real newlines (not `\n`).
+- On implementation start: transition to "In Progress".
+- On PR ready to merge: comment on ticket with PR URL, transition to "Resolved".
+- Child tickets in Business (simplified) projects: use JQL `parent = <ISSUE_KEY>` — they are not in `subtasks`.
+- **Never reference Jira on GitHub Issues or pull requests.**

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -137,6 +137,21 @@ gh pr create --title "<title>" --body "<PR body>"
 
 PR body: follow the project CLAUDE.md language if specified; otherwise Japanese. Current state only, no update history.
 
+### Write Session State
+
+After PR creation, write the PR URL to the session state file so hooks can reference it
+without parsing the transcript:
+
+```bash
+mkdir -p -m 700 ~/.claude/data
+PR_URL=$(gh pr view --json url -q .url)
+SESSION_ID=$(jq -r '.session_id // ""' <<< "${CLAUDE_HOOK_INPUT:-{}}")
+jq -n --arg pr_url "$PR_URL" --arg session_id "$SESSION_ID" \
+    '{"session_id": $session_id, "pr_url": $pr_url}' \
+    > ~/.claude/data/session-state.json
+chmod 600 ~/.claude/data/session-state.json
+```
+
 ### After PR Creation
 
 Immediately run `/pr-health-monitor <PR number>` when done.

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -143,7 +143,7 @@ After PR creation, write the PR URL to the session state file so hooks can refer
 without parsing the transcript:
 
 ```bash
-mkdir -p -m 700 ~/.claude/data
+mkdir -p ~/.claude/data && chmod 700 ~/.claude/data
 PR_URL=$(gh pr view --json url -q .url)
 SESSION_ID=$(jq -r '.session_id // ""' <<< "${CLAUDE_HOOK_INPUT:-{}}")
 jq -n --arg pr_url "$PR_URL" --arg session_id "$SESSION_ID" \

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -145,9 +145,8 @@ without parsing the transcript:
 ```bash
 mkdir -p ~/.claude/data && chmod 700 ~/.claude/data
 PR_URL=$(gh pr view --json url -q .url)
-SESSION_ID=$(jq -r '.session_id // ""' <<< "${CLAUDE_HOOK_INPUT:-{}}")
-jq -n --arg pr_url "$PR_URL" --arg session_id "$SESSION_ID" \
-    '{"session_id": $session_id, "pr_url": $pr_url}' \
+jq -n --arg pr_url "$PR_URL" --argjson timestamp "$(date +%s)" \
+    '{"pr_url": $pr_url, "timestamp": $timestamp}' \
     > ~/.claude/data/session-state.json
 chmod 600 ~/.claude/data/session-state.json
 ```

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -282,9 +282,8 @@ without parsing the transcript:
 ```bash
 mkdir -p ~/.claude/data && chmod 700 ~/.claude/data
 PR_URL=$(gh pr view --json url -q .url)
-SESSION_ID=$(jq -r '.session_id // ""' <<< "${CLAUDE_HOOK_INPUT:-{}}")
-jq -n --arg pr_url "$PR_URL" --arg session_id "$SESSION_ID" \
-    '{"session_id": $session_id, "pr_url": $pr_url}' \
+jq -n --arg pr_url "$PR_URL" --argjson timestamp "$(date +%s)" \
+    '{"pr_url": $pr_url, "timestamp": $timestamp}' \
     > ~/.claude/data/session-state.json
 chmod 600 ~/.claude/data/session-state.json
 ```

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -280,7 +280,7 @@ After PR creation, write the PR URL to the session state file so hooks can refer
 without parsing the transcript:
 
 ```bash
-mkdir -p -m 700 ~/.claude/data
+mkdir -p ~/.claude/data && chmod 700 ~/.claude/data
 PR_URL=$(gh pr view --json url -q .url)
 SESSION_ID=$(jq -r '.session_id // ""' <<< "${CLAUDE_HOOK_INPUT:-{}}")
 jq -n --arg pr_url "$PR_URL" --arg session_id "$SESSION_ID" \

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -274,6 +274,21 @@ mcp__atlassian__addCommentToJiraIssue({
 Explicitly set `contentFormat: "markdown"`, and write line breaks as actual newline
 characters rather than the literal `\n` (see "Notes on Jira MCP Operations" for details).
 
+### Write Session State
+
+After PR creation, write the PR URL to the session state file so hooks can reference it
+without parsing the transcript:
+
+```bash
+mkdir -p -m 700 ~/.claude/data
+PR_URL=$(gh pr view --json url -q .url)
+SESSION_ID=$(jq -r '.session_id // ""' <<< "${CLAUDE_HOOK_INPUT:-{}}")
+jq -n --arg pr_url "$PR_URL" --arg session_id "$SESSION_ID" \
+    '{"session_id": $session_id, "pr_url": $pr_url}' \
+    > ~/.claude/data/session-state.json
+chmod 600 ~/.claude/data/session-state.json
+```
+
 ### After PR Creation
 
 Immediately run `/pr-health-monitor <PR number>` when done.


### PR DESCRIPTION
## 概要

モダンハーネスエンジニアリングのベストプラクティスに基づき、`dot_claude` 配下の設定・フック・ルールを見直した。

主な方針:「メカニズムで解く。リクエストに頼るな」— 自然言語の指示ではなく、コードレベルで制約を強制する。

## 変更内容

### CLAUDE.md 最小化（100行 → 50行）

- エージェントが読めば推測できる内容・冗長なチェックリストを削除
- ベストプラクティス推奨の「60行以下」に準拠
- 詳細は `rules/workflow.md` へ委譲

### rules/ 新規ファイル追加

| ファイル | 内容 |
|---|---|
| `rules/workflow.md` | ADR-001〜003 + 作業チェックリスト + Jira ルール |
| `rules/security.md` | 秘密情報・危険コマンド・AI 固有リスク（プロンプトインジェクション等）|

### rules/workflow-sub-agents.md 圧縮（277行 → 80行）

判断木・クイックリファレンス・アンチパターン表のみ残し、冗長な説明を削除。

### フック改善：トランスクリプトパース廃止

| 変更前 | 変更後 |
|---|---|
| transcript をテキスト grep でスコア抽出 | PostToolUse フックがステートファイルに構造化データを書き出し |
| transcript をテキスト grep で PR URL 抽出 | ステートファイル優先 → JSONL パース（フォールバック）|

**非決定論的だった問題点**:
- テキスト grep はフォーマット変更で無音に壊れる
- プロンプトインジェクション（"Score: 10" を本文に書けば迂回できた）
- 複数の PR URL が存在する場合に誤検知

### private_settings.json: onFailure 明示

- 通知系フック: （通知失敗は許容）
- enforcement Stop フック: （ゲートがクラッシュしても無音で素通りしない）

### skills: セッションステートファイル書き込み追加

issue-pr / ticket-pr スキルが PR 作成後に `~/.claude/data/session-state.json` へ PR URL を書き出す。Stop フックがトランスクリプトをパースせずこのファイルを参照できる。

## 動作確認

- deep-review（ローカル diff モード）を実行し、スコア ≥ 50 の指摘 3 件（enforcement フックの onFailure、ステートファイルのパーミッション、書き込み失敗ハンドリング）を修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)