### PR TITLE
fix: claude 起動時のパーミッションモードを --dangerously-skip-permissions から --permission-mode auto に変更する

### DIFF
--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -5,15 +5,15 @@
 # claude コマンドのラッパー関数。
 # AI エージェント・chezmoi の更新を行い、--permission-mode auto を付与して実行する。
 # ただし remote-control サブコマンドはフラグを付与しない。
-# （auto モードのフラグ（2トークン）が前置されると process.argv[2] が "remote-control" でなくなり、
+# （auto モードのフラグが前置されると process.argv[2] が "remote-control" でなくなり、
 #   コマンドディスパッチが失敗して "Unknown argument: remote-control" エラーが発生するため）
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias claude 2>/dev/null
 # カレントディレクトリを Claude Code のワークスペース信頼済みディレクトリとして
 # ~/.claude.json に登録する。
 # Workspace Trust dialog の非永続化は --dangerously-skip-permissions 固有ではなく
-# Claude Code 全体の既知の問題であり、hasTrustDialogAccepted が永続化されないと
-# statusLine や hooks が無音でスキップされてしまう。auto モードでも同様に必要な対策。
+# Claude Code 全体の既知の問題（Issue #165 で検証済み）であり、hasTrustDialogAccepted が
+# 永続化されないと statusLine や hooks が無音でスキップされてしまう。auto モードでも同様に必要な対策。
 _claude_trust_cwd() {
   local config="$HOME/.claude.json"
   [ -f "$config" ] || return 0

--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -1,18 +1,19 @@
 # AI CLI ツールのエイリアス設定
-# --dangerously-skip-permissions や --yolo は、確認プロンプトをスキップして実行するためのオプションです。
+# --yolo は、確認プロンプトをスキップして実行するためのオプションです。
+# claude は --permission-mode auto で、分類器による安全チェックを介して確認プロンプトを削減します。
 # AI エージェントの自動更新 (update-ai-agents.sh --quick --only <agent>) を各 CLI 実行前に実行します。
 # claude コマンドのラッパー関数。
-# AI エージェント・chezmoi の更新を行い、--dangerously-skip-permissions を付与して実行する。
+# AI エージェント・chezmoi の更新を行い、--permission-mode auto を付与して実行する。
 # ただし remote-control サブコマンドはフラグを付与しない。
-# （--dangerously-skip-permissions が前置されると process.argv[2] が "remote-control" でなくなり、
+# （auto モードのフラグ（2トークン）が前置されると process.argv[2] が "remote-control" でなくなり、
 #   コマンドディスパッチが失敗して "Unknown argument: remote-control" エラーが発生するため）
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias claude 2>/dev/null
 # カレントディレクトリを Claude Code のワークスペース信頼済みディレクトリとして
 # ~/.claude.json に登録する。
-# --dangerously-skip-permissions 環境では Workspace Trust dialog が機能せず
-# hasTrustDialogAccepted が永続化されないため、statusLine や hooks が無音で
-# スキップされてしまう問題への対策。
+# Workspace Trust dialog の非永続化は --dangerously-skip-permissions 固有ではなく
+# Claude Code 全体の既知の問題であり、hasTrustDialogAccepted が永続化されないと
+# statusLine や hooks が無音でスキップされてしまう。auto モードでも同様に必要な対策。
 _claude_trust_cwd() {
   local config="$HOME/.claude.json"
   [ -f "$config" ] || return 0
@@ -38,7 +39,7 @@ claude() {
       command claude "$@" ;;
     *)
       _claude_trust_cwd
-      command claude --dangerously-skip-permissions "$@" ;;
+      command claude --permission-mode auto "$@" ;;
   esac
 }
 alias codex='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only codex; ~/.local/share/chezmoi/update.sh; codex --yolo'

--- a/home/dot_zshrc.d/executable_90-ai-alias.zsh
+++ b/home/dot_zshrc.d/executable_90-ai-alias.zsh
@@ -5,15 +5,15 @@
 # claude コマンドのラッパー関数。
 # AI エージェントの更新を行い、--permission-mode auto を付与して実行する。
 # ただし remote-control サブコマンドはフラグを付与しない。
-# （auto モードのフラグ（2トークン）が前置されると process.argv[2] が "remote-control" でなくなり、
+# （auto モードのフラグが前置されると process.argv[2] が "remote-control" でなくなり、
 #   コマンドディスパッチが失敗して "Unknown argument: remote-control" エラーが発生するため）
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias claude 2>/dev/null
 # カレントディレクトリを Claude Code のワークスペース信頼済みディレクトリとして
 # ~/.claude.json に登録する。
 # Workspace Trust dialog の非永続化は --dangerously-skip-permissions 固有ではなく
-# Claude Code 全体の既知の問題であり、hasTrustDialogAccepted が永続化されないと
-# statusLine や hooks が無音でスキップされてしまう。auto モードでも同様に必要な対策。
+# Claude Code 全体の既知の問題（Issue #165 で検証済み）であり、hasTrustDialogAccepted が
+# 永続化されないと statusLine や hooks が無音でスキップされてしまう。auto モードでも同様に必要な対策。
 _claude_trust_cwd() {
   local config="$HOME/.claude.json"
   [ -f "$config" ] || return 0

--- a/home/dot_zshrc.d/executable_90-ai-alias.zsh
+++ b/home/dot_zshrc.d/executable_90-ai-alias.zsh
@@ -1,18 +1,19 @@
 # AI CLI ツールのエイリアス設定
-# --dangerously-skip-permissions や --yolo は、確認プロンプトをスキップして実行するためのオプションです。
+# --yolo は、確認プロンプトをスキップして実行するためのオプションです。
+# claude は --permission-mode auto で、分類器による安全チェックを介して確認プロンプトを削減します。
 # AI エージェントの自動更新 (update-ai-agents.sh --quick) を各 CLI 実行前に実行します。
 # claude コマンドのラッパー関数。
-# AI エージェントの更新を行い、--dangerously-skip-permissions を付与して実行する。
+# AI エージェントの更新を行い、--permission-mode auto を付与して実行する。
 # ただし remote-control サブコマンドはフラグを付与しない。
-# （--dangerously-skip-permissions が前置されると process.argv[2] が "remote-control" でなくなり、
+# （auto モードのフラグ（2トークン）が前置されると process.argv[2] が "remote-control" でなくなり、
 #   コマンドディスパッチが失敗して "Unknown argument: remote-control" エラーが発生するため）
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias claude 2>/dev/null
 # カレントディレクトリを Claude Code のワークスペース信頼済みディレクトリとして
 # ~/.claude.json に登録する。
-# --dangerously-skip-permissions 環境では Workspace Trust dialog が機能せず
-# hasTrustDialogAccepted が永続化されないため、statusLine や hooks が無音で
-# スキップされてしまう問題への対策。
+# Workspace Trust dialog の非永続化は --dangerously-skip-permissions 固有ではなく
+# Claude Code 全体の既知の問題であり、hasTrustDialogAccepted が永続化されないと
+# statusLine や hooks が無音でスキップされてしまう。auto モードでも同様に必要な対策。
 _claude_trust_cwd() {
   local config="$HOME/.claude.json"
   [ -f "$config" ] || return 0
@@ -37,7 +38,7 @@ claude() {
       command claude "$@" ;;
     *)
       _claude_trust_cwd
-      command claude --dangerously-skip-permissions "$@" ;;
+      command claude --permission-mode auto "$@" ;;
   esac
 }
 alias codex='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick; codex --yolo'


### PR DESCRIPTION
## 概要

`claude` コマンドのラッパー関数（zsh/bash 両方）のデフォルト起動時パーミッションモードを、安全チェックを一切行わない `--dangerously-skip-permissions`（`bypassPermissions` 相当）から、分類器による安全チェックを介しつつ確認プロンプトを削減する `--permission-mode auto` に変更しました。

Closes #165

## 変更内容

- `home/dot_zshrc.d/executable_90-ai-alias.zsh` の `claude()` 関数: `command claude --dangerously-skip-permissions "$@"` → `command claude --permission-mode auto "$@"`
- `home/dot_bashrc.d/executable_90-ai-alias.sh` の `claude()` 関数: 同上
- 関連コメント（先頭の説明文、関数直前の説明、`remote-control` 分岐の説明、Workspace Trust dialog に関する説明）を、変更後の挙動・調査結果に合わせて更新

`remote-control`/`rc` サブコマンドの分岐（フラグを付与しない）は変更していません。Remote Control セッションは auto モードにも非対応のため、現状の回避策は引き続き正しい挙動です。

## 対象外（理由）

- `codex` / `gemini` / `copilot`: `--yolo` を使用する別 CLI で、auto モードという概念自体を持たないため対象外
- `alias happy='...; happy --dangerously-skip-permissions'`: `happy` は `claude` とは別の CLI であり、Issue のスコープ（Claude Code 起動時）に含まれない
- `home/dot_claude/private_settings.json` の `skipDangerousModePermissionPrompt`: `happy` エイリアスが引き続き `--dangerously-skip-permissions` を使うため変更不要

## 調査結果・受容リスク（詳細は Issue コメント参照）

- `auto` モードは Anthropic 公式ドキュメントで `bypassPermissions` の推奨代替として明記されている
- Workspace Trust dialog の非永続化は `bypassPermissions` 固有ではなく Claude Code 全体の既知の問題であり、`_claude_trust_cwd()` はモード変更後も無条件で維持
- 保護パス（`.git` / `.claude` 等）への書き込みは `auto` モードでは分類器評価の対象となり、`bypassPermissions` 時より確認・ブロックが発生し得る（実利用で支障が出た場合は別 Issue で対応）
- auto モードにはアカウント/モデル要件を満たさない場合に無言で別モードへデグレードする既知の未修正バグが存在するが、フォールバック実装は行わず受容

## 検証

- 両ファイルとも `bash -n` で構文チェック済み（zsh 未インストール環境のため bash -n で代替、zsh 固有構文なし）
- zsh 版は Docker 上で `chezmoi apply --dry-run --verbose` を実行し、差分が期待通りであることを確認済み
- bash 版は Docker デーモンが応答不能だったため、ユーザー承認のもと `bash -n` のみで代替検証
- `/deep-review`（ローカル diff モード）を実行し、指摘事項（コメントの半角スペース欠落・冗長で陳腐化しやすい記述・未検証の断定表現）を修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)