### PR TITLE
feat: spec/plan のエージェントレビューと AskUserQuestion 強制を追加

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -7,6 +7,7 @@
 ## Behavior
 
 - No flattery. Push back when warranted. Be concise.
+- Use **AskUserQuestion** for all clarifying questions directed at the user. Do not ask questions as plain text.
 
 ## Language
 
@@ -49,3 +50,4 @@ Use the Todo tool for all multi-step work without omission.
 
 @CLAUDE.local.md
 @RTK.md
+@rules/superpowers.md

--- a/home/dot_claude/rules/superpowers.md
+++ b/home/dot_claude/rules/superpowers.md
@@ -11,20 +11,37 @@ you MUST dispatch a sub-agent to review the document and apply fixes.
 1. Dispatch a sub-agent with the following instruction (substituting the
    actual file path):
 
-   > Read `<file path>`. Review it for: placeholder text (TBD/TODO),
-   > internal contradictions, ambiguous requirements that could be
-   > interpreted two ways, missing coverage relative to the stated goal,
-   > and — for plan files only — steps that describe what to do without
-   > showing how (missing code blocks). Fix all issues you find in place.
-   > Report a one-line summary of each fix made, or "No issues found."
+   > Read `<file path>`. Review it for:
+   > - Placeholder text (TBD/TODO)
+   > - Internal contradictions
+   > - Missing coverage relative to the stated goal
+   > - For plan files only: steps that describe what to do without showing
+   >   how (missing code blocks)
+   >
+   > Fix the above issues in place and report a one-line summary of each
+   > fix made.
+   >
+   > For ambiguous requirements (those that could be interpreted two or
+   > more ways): do NOT silently pick an interpretation. Instead, report
+   > each ambiguity as a question with the options, so the main agent can
+   > ask the user to choose. Do not edit the document for these items.
+   >
+   > If nothing needs attention, report "No issues found."
 
 2. Wait for the sub-agent to complete.
 3. If the sub-agent reports fixes, read the updated file and confirm the
-   changes look correct before proceeding.
-4. Only after the review is complete, present the file to the user for
+   changes look correct.
+4. If the sub-agent reports ambiguities, resolve them with the user via
+   AskUserQuestion before proceeding.
+5. Only after all issues are resolved, present the file to the user for
    review.
 
 ### Clarifying questions
 
-All clarifying questions directed at the user MUST be asked via the
-AskUserQuestion tool. Do not ask questions as plain text.
+**Main agent:** All clarifying questions directed at the user MUST be asked
+via the AskUserQuestion tool. Do not ask questions as plain text.
+
+**Sub-agents:** Sub-agents cannot use AskUserQuestion. If a sub-agent needs
+to ask the user something, it must report the question (with options where
+applicable) back to the main agent in its output. The main agent then uses
+AskUserQuestion to relay it to the user.

--- a/home/dot_claude/rules/superpowers.md
+++ b/home/dot_claude/rules/superpowers.md
@@ -1,0 +1,30 @@
+# Superpowers Workflow Rules
+
+## Spec and Plan Agent Review
+
+After writing a spec file (`docs/superpowers/specs/*.md`) or a plan file
+(`docs/superpowers/plans/*.md`), **before asking the user to review it**,
+you MUST dispatch a sub-agent to review the document and apply fixes.
+
+### Review procedure
+
+1. Dispatch a sub-agent with the following instruction (substituting the
+   actual file path):
+
+   > Read `<file path>`. Review it for: placeholder text (TBD/TODO),
+   > internal contradictions, ambiguous requirements that could be
+   > interpreted two ways, missing coverage relative to the stated goal,
+   > and — for plan files only — steps that describe what to do without
+   > showing how (missing code blocks). Fix all issues you find in place.
+   > Report a one-line summary of each fix made, or "No issues found."
+
+2. Wait for the sub-agent to complete.
+3. If the sub-agent reports fixes, read the updated file and confirm the
+   changes look correct before proceeding.
+4. Only after the review is complete, present the file to the user for
+   review.
+
+### Clarifying questions
+
+All clarifying questions directed at the user MUST be asked via the
+AskUserQuestion tool. Do not ask questions as plain text.

--- a/home/dot_config/git/ignore
+++ b/home/dot_config/git/ignore
@@ -22,3 +22,4 @@ __pycache__/
 
 **/.claude/settings.local.json
 docs/superpowers/
+.superpowers/

--- a/home/dot_config/git/ignore
+++ b/home/dot_config/git/ignore
@@ -21,3 +21,4 @@ __pycache__/
 *.pyc
 
 **/.claude/settings.local.json
+docs/superpowers/


### PR DESCRIPTION
## 概要

superpowers のワークフローを dotfiles 側から拡張し、spec・plan ファイル作成後にエージェントレビューを自律的に実施する。

## 変更内容

- `home/dot_config/git/ignore`: `docs/superpowers/` と `.superpowers/` をグローバル gitignore に追加（全リポジトリで除外）
- `home/dot_claude/rules/superpowers.md`（新規）: spec/plan ファイル作成後のサブエージェントレビュー手順と AskUserQuestion 強制ルールを定義
- `home/dot_claude/CLAUDE.md`: AskUserQuestion 強制バレットを Behavior セクションに追加、`@rules/superpowers.md` を参照に追加

## ワークフロー変更

**変更前:** spec/plan 作成 → ユーザーに確認

**変更後:** spec/plan 作成 → サブエージェントでレビュー → 修正 → ユーザーに確認

Closes #155