### PR TITLE
fix: deep-review で冗長・陳腐化しうるコメントを指摘できるようにする

### DIFF
--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -69,7 +69,10 @@ Do NOT report the following:
 
 - **Agent d (past PR comments) [PR mode only]**: Find recently merged PRs that touched the same files (`gh pr list --state merged`). Check their review comments for concerns that may also apply here.
 
-- **Agent e (code-comment consistency)**: Read code comments and docstrings in changed files. Flag cases where the implementation contradicts what a comment describes.
+- **Agent e (code-comment quality)**: Read code comments and docstrings in changed files. Flag:
+  - Cases where the implementation contradicts what a comment describes.
+  - Redundant comments that merely restate what the code already makes obvious (e.g. a comment saying "increment i by 1" directly above `i++`).
+  - Comments prone to becoming stale — descriptions of specific values, counts, enumerated lists, or implementation details duplicated from the code, which are likely to drift out of sync when the code changes.
 
 - **Agent f (security)**: Check for:
   - Missing input validation / sanitisation (XSS, SQL injection, etc.)

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -55,7 +55,7 @@ Do NOT report the following:
 - Pre-existing issues on lines not touched by this PR
 - Issues that linters, type checkers, or CI already catch (formatting, import errors, type errors, etc.)
 - Intentionally suppressed issues (lint-ignore comments, etc.)
-- General code quality concerns (test coverage, documentation) unless explicitly required in CLAUDE.md
+- General code quality concerns (test coverage, documentation) unless explicitly required in CLAUDE.md or explicitly listed as a specific agent's scope below (e.g. Agent e's redundant/stale-comment checks)
 - Functional changes that are clearly intentional given the broader context
 - Anything asserted without a concrete `file:line` citation
 
@@ -69,10 +69,12 @@ Do NOT report the following:
 
 - **Agent d (past PR comments) [PR mode only]**: Find recently merged PRs that touched the same files (`gh pr list --state merged`). Check their review comments for concerns that may also apply here.
 
-- **Agent e (code-comment quality)**: Read code comments and docstrings in changed files. Flag:
+- **Agent e (code-comment quality)**: Read code comments and docstrings in changed files. These checks are explicitly in scope for this agent, so the shared "general code quality concerns" suppression above does not apply to them. Flag:
   - Cases where the implementation contradicts what a comment describes.
   - Redundant comments that merely restate what the code already makes obvious (e.g. a comment saying "increment i by 1" directly above `i++`).
   - Comments prone to becoming stale — descriptions of specific values, counts, enumerated lists, or implementation details duplicated from the code, which are likely to drift out of sync when the code changes.
+
+  If the same redundant/stale-prone pattern repeats many times in the diff, report it once with one or two representative `file:line` examples rather than listing every occurrence.
 
 - **Agent f (security)**: Check for:
   - Missing input validation / sanitisation (XSS, SQL injection, etc.)
@@ -112,6 +114,8 @@ Score the issue on a scale of 0-100 based on your level of confidence that it is
 - **100**: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 
 For issues sourced from CLAUDE.md, double-check that the CLAUDE.md actually mentions that specific issue before scoring high.
+
+Findings from an agent's explicitly listed scope (e.g. Agent e's redundant/stale-comment checks) are not "unscoped stylistic nitpicks" for the purpose of the 25-point band above — score them on the same real-world-impact basis as any other finding (how likely the comment is to mislead a future reader or drift from the code it describes).
 
 Each agent must return the score in the format: `Score: <0-100>`
 (The Stop hook extracts scores using this exact format.)


### PR DESCRIPTION
## 概要

deep-review スキルの Agent e (code-comment quality) に、冗長なコメントと陳腐化しやすいコメントを検出する観点を追加しました。

## 変更内容

- Agent e のスコープを拡張し、以下も指摘対象に追加:
  - 冗長なコメント（コードを見れば自明な内容を繰り返すだけのコメント）
  - 陳腐化しやすいコメント（具体的な値・件数・列挙・実装詳細をコード側と重複して記述しており、コード変更時にコメント側だけ古くなりやすいもの）
- 追加したスコープが、全エージェント共通の false-positive 抑制ルール（一般的なドキュメント品質懸念は CLAUDE.md に明記がなければ報告しない）と矛盾し、実質的に無効化されてしまう問題を deep-review 実行時に発見したため、以下も併せて修正:
  - 共通抑制ルールに「各エージェントのスコープとして明記されている場合は除く」という例外を追加
  - スコアリング指針に、Agent e のこれら指摘は「CLAUDE.md 未記載の一般的なスタイル指摘」として自動的に低スコア（25点帯）に丸められないことを明記
  - 同一パターンが多数出現する場合に代表例へ絞って報告する指示を追加し、Step 5 のスコアリングサブエージェントが無制限に増殖しないようにした

## 判断記録

1. **判断内容の要約**: deep-review の Agent e スコープを拡張し、冗長コメント・陳腐化しうるコメントを検出対象に追加。実装時に見つかった既存ルールとの矛盾も合わせて解消。
2. **検討した代替案**: 新しい専用エージェント（Agent j 等）を追加する案も検討。
3. **不採用の理由**: 既存の Agent e（コメント整合性チェック）とスコープが近く、責務を分割するより統合した方がレビュー対象ファイルの二重読み込みを避けられるため、既存エージェントの拡張を採用。
4. **前提・仮定・不確実性**: 「冗長」「陳腐化しうる」の判定基準はプロンプト上の自然文記述に依存し、LLM の解釈幅が残る。実運用でのノイズ量は実際にレビューを回してみないと確定できない。
5. **他エージェントによるレビュー可否**: `/deep-review`（ローカル diff モード）を実行済み。8並列サブエージェントのうち3エージェント（bugs, code-comment consistency, performance）が同一の実質的問題（追加スコープと共通抑制ルールの矛盾）を指摘し、上記の追加修正で対応済み。

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)