### PR TITLE
docs: 仕様書やプランをConfluenceにアップロードするルールを追加

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -51,3 +51,4 @@ Use the Todo tool for all multi-step work without omission.
 @CLAUDE.local.md
 @RTK.md
 @rules/superpowers.md
+@rules/confluence.md

--- a/home/dot_claude/rules/confluence.md
+++ b/home/dot_claude/rules/confluence.md
@@ -1,0 +1,56 @@
+# Confluence Upload Rules
+
+Rules for sharing user-facing Markdown deliverables via Confluence.
+
+---
+
+## When to Apply
+
+Applies to Markdown documents created for the user to read or review as a deliverable:
+
+- Investigation results (調査結果)
+- Spec files (`docs/superpowers/specs/*.md`)
+- Plan files (`docs/superpowers/plans/*.md`)
+- Other standalone write-ups intended for the user, not for the codebase itself
+
+Does not apply to commit messages, PR bodies, code comments, or other routine
+Git/GitHub artifacts — only to documents whose primary purpose is to be read by the user.
+
+## Procedure
+
+1. **Resolve cloudId**: same approach as `ticket-pr`'s cloudId resolution — try the site
+   hostname first, otherwise use `mcp__atlassian__getAccessibleAtlassianResources`.
+2. **Determine space and parent page**: there is no fixed space or parent page configured.
+   - If unknown for this session, ask the user via AskUserQuestion (space key/name, and
+     parent page if any). Do not guess or fabricate a space key or page ID.
+   - Once confirmed in a session, reuse the same space/parent for subsequent uploads in
+     that session without re-asking, unless the user indicates otherwise.
+3. **Check for sensitive information**: verify the document contains no secrets (tokens,
+   passwords, internal URLs, credentials) before uploading — same check already required
+   before posting to GitHub Issues or Jira (see `rules/security.md`).
+4. **Create the page** with `mcp__atlassian__createConfluencePage`:
+   - `cloudId`, `spaceId`, `parentId` (if any), `title`, `body`, `contentFormat: "markdown"`.
+   - Title convention: `<doc type> - <topic>`, e.g. `調査結果 - <topic>`,
+     `仕様書 - Issue #<number> <title>`, `プラン - Issue #<number> <title>`.
+5. **Update instead of duplicating**: if the document is revised later in the same session
+   (e.g. after sub-agent review feedback or user comments), reuse the page created in step 4
+   and call `mcp__atlassian__updateConfluencePage` with its `pageId` instead of creating a
+   new page.
+6. **Present the URL, not the content**: report the resulting Confluence page URL to the
+   user. Do not paste the full document body again in chat or in an Issue/ticket comment —
+   a short summary plus the Confluence URL is sufficient.
+
+## Interaction with Other Skills
+
+- **`issue-pr` (Phase 5) / `ticket-pr` (Phase 6)**: after uploading the requirements document
+  to Confluence, the GitHub Issue comment / Jira ticket comment must contain the Confluence
+  URL plus a short summary only — not the full document body.
+- **`rules/superpowers.md` spec/plan review workflow**: after the sub-agent review is
+  complete, upload the reviewed document to Confluence before presenting it to the user, and
+  give the user the Confluence URL alongside the local file path.
+
+## Notes
+
+- If MCP resolution (cloudId, space, page) fails, report the error to the user and ask how
+  to proceed rather than guessing.
+- Uploaded content is still subject to `rules/security.md` — never include secrets.

--- a/home/dot_claude/rules/confluence.md
+++ b/home/dot_claude/rules/confluence.md
@@ -8,7 +8,7 @@ Rules for sharing user-facing Markdown deliverables via Confluence.
 
 Applies to Markdown documents created for the user to read or review as a deliverable:
 
-- Investigation results (調査結果)
+- Investigation results
 - Spec files (`docs/superpowers/specs/*.md`)
 - Plan files (`docs/superpowers/plans/*.md`)
 - Other standalone write-ups intended for the user, not for the codebase itself
@@ -30,8 +30,10 @@ Git/GitHub artifacts — only to documents whose primary purpose is to be read b
    before posting to GitHub Issues or Jira (see `rules/security.md`).
 4. **Create the page** with `mcp__atlassian__createConfluencePage`:
    - `cloudId`, `spaceId`, `parentId` (if any), `title`, `body`, `contentFormat: "markdown"`.
-   - Title convention: `<doc type> - <topic>`, e.g. `調査結果 - <topic>`,
-     `仕様書 - Issue #<number> <title>`, `プラン - Issue #<number> <title>`.
+   - Title convention: `<doc type> - <topic>`, e.g. `Investigation - <topic>`,
+     `Spec - Issue #<number> <title>`, `Plan - Issue #<number> <title>`. Use whatever
+     language the document itself is written in for `<topic>`/`<title>`; keep `<doc type>`
+     in English so the title convention stated here stays consistent with this rule file.
 5. **Update instead of duplicating**: if the document is revised later in the same session
    (e.g. after sub-agent review feedback or user comments), reuse the page created in step 4
    and call `mcp__atlassian__updateConfluencePage` with its `pageId` instead of creating a

--- a/home/dot_claude/rules/superpowers.md
+++ b/home/dot_claude/rules/superpowers.md
@@ -33,8 +33,9 @@ you MUST dispatch a sub-agent to review the document and apply fixes.
    changes look correct.
 4. If the sub-agent reports ambiguities, resolve them with the user via
    AskUserQuestion before proceeding.
-5. Only after all issues are resolved, present the file to the user for
-   review.
+5. Only after all issues are resolved, upload the document to Confluence
+   following `rules/confluence.md`, then present the user with the local
+   file path and the Confluence URL.
 
 ### Clarifying questions
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -87,7 +87,7 @@ document body:
 gh issue comment $ARGUMENTS --body "$(cat <<'EOF'
 [short summary]
 
-詳細: [Confluence URL]
+Details: [Confluence URL]
 EOF
 )"
 ```

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -76,11 +76,18 @@ Create in the following format:
 5. Whether other agents can review
 ```
 
-### Phase 5: Post Comment to Issue
+### Phase 5: Upload to Confluence and Post Comment to Issue
+
+Upload the requirements document to Confluence following `rules/confluence.md`.
+
+Then post a short summary plus the Confluence URL as the Issue comment — not the full
+document body:
 
 ```bash
 gh issue comment $ARGUMENTS --body "$(cat <<'EOF'
-[requirements document content]
+[short summary]
+
+詳細: [Confluence URL]
 EOF
 )"
 ```

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -134,10 +134,13 @@ document body — with the MCP tool `mcp__atlassian__addCommentToJiraIssue`.
 mcp__atlassian__addCommentToJiraIssue({
   cloudId: "<cloud-id>",
   issueIdOrKey: "<ticket-key>",
-  commentBody: "<short summary>\n\n詳細: <Confluence URL>",
+  commentBody: "<short summary>[newline][newline]Details: <Confluence URL>",
   contentFormat: "markdown"
 })
 ```
+
+`[newline]` above denotes an actual newline character, not the literal `\n` — see the
+line-break note below.
 
 Always verify no sensitive information is included.
 Explicitly set `contentFormat: "markdown"`, and write line breaks as actual newline

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -123,15 +123,18 @@ Create in the following format:
 5. Whether other agents can review
 ```
 
-### Phase 6: Post Comment to Jira Ticket
+### Phase 6: Upload to Confluence and Post Comment to Jira Ticket
 
-Post the requirements document as a comment with the MCP tool `mcp__atlassian__addCommentToJiraIssue`.
+Upload the requirements document to Confluence following `rules/confluence.md`.
+
+Then post a short summary plus the Confluence URL as the ticket comment — not the full
+document body — with the MCP tool `mcp__atlassian__addCommentToJiraIssue`.
 
 ```
 mcp__atlassian__addCommentToJiraIssue({
   cloudId: "<cloud-id>",
   issueIdOrKey: "<ticket-key>",
-  commentBody: "<requirements document content>",
+  commentBody: "<short summary>\n\n詳細: <Confluence URL>",
   contentFormat: "markdown"
 })
 ```


### PR DESCRIPTION
## 概要

ユーザーに見せる目的で作成した Markdown ドキュメント（調査結果・仕様書・プラン）を MCP 経由で Confluence にアップロードし、URL をユーザーに提示するルールを追加する。

## 変更内容

- `home/dot_claude/rules/confluence.md`（新規）: Confluence アップロードの適用範囲・手順（cloudId 解決、スペース/親ページの確認、機密情報チェック、ページ作成・更新、URL 提示）を定義
- `home/dot_claude/CLAUDE.md`: `@rules/confluence.md` を参照に追加（常時ロード）
- `home/dot_claude/rules/superpowers.md`: spec/plan レビュー完了後のステップに Confluence アップロードを追加
- `home/dot_claude/skills/issue-pr/SKILL.md`: Phase 5 で要件定義書を Confluence にアップロードし、Issue コメントには要約 + Confluence URL のみ記載するよう変更
- `home/dot_claude/skills/ticket-pr/SKILL.md`: Phase 6 で同様に、Jira チケットコメントには要約 + Confluence URL のみ記載するよう変更

## スペース／親ページの決定方針

固定のスペース・親ページは設けず、不明な場合はセッション内で都度 AskUserQuestion によりユーザーに確認する。

Closes #162