### PR TITLE
fix: EnterWorktree 実行後の Workspace Trust ダイアログを抑止

### DIFF
--- a/home/dot_claude/hooks/executable_trust-worktree-cwd.sh
+++ b/home/dot_claude/hooks/executable_trust-worktree-cwd.sh
@@ -6,6 +6,8 @@
 # 90-ai-alias.zsh/sh の _claude_trust_cwd() が実行されず、
 # Workspace Trust dialog が発生する問題 (Issue #166) への対策。
 
+command -v jq > /dev/null 2>&1 || exit 0
+
 INPUT_JSON=$(cat)
 CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2> /dev/null)
 
@@ -13,7 +15,6 @@ CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2> /dev/null)
 
 CONFIG="$HOME/.claude.json"
 [ -f "$CONFIG" ] || exit 0
-command -v jq > /dev/null 2>&1 || exit 0
 
 if [ "$(jq -r --arg p "$CWD" '.projects[$p].hasTrustDialogAccepted // false' "$CONFIG" 2> /dev/null)" != "true" ]; then
     TMP=$(mktemp "${CONFIG}.XXXXXX") || exit 0

--- a/home/dot_claude/hooks/executable_trust-worktree-cwd.sh
+++ b/home/dot_claude/hooks/executable_trust-worktree-cwd.sh
@@ -21,7 +21,7 @@ if [ "$(jq -r --arg p "$CWD" '.projects[$p].hasTrustDialogAccepted // false' "$C
     PERM=$(stat -c '%a' "$CONFIG" 2> /dev/null || stat -f '%Lp' "$CONFIG" 2> /dev/null)
     [ -n "$PERM" ] && chmod "$PERM" "$TMP"
     if jq --arg p "$CWD" '.projects[$p] = ((.projects[$p] // {}) + {hasTrustDialogAccepted: true})' "$CONFIG" > "$TMP"; then
-        mv "$TMP" "$CONFIG"
+        mv "$TMP" "$CONFIG" || rm -f "$TMP"
     else
         rm -f "$TMP"
     fi

--- a/home/dot_claude/hooks/executable_trust-worktree-cwd.sh
+++ b/home/dot_claude/hooks/executable_trust-worktree-cwd.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# EnterWorktree の PostToolUse フックスクリプト。
+# フック入力 JSON の cwd (EnterWorktree 実行後の新しい作業ディレクトリ) を
+# Claude Code のワークスペース信頼済みディレクトリとして ~/.claude.json に登録する。
+# EnterWorktree はシェルラッパー (claude コマンド) 経由で起動されないため、
+# 90-ai-alias.zsh/sh の _claude_trust_cwd() が実行されず、
+# Workspace Trust dialog が発生する問題 (Issue #166) への対策。
+
+INPUT_JSON=$(cat)
+CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2> /dev/null)
+
+[ -n "$CWD" ] || exit 0
+
+CONFIG="$HOME/.claude.json"
+[ -f "$CONFIG" ] || exit 0
+command -v jq > /dev/null 2>&1 || exit 0
+
+if [ "$(jq -r --arg p "$CWD" '.projects[$p].hasTrustDialogAccepted // false' "$CONFIG" 2> /dev/null)" != "true" ]; then
+    TMP=$(mktemp "${CONFIG}.XXXXXX") || exit 0
+    # 元ファイルのパーミッションを一時ファイルに反映する (GNU stat / BSD stat の両方に対応)
+    PERM=$(stat -c '%a' "$CONFIG" 2> /dev/null || stat -f '%Lp' "$CONFIG" 2> /dev/null)
+    [ -n "$PERM" ] && chmod "$PERM" "$TMP"
+    if jq --arg p "$CWD" '.projects[$p] = ((.projects[$p] // {}) + {hasTrustDialogAccepted: true})' "$CONFIG" > "$TMP"; then
+        mv "$TMP" "$CONFIG"
+    else
+        rm -f "$TMP"
+    fi
+fi
+
+exit 0

--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -69,6 +69,16 @@
             "onFailure": "ignore"
           }
         ]
+      },
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/trust-worktree-cwd.sh",
+            "onFailure": "ignore"
+          }
+        ]
       }
     ],
     "PermissionRequest": [


### PR DESCRIPTION
## 概要

`EnterWorktree` でセッション内に作成した git worktree ディレクトリで、Workspace Trust ダイアログ（「このプロジェクトは信頼できますか？」）が毎回表示される問題（Issue #166）を解消する。

## 原因

`home/dot_zshrc.d/`・`home/dot_bashrc.d/` の既存 `_claude_trust_cwd()` は `claude` シェルラッパー起動時のみ `~/.claude.json` の `projects[<path>].hasTrustDialogAccepted` を設定する。`EnterWorktree` はシェルラッパー経由で起動されないため、このロジックが実行されず、実機検証の結果、ダイアログは `EnterWorktree` 実行後の最初のツール呼び出しでトリガーされることを確認した。

## 対応内容

- `home/dot_claude/hooks/executable_trust-worktree-cwd.sh` を新規追加。`EnterWorktree` の PostToolUse フックとして、フック標準入力 JSON の `cwd`（新ワークツリーパス）を `~/.claude.json` に信頼済み登録する（既存 `_claude_trust_cwd()` とは独立実装、mktemp+mv によるアトミック書き込み）。
- `home/dot_claude/private_settings.json` の `hooks.PostToolUse` に、上記スクリプトを matcher `"EnterWorktree"` として登録。
- deep-review の指摘（`mv` 失敗時の一時ファイルリーク、Score 65）を修正済み。

## スコープ外

- `ExitWorktree` 実行時の `~/.claude.json` エントリ掃除は対象外（登録のみのスコープ、Spec で確認済み）。

## 検証結果

- フックスクリプトの単体動作確認（正常系: 新規登録・冪等再実行、異常系: `cwd` 空文字・`~/.claude.json` 不在）: すべて期待通り。
- `private_settings.json` の JSON 妥当性・エントリ内容: 確認済み。
- 隔離した destination への `chezmoi apply`: エラーなく完了、スクリプトが実行可能な状態でデプロイされ `settings.json` に反映されることを確認。
- 実際の Claude Code + Docker 上での対話的な E2E 確認（`EnterWorktree` 実行後にダイアログが出ないことの目視確認）は本 PR の自動化範囲外。マージ後、実環境での手動確認を推奨。

## 関連ドキュメント

- Spec: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/3538968/Spec+-+Issue+166+EnterWorktree+Workspace+Trust
- Plan: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/3473494/Plan+-+Issue+166+EnterWorktree+Workspace+Trust

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)