### PR TITLE
docs: coding-csharp ルールの作成

### DIFF
--- a/home/dot_claude/rules/coding-csharp.md
+++ b/home/dot_claude/rules/coding-csharp.md
@@ -6,10 +6,6 @@ paths:
 
 # C# Coding Rules
 
-Based on a cross-repository survey of book000 / tomacheese organization C# projects
-(github-webhook-bridge, watch-wishlist-sale, IdlingLightManager, ElitesRNGAuraObserver,
-VRCXDiscordTracker, ZoomInClass).
-
 ## Project Setup
 
 - Use SDK-style `.csproj` (`<Project Sdk="Microsoft.NET.Sdk">`). Legacy-style project

--- a/home/dot_claude/rules/coding-csharp.md
+++ b/home/dot_claude/rules/coding-csharp.md
@@ -22,14 +22,13 @@ paths:
     warning-severity diagnostics below, or `TreatWarningsAsErrors`, to actually
     gate the build)
 - Target the latest LTS/STS `net<major>.0` (Windows GUI apps add the Windows TFM,
-  e.g. `net10.0-windows` or `net9.0-windows10.0.17763.0`)
+  `net<major>.0-windows`, optionally suffixed with a target Windows SDK version)
 - Windows GUI apps (WinForms, etc.): `<OutputType>WinExe</OutputType>`,
   `<PublishSingleFile>true</PublishSingleFile>`, `<DebugType>embedded</DebugType>`.
-  `PublishSingleFile` requires a `RuntimeIdentifier` (e.g. `win-x64`) on any
-  project that publishes it — set directly in the `.csproj` or via a publish
-  profile (`.pubxml`). A companion self-contained updater project additionally
-  sets `<RuntimeIdentifier>win-x64</RuntimeIdentifier>` and
-  `<SelfContained>true</SelfContained>`
+  `PublishSingleFile` requires a `RuntimeIdentifier` on any project that publishes
+  it — set directly in the `.csproj` or via a publish profile (`.pubxml`). A
+  companion self-contained updater project additionally sets `<RuntimeIdentifier>`
+  and `<SelfContained>true</SelfContained>`
 
 ## StyleCop
 
@@ -56,24 +55,22 @@ paths:
 
 - Every repo has its own root `.editorconfig` (`root = true`) — do not rely on a
   shared/central template. When creating a new C# repo, copy the fullest existing
-  one (e.g. from `github-webhook-bridge` or `IdlingLightManager`) as the starting point
+  repo's `.editorconfig` as the starting point
 - Baseline formatting: `indent_style = space`, `indent_size = 4` for `*.cs`
   (`indent_size = 2` for `*.xml`, `*.json`, `*.yaml`, `*.yml`, `*.resx`, `*.pubxml`),
   `end_of_line = crlf`, `charset = utf-8`, `insert_final_newline = true`,
   `trim_trailing_whitespace = true`
 - Set almost all Roslyn `IDE*` / `CA*` / `SA*` diagnostics to `warning` severity by
-  default. Only relax a rule with an inline comment explaining why (e.g.
-  `dotnet_diagnostic.CA1848.severity = none # LoggerMessage デリゲートを使用しなくてもよい`) —
-  never disable a rule silently
+  default. Only relax a rule with an inline comment explaining why — never disable
+  a rule silently
 - It is acceptable to relax documentation-comment rules (`CS1591`, `SA1600`,
   `SA1602`, `SA1611`, `SA1615`, `SA1618`) during incremental adoption, but mark the
   override with a "段階的に対応" (phased rollout) comment so it reads as temporary
 - Add a `[tests/**.cs]` (or equivalent glob) section that relaxes test-only
-  conventions instead of loosening them globally, e.g.:
-  - `dotnet_diagnostic.CA1707.severity = none` — allow underscores in xUnit
-    `Method_Scenario_Expected` test names
-  - `dotnet_diagnostic.IDE1006.severity = none` — `[Fact]`/`[Theory]` methods don't
-    need an `Async` suffix
+  conventions instead of loosening them globally: allow underscores in xUnit
+  `Method_Scenario_Expected` test names (`dotnet_diagnostic.CA1707.severity = none`)
+  and drop the `Async`-suffix expectation for `[Fact]`/`[Theory]` methods
+  (`dotnet_diagnostic.IDE1006.severity = none`)
 
 ## Code Style
 
@@ -95,7 +92,7 @@ paths:
   (`Host.CreateDefaultBuilder()`), DI via `ConfigureServices`, options bound with
   `services.AddOptions<T>().Bind(...).ValidateOnStart()`
 - Logging: Serilog (`UseSerilog`), enrich from log context, override noisy
-  framework categories (e.g. `MinimumLevel.Override("Microsoft", LogEventLevel.Warning)`)
+  framework log categories to a higher minimum level
 - Azure Functions projects: `Microsoft.Azure.Functions.Worker` (isolated worker
   model), OpenTelemetry + Azure Monitor exporter for observability
 
@@ -107,18 +104,17 @@ paths:
 - Use `[InternalsVisibleTo("<ProjectName>.Tests")]` in the main project (via
   `AssemblyAttribute` in the `.csproj` or `AssemblyInfo`) instead of making members
   `public` just for testability
-- Test method names: PascalCase describing behaviour (e.g.
-  `RunAsyncCreatedTitleContainsStarred`) or the underscore-separated
+- Test method names: PascalCase describing behaviour, or the underscore-separated
   `Method_Scenario_Expected` xUnit convention — both are acceptable within one
   project as long as the `.editorconfig` test-only override permits underscores
-- CI enforces a minimum line-coverage threshold (project-specific, e.g. 80%) —
-  check for an existing threshold before lowering it
+- CI enforces a minimum line-coverage threshold (project-specific) — check for an
+  existing threshold before lowering it
 
 ## CI (GitHub Actions)
 
 - Runner: `windows-latest` (required for WinForms / Windows-only TFMs)
 - Setup with `actions/setup-dotnet`, pinning `dotnet-version` to the SDK's
-  major version with a floating patch (e.g. `"10.0.x"`)
+  major version with a floating patch (`"<major>.0.x"`)
 - Steps: `dotnet restore` → `dotnet build --no-restore -c Release` →
   `dotnet test --no-build -c Release`
 - Style/format check: `dotnet format <sln> --verify-no-changes --severity warn`

--- a/home/dot_claude/rules/coding-csharp.md
+++ b/home/dot_claude/rules/coding-csharp.md
@@ -2,6 +2,10 @@
 paths:
   - "**/*.cs"
   - "**/*.csproj"
+  - "**/*.sln"
+  - "**/*.pubxml"
+  - "**/Directory.Build.props"
+  - "**/stylecop.json"
 ---
 
 # C# Coding Rules
@@ -65,7 +69,8 @@ paths:
   a rule silently
 - It is acceptable to relax documentation-comment rules (`CS1591`, `SA1600`,
   `SA1602`, `SA1611`, `SA1615`, `SA1618`) during incremental adoption, but mark the
-  override with a "段階的に対応" (phased rollout) comment so it reads as temporary
+  override with a `# 段階的に対応` (phased-rollout) comment so it reads as temporary,
+  not permanent
 - Add a `[tests/**.cs]` (or equivalent glob) section that relaxes test-only
   conventions instead of loosening them globally: allow underscores in xUnit
   `Method_Scenario_Expected` test names (`dotnet_diagnostic.CA1707.severity = none`)

--- a/home/dot_claude/rules/coding-csharp.md
+++ b/home/dot_claude/rules/coding-csharp.md
@@ -1,0 +1,119 @@
+---
+paths:
+  - "**/*.cs"
+  - "**/*.csproj"
+  - "**/.editorconfig"
+---
+
+# C# Coding Rules
+
+Based on a cross-repository survey of book000 / tomacheese organization C# projects
+(github-webhook-bridge, watch-wishlist-sale, IdlingLightManager, ElitesRNGAuraObserver,
+VRCXDiscordTracker, ZoomInClass).
+
+## Project Setup
+
+- Use SDK-style `.csproj` (`<Project Sdk="Microsoft.NET.Sdk">`). Legacy-style project
+  files (`ToolsVersion`, `packages.config`) are only acceptable in old, unmaintained
+  projects — never introduce them in new code
+- Set in every project (or hoist to a shared `Directory.Build.props` when a repo has
+  multiple projects):
+  - `<ImplicitUsings>enable</ImplicitUsings>`
+  - `<Nullable>enable</Nullable>`
+  - `<GenerateDocumentationFile>true</GenerateDocumentationFile>`
+  - `<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>` (fails the build on
+    `.editorconfig` IDE-diagnostic violations, not just formatting)
+- Target the latest LTS/STS `net<major>.0` (Windows GUI apps add the Windows TFM,
+  e.g. `net10.0-windows` or `net9.0-windows10.0.17763.0`)
+- Windows GUI apps (WinForms, etc.): `<OutputType>WinExe</OutputType>`,
+  `<PublishSingleFile>true</PublishSingleFile>`, `<DebugType>embedded</DebugType>`.
+  A companion self-contained updater project additionally sets
+  `<RuntimeIdentifier>win-x64</RuntimeIdentifier>` and `<SelfContained>true</SelfContained>`
+
+## StyleCop
+
+- Add `StyleCop.Analyzers` as a build-time-only analyzer:
+
+  ```xml
+  <PackageReference Include="StyleCop.Analyzers" Version="x.y.z">
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PrivateAssets>all</PrivateAssets>
+  </PackageReference>
+  ```
+
+- Provide a `stylecop.json` next to the `.csproj` and reference it with
+  `<AdditionalFiles Include="stylecop.json" />`
+- Set `"documentationCulture": "ja-JP"` and `"xmlHeader": false` unless the project's
+  CLAUDE.md specifies a different documentation language
+
+## `.editorconfig`
+
+- Every repo has its own root `.editorconfig` (`root = true`) — do not rely on a
+  shared/central template. When creating a new C# repo, copy the fullest existing
+  one (e.g. from `github-webhook-bridge` or `IdlingLightManager`) as the starting point
+- Baseline formatting: `indent_style = space`, `indent_size = 4` for `*.cs`
+  (`indent_size = 2` for `*.xml`, `*.json`, `*.yaml`, `*.yml`, `*.resx`, `*.pubxml`),
+  `end_of_line = crlf`, `charset = utf-8`, `insert_final_newline = true`,
+  `trim_trailing_whitespace = true`
+- Set almost all Roslyn `IDE*` / `CA*` / `SA*` diagnostics to `warning` severity by
+  default. Only relax a rule with an inline comment explaining why (e.g.
+  `dotnet_diagnostic.CA1848.severity = none # LoggerMessage デリゲートを使用しなくてもよい`) —
+  never disable a rule silently
+- It is acceptable to relax documentation-comment rules (`CS1591`, `SA1600`,
+  `SA1602`, `SA1611`, `SA1615`, `SA1618`) during incremental adoption, but mark the
+  override with a "段階的に対応" (phased rollout) comment so it reads as temporary
+- Add a `[tests/**.cs]` (or equivalent glob) section that relaxes test-only
+  conventions instead of loosening them globally, e.g.:
+  - `dotnet_diagnostic.CA1707.severity = none` — allow underscores in xUnit
+    `Method_Scenario_Expected` test names
+  - `dotnet_diagnostic.IDE1006.severity = none` — `[Fact]`/`[Theory]` methods don't
+    need an `Async` suffix
+
+## Code Style
+
+- File-scoped namespaces (`namespace Foo.Bar;`), not block-scoped
+  (`namespace Foo.Bar { ... }`)
+- `using` directives outside the namespace, `System.*` usings first, no blank line
+  between using groups
+- Prefer expression-bodied members (`=>`) when the body fits on one line; prefer
+  pattern matching, switch expressions, and target-typed `new()`
+- XML doc comments on public/exposed members, written in Japanese unless the
+  project's own CLAUDE.md says otherwise
+- Suppress a specific, justified diagnostic with
+  `[SuppressMessage("Category", "RuleId:Name", Justification = "...")]` rather than a
+  blanket `#pragma warning disable`
+
+## Application Structure
+
+- Console/service apps: `Microsoft.Extensions.Hosting` Generic Host
+  (`Host.CreateDefaultBuilder()`), DI via `ConfigureServices`, options bound with
+  `services.AddOptions<T>().Bind(...).ValidateOnStart()`
+- Logging: Serilog (`UseSerilog`), enrich from log context, override noisy
+  framework categories (e.g. `MinimumLevel.Override("Microsoft", LogEventLevel.Warning)`)
+- Azure Functions projects: `Microsoft.Azure.Functions.Worker` (isolated worker
+  model), OpenTelemetry + Azure Monitor exporter for observability
+
+## Testing
+
+- Framework: **xUnit** + **Moq** + **coverlet.collector**
+- Test project name: `<ProjectName>.Tests`, referencing the main project via
+  `<ProjectReference>`
+- Use `[InternalsVisibleTo("<ProjectName>.Tests")]` in the main project (via
+  `AssemblyAttribute` in the `.csproj` or `AssemblyInfo`) instead of making members
+  `public` just for testability
+- Test method names: PascalCase describing behaviour (e.g.
+  `RunAsyncCreatedTitleContainsStarred`) or the underscore-separated
+  `Method_Scenario_Expected` xUnit convention — both are acceptable within one
+  project as long as the `.editorconfig` test-only override permits underscores
+- CI enforces a minimum line-coverage threshold (project-specific, e.g. 80%) —
+  check for an existing threshold before lowering it
+
+## CI (GitHub Actions)
+
+- Runner: `windows-latest` (required for WinForms / Windows-only TFMs)
+- Setup with `actions/setup-dotnet`, pinning `dotnet-version` to the SDK's
+  major version with a floating patch (e.g. `"10.0.x"`)
+- Steps: `dotnet restore` → `dotnet build --no-restore -c Release` →
+  `dotnet test --no-build -c Release`
+- Style/format check: `dotnet format <sln> --verify-no-changes --severity warn`
+  in CI — this must pass before merge, same as StyleCop warnings at build time

--- a/home/dot_claude/rules/coding-csharp.md
+++ b/home/dot_claude/rules/coding-csharp.md
@@ -2,7 +2,6 @@
 paths:
   - "**/*.cs"
   - "**/*.csproj"
-  - "**/.editorconfig"
 ---
 
 # C# Coding Rules
@@ -21,14 +20,20 @@ VRCXDiscordTracker, ZoomInClass).
   - `<ImplicitUsings>enable</ImplicitUsings>`
   - `<Nullable>enable</Nullable>`
   - `<GenerateDocumentationFile>true</GenerateDocumentationFile>`
-  - `<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>` (fails the build on
-    `.editorconfig` IDE-diagnostic violations, not just formatting)
+  - `<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>` (runs `.editorconfig`
+    IDE code-style analyzers at build time and surfaces them as build
+    warnings/errors at whatever severity `.editorconfig` assigns — combine with
+    warning-severity diagnostics below, or `TreatWarningsAsErrors`, to actually
+    gate the build)
 - Target the latest LTS/STS `net<major>.0` (Windows GUI apps add the Windows TFM,
   e.g. `net10.0-windows` or `net9.0-windows10.0.17763.0`)
 - Windows GUI apps (WinForms, etc.): `<OutputType>WinExe</OutputType>`,
   `<PublishSingleFile>true</PublishSingleFile>`, `<DebugType>embedded</DebugType>`.
-  A companion self-contained updater project additionally sets
-  `<RuntimeIdentifier>win-x64</RuntimeIdentifier>` and `<SelfContained>true</SelfContained>`
+  `PublishSingleFile` requires a `RuntimeIdentifier` (e.g. `win-x64`) on any
+  project that publishes it — set directly in the `.csproj` or via a publish
+  profile (`.pubxml`). A companion self-contained updater project additionally
+  sets `<RuntimeIdentifier>win-x64</RuntimeIdentifier>` and
+  `<SelfContained>true</SelfContained>`
 
 ## StyleCop
 
@@ -43,8 +48,13 @@ VRCXDiscordTracker, ZoomInClass).
 
 - Provide a `stylecop.json` next to the `.csproj` and reference it with
   `<AdditionalFiles Include="stylecop.json" />`
-- Set `"documentationCulture": "ja-JP"` and `"xmlHeader": false` unless the project's
-  CLAUDE.md specifies a different documentation language
+- Set `settings.documentationRules.documentationCulture` to `"ja-JP"` and
+  `settings.documentationRules.xmlHeader` to `false` unless the project's
+  CLAUDE.md specifies a different documentation language:
+
+  ```json
+  { "settings": { "documentationRules": { "documentationCulture": "ja-JP", "xmlHeader": false } } }
+  ```
 
 ## `.editorconfig`
 
@@ -116,4 +126,5 @@ VRCXDiscordTracker, ZoomInClass).
 - Steps: `dotnet restore` → `dotnet build --no-restore -c Release` →
   `dotnet test --no-build -c Release`
 - Style/format check: `dotnet format <sln> --verify-no-changes --severity warn`
-  in CI — this must pass before merge, same as StyleCop warnings at build time
+  in CI — this is the step that actually gates merges on formatting/style,
+  since StyleCop/analyzer diagnostics are build-time warnings, not build failures


### PR DESCRIPTION
## 概要

book000 / tomacheese オーガニゼーションの C# プロジェクトを横断的に調査し、C# 独自のコーディングルール `home/dot_claude/rules/coding-csharp.md` を新規作成した。

## 調査対象リポジトリ

- book000/github-webhook-bridge
- book000/ZoomInClass
- tomacheese/watch-wishlist-sale
- tomacheese/ElitesRNGAuraObserver
- tomacheese/IdlingLightManager
- tomacheese/VRCXDiscordTracker

## ルールに含めた主な内容

- SDK スタイル csproj / Directory.Build.props / Nullable・ImplicitUsings 有効化などのプロジェクト設定
- StyleCop.Analyzers + stylecop.json の設定方針(ドキュメント文化 ja-JP など)
- 各リポジトリで共通する `.editorconfig` の方針(ほぼ全診断を warning にし、緩和時は理由コメント必須)
- ファイルスコープ名前空間・式本体メンバーなどのコードスタイル
- Generic Host + DI + Serilog によるアプリケーション構成パターン
- xUnit + Moq + coverlet によるテスト方針、InternalsVisibleTo の使い方
- GitHub Actions での CI パターン(windows-latest, dotnet restore/build/test, dotnet format での書式チェック)

## 判断記録

1. **判断内容の要約**: 既存の `coding-*.md`(py/ts/sh/docker/github-actions)と同じ frontmatter 形式・構成で `coding-csharp.md` を新規追加した。
2. **検討した代替案**: (a) 各リポジトリの `.editorconfig` を丸ごと転記する、(b) book000/templates に C# 用共通テンプレートを新設してそこへ誘導する。
3. **不採用の理由**: (a) は 1,000 行超で保守性が低く、`.editorconfig` 自体は各リポジトリで手動コピーされ差分があるため丸写しは実態と乖離する。(b) は templates リポジトリに C# 向けの共通アセットが存在せず、今回のスコープ外の新規作成が必要になるため見送った。
4. **前提・仮定・不確実性**: 対象 6 リポジトリの `main`/`master` 最新状態を調査時点でのスナップショットとして扱っている。今後リポジトリ構成や規約が変わった場合はルールの追随が必要。
5. **他エージェントによるレビュー**: `/deep-review`(ローカル diff モード)を実行し、指摘事項(EnforceCodeStyleInBuild の挙動説明、PublishSingleFile と RuntimeIdentifier の関係、stylecop.json のキー階層、frontmatter paths の対象過剰)をすべて修正済み。

Closes #160