### PR TITLE
docs: GitHub Actions のコーディングルールを実態調査とベストプラクティスに基づき更新

### DIFF
--- a/home/dot_claude/rules/coding-github-actions.md
+++ b/home/dot_claude/rules/coding-github-actions.md
@@ -18,18 +18,21 @@ paths:
 
 ## Action Version References
 
+- Applies to step-level Action references (`steps[].uses`) — not the
+  reusable-workflow calls in the previous section, which intentionally stay
+  on `@master`.
 - Pin every Action (including first-party `actions/*`) to a full-length commit SHA
   with a version comment, per [GitHub's secure-use guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions).
   Renovate (`book000/templates//renovate/base`, preset
   `helpers:pinGitHubActionDigestsToSemver`) manages these — don't hand-edit SHAs.
 
   ```yaml
-  # good
-  uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v6.0.1
+  # good (SHA and version comment refer to the same release)
+  - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
   # bad
-  uses: actions/checkout@v6
-  uses: actions/checkout@main
+  - uses: actions/checkout@v6
+  - uses: actions/checkout@main
   ```
 
 ## Node.js Version

--- a/home/dot_claude/rules/coding-github-actions.md
+++ b/home/dot_claude/rules/coding-github-actions.md
@@ -18,15 +18,17 @@ paths:
 
 ## Action Version References
 
-- Reference Actions by major version tag
+- Pin every Action (including first-party `actions/*`) to a full-length commit SHA
+  with a version comment, per [GitHub's secure-use guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions).
+  Renovate (`book000/templates//renovate/base`, preset
+  `helpers:pinGitHubActionDigestsToSemver`) manages these — don't hand-edit SHAs.
 
   ```yaml
   # good
-  uses: actions/checkout@v6
-  uses: actions/setup-node@v6
-  uses: actions/cache@v5
+  uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v6.0.1
 
-  # bad (no pinned version)
+  # bad
+  uses: actions/checkout@v6
   uses: actions/checkout@main
   ```
 
@@ -35,19 +37,105 @@ paths:
 - Use `node-version-file: .node-version` for Node setup (do not hard-code the version)
 
   ```yaml
-  - uses: actions/setup-node@v6
+  - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
     with:
       node-version-file: .node-version
   ```
 
 ## Step Names
 
-- Prefix step names with an emoji matching the step's content
+- Default to plain step names: sentence case, English, imperative-verb phrasing,
+  no trailing punctuation. Do not add an emoji prefix by default.
+- If a file already uses emoji-prefixed steps (e.g. following
+  `book000/templates`), keep the whole file consistent — don't mix emoji and
+  plain steps — and reuse this mapping instead of inventing new emoji:
+
+  | Emoji | Purpose |
+  |---|---|
+  | 🛎 / 📥 | Checkout |
+  | 🏗 / 🏗️ | Setup runtime / build |
+  | 👨🏻‍💻 | Install dependencies |
+  | 📂 | Cache / path lookup |
+  | 👀 | Lint / status check |
+  | 🧪 | Test |
+  | 📦 | Package / artifact / release |
+  | 🚀 | Deploy |
+  | 🔄 | Update status |
+  | 🏷️ | Version bump / tag |
+  | 🔑 | Login / auth |
 
   ```yaml
+  # good (plain, the default)
+  - name: Checkout
+  - name: Install dependencies
+
+  # good (emoji, only matching an existing file convention)
   - name: 🛎 Checkout
-  - name: 🏗 Setup node
   - name: 📦 Install dependencies
-  - name: 🔍 Lint
-  - name: 🧪 Test
+
+  # bad (mixed styles in one file)
+  - name: 🛎 Checkout
+  - name: Install dependencies
   ```
+
+## Permissions
+
+- Set `permissions` explicitly (workflow- and/or job-level); do not rely on
+  the repository default. Grant only the scopes a job needs.
+
+  ```yaml
+  permissions: {}       # no token access needed
+
+  permissions:
+    contents: read       # e.g. checkout-only jobs
+
+  jobs:
+    release:
+      permissions:
+        contents: write  # scoped up only for the job that needs it
+  ```
+
+## Concurrency
+
+- Use this group shape to cancel superseded runs:
+
+  ```yaml
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+  ```
+
+- Include `github.event_name` whenever a workflow can be triggered by both
+  `pull_request` and `pull_request_target` — otherwise they share a group and
+  cancel each other.
+- For deploys that must not be cancelled mid-way (e.g. GitHub Pages), use a
+  stable group with `cancel-in-progress: false`:
+
+  ```yaml
+  concurrency:
+    group: pages
+    cancel-in-progress: false
+  ```
+
+## Untrusted Input in `run:` Steps
+
+- Never interpolate `${{ ... }}` from untrusted context (issue/PR
+  titles/bodies, branch names, commit messages) directly into `run:`. Pass it
+  through `env:` instead.
+
+  ```yaml
+  # bad
+  - run: echo "Title is ${{ github.event.issue.title }}"
+
+  # good
+  - env:
+      TITLE: ${{ github.event.issue.title }}
+    run: echo "Title is $TITLE"
+  ```
+
+## `pull_request_target`
+
+- Avoid it unless a job genuinely needs a privileged token/secrets while
+  reacting to a fork PR. Prefer `pull_request`, or split privileged
+  post-processing into a separate `workflow_run` workflow that only reads
+  artifacts rather than checking out untrusted code with elevated permissions.


### PR DESCRIPTION
## 概要

`home/dot_claude/rules/coding-github-actions.md`(Claude Code 用の GitHub Actions コーディングルール)を、`book000` / `jaoafa` / `tomacheese` 3オーガニゼーションの実態調査と GitHub 公式のセキュリティベストプラクティスに基づいて更新しました。

## 調査内容

非フォーク・非アーカイブの144リポジトリ(book000: 66, jaoafa: 24, tomacheese: 54)、約290ワークフローファイル、約1,170個の named step を `gh api` で横断的に取得・集計しました。

## 変更点

### Step Names(既存ルールの実態への修正)
- 既存ルールは「絵文字プレフィックスを常に付与」だったが、実態は逆(絵文字なしが book000 71%・jaoafa 89%・tomacheese 77%)だったため、「デフォルトは絵文字なし、既存ファイルの慣習に一致する場合のみ絵文字使用」に修正。
- `book000/templates` の再利用可能ワークフロー(呼び出し数最多)で使われている絵文字→意味の対応表を追加。

### Action Version References(公式ベストプラクティスへ更新)
- 「メジャーバージョンタグ固定」から「フルコミット SHA 固定」に変更(GitHub 公式の secure-use guidance に準拠)。
- 対応する Renovate 設定変更は別PR: book000/templates#406

### Permissions / Concurrency(実態調査に基づく新規追加)
- permissions: 実態(`contents: read` や `{}` が最頻出)に基づく least-privilege の指針。
- concurrency: 設定済みファイルの約70%が使っている `group` の形(`github.event_name` を含める理由も明記)。

### Untrusted Input / pull_request_target(公式セキュリティガイドに基づく新規追加)
- `run:` へのコンテキスト直接埋め込みによるスクリプトインジェクション対策。
- `pull_request_target` の危険性と回避策。

## レビュー

`/deep-review`(ローカル diff モード)を実施し、指摘2件(Renovate プリセット名の namespace 欠落、Node.js Version セクションの旧ルールとの不整合)を修正済みです。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T42vamwfnFphu9hL3J55ME