### PR TITLE
fix: tmux セレクタのセッション表示バグを修正

### DIFF
--- a/home/dot_bash_profile.d/executable_10-tmux-selector.sh
+++ b/home/dot_bash_profile.d/executable_10-tmux-selector.sh
@@ -87,20 +87,24 @@ tmux_session_selector() {
   local detailed_options=""
   if [[ -n "$sessions" ]]; then
     local sname sattached swindows screated
-    local created_fmt attach_status pane_id cwd cmd display
+    local attach_status pane_id cwd cmd display
 
     while IFS='|' read -r sname sattached swindows screated; do
       [[ -n "$sname" ]] || continue
 
-      # created整形（GNU date / BSD date fallback）
-      if [[ -n "$screated" && "$screated" != "0" ]]; then
-        created_fmt="$(
-          date -d "@$screated" "+%Y/%m/%d %H:%M:%S" 2>/dev/null \
-          || date -r "$screated" "+%Y/%m/%d %H:%M:%S" 2>/dev/null \
-          || echo "$screated"
-        )"
+      # 経過時間を短縮形で算出（例: 5s, 3m, 2h, 1d）
+      # 行末ではなくコマンドの直後に配置することでモバイル幅でも見切れを防ぐ
+      local now_ts age_str
+      now_ts="$(date +%s 2>/dev/null || echo 0)"
+      if [[ -n "$screated" && "$screated" != "0" && "$now_ts" -gt 0 ]]; then
+        local diff=$(( now_ts - screated ))
+        if   (( diff < 60     )); then age_str="${diff}s"
+        elif (( diff < 3600   )); then age_str="$(( diff / 60 ))m"
+        elif (( diff < 86400  )); then age_str="$(( diff / 3600 ))h"
+        else                           age_str="$(( diff / 86400 ))d"
+        fi
       else
-        created_fmt="unknown"
+        age_str="?"
       fi
 
       [[ "${sattached:-0}" -gt 0 ]] && attach_status=" (attached)" || attach_status=""
@@ -122,7 +126,9 @@ tmux_session_selector() {
         fi
       fi
 
-      display="$sname: [$cmd] ($cwd) ${swindows}w (created $created_fmt)$attach_status"
+      # フォーマット: "NAME: [CMD|AGE] (PATH) Nw [(attached)]"
+      # AGE をコマンドの直後に入れることで、パスが長くても作成時期が見切れない
+      display="$sname: [$cmd|$age_str] ($cwd) ${swindows}w$attach_status"
       # タブ文字が含まれると TSV の区切りが崩れるため、スペースに置換する
       display="${display//$'\t'/ }"
       # KEY は session_name。tmux のターゲット指定は "${session_name}:" で厳密に扱う
@@ -174,6 +180,10 @@ tmux_session_selector() {
   '\'' _ {2} {3} {4}'
 
   # --- fzf ---
+  # --no-sort を付けない理由: --filter モードでは --no-sort + --with-nth の組み合わせで
+  # フィールドが剥ぎ取られる挙動が fzf 0.29 系で確認されているため、副作用を避けて外している。
+  # インタラクティブモードでは --no-sort の有無に関わらず選択結果は全フィールドを含む。
+  # クエリ未入力時は全アイテムのスコアが 0 で安定ソートされ入力順が保たれる。
   local selected
   if [[ "$terminal_width" -ge "$TMUX_MIN_WIDTH" ]]; then
     selected="$(
@@ -181,7 +191,6 @@ tmux_session_selector() {
         --height="$TMUX_FZF_HEIGHT" \
         --reverse \
         --border \
-        --no-sort \
         --delimiter=$'\t' \
         --with-nth=1 \
         --prompt='Select session/action: ' \
@@ -195,7 +204,6 @@ tmux_session_selector() {
         --height="$TMUX_FZF_HEIGHT" \
         --reverse \
         --border \
-        --no-sort \
         --delimiter=$'\t' \
         --with-nth=1 \
         --prompt='Select session/action: '

--- a/home/dot_bash_profile.d/executable_10-tmux-selector.sh
+++ b/home/dot_bash_profile.d/executable_10-tmux-selector.sh
@@ -119,7 +119,18 @@ tmux_session_selector() {
       cwd="?"
       if [[ -n "$pane_id" ]]; then
         cmd="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || echo "unknown")"
-        cwd="$(tmux display-message -p -t "$pane_id" '#{pane_current_path}' 2>/dev/null || echo "?")"
+
+        # TMUX_PROJECT_DIR が設定されていれば優先する。
+        # pane_current_path はサブプロセスの影響で一時的に別ディレクトリを指すことがあるため信頼性が低い。
+        # 設定方法: tmux new-session -e TMUX_PROJECT_DIR="$(pwd)"
+        #           または tmux set-environment -t <session> TMUX_PROJECT_DIR "$(pwd)"
+        local project_dir
+        project_dir="$(tmux show-environment -t "${sname}" TMUX_PROJECT_DIR 2>/dev/null)"
+        if [[ "$project_dir" == TMUX_PROJECT_DIR=* ]]; then
+          cwd="${project_dir#TMUX_PROJECT_DIR=}"
+        else
+          cwd="$(tmux display-message -p -t "$pane_id" '#{pane_current_path}' 2>/dev/null || echo "?")"
+        fi
         [[ -n "${HOME:-}" ]] && cwd="${cwd/#$HOME/\~}"
         if [[ "${#cwd}" -gt "$TMUX_PATH_MAX" ]]; then
           cwd="…${cwd: -$TMUX_PATH_MAX}"
@@ -220,7 +231,9 @@ tmux_session_selector() {
   case "$sel_type" in
     NEW)
       sleep "$TMUX_SESSION_DELAY"
-      tmux new-session
+      # TMUX_PROJECT_DIR を現在のディレクトリで設定してセッションを作成する。
+      # 以降はセレクタが pane_current_path の代わりにこの値を使うため表示が安定する。
+      tmux new-session -e "TMUX_PROJECT_DIR=$(pwd)"
       ;;
     SESSION)
       # 重要: 数字名でも曖昧にならないよう session_name: で attach


### PR DESCRIPTION
## 概要

tmux セッションセレクタ（SSH ログイン時に起動する fzf UI）において、複数のセッションが同一の表示になるバグを修正する。

## 問題 1: 表示の見分けがつかない

コマンド・パス・ウィンドウ数が同じ複数セッションで、行末の作成日時が幅の狭いターミナルで見切れ、区別が付かなくなっていた。

**修正**: 作成日時をコマンド直後の相対時間（例: `2h`、`5m`）に変更。パスより前に配置されるため、幅が狭くても見切れない。

旧フォーマット:
```
1: [claude] (/mnt/hdd/repos/github.com/akubiusa/dotfiles) 1w (created 2026/06/29 18:36:31)
9: [claude] (/mnt/hdd/repos/github.com/akubiusa/dotfiles) 1w (created 2026/06/29 20:04:12)
```

新フォーマット:
```
1: [claude|2h] (/mnt/hdd/repos/github.com/akubiusa/dotfiles) 1w
9: [claude|5m] (/mnt/hdd/repos/github.com/akubiusa/dotfiles) 1w
```

あわせて `--no-sort` を除去（fzf 0.29 の `--filter` モードで `--with-nth` と組み合わせるとフィールドが剥ぎ取られる挙動が確認されたため副作用回避）。

## 問題 2: `pane_current_path` が不安定

`pane_current_path` はサブプロセスが別ディレクトリで実行された際に一時的にそのディレクトリを指すため、セレクタに誤ったパスが表示されることがあった。

例: session 1（github-webhook-bridge）が過去のツール呼び出しで dotfiles のパスを触っていたため `pane_current_path = dotfiles` になり、session 9（dotfiles）と同じ表示になった。

**修正**: セッション環境変数 `TMUX_PROJECT_DIR` を導入。設定されている場合は `pane_current_path` より優先して使用する。

- セレクタで「Create New Session」を選んだ場合、現在のディレクトリを自動設定
- 既存セッションへの手動設定: `tmux set-environment -t <session> TMUX_PROJECT_DIR "$(pwd)"`
- 未設定のセッションは従来通り `pane_current_path` にフォールバック