### PR TITLE
fix: issue-pr の spec/plan 言語・PR作成先・マージ後クリーンアップを改善 (#168, #169, #171)

### DIFF
--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -265,7 +265,7 @@ Post the spec and plan summaries plus their Confluence URLs as an Issue
 comment — not the full document bodies:
 
 ```bash
-gh issue comment "$ARGUMENTS" --body "$(cat <<'EOF'
+gh issue comment "$ARGUMENTS" --repo "$ISSUE_OWNER/$ISSUE_REPO" --body "$(cat <<'EOF'
 [short summary]
 
 Spec: [Confluence URL]
@@ -273,6 +273,11 @@ Plan: [Confluence URL]
 EOF
 )"
 ```
+
+`--repo` is required here — without it, `gh issue comment` resolves the
+target repository from the local `origin`, which is wrong whenever
+`ISSUE_OWNER/ISSUE_REPO` (set in Phase 2) differs from `origin` (the fork
+scenario this Issue set targets).
 
 Verify no sensitive information is included before posting.
 
@@ -349,7 +354,7 @@ issue title / spec summary, e.g.:
 
 ```bash
 PR_TITLE="<derived from the issue title / spec summary>"
-gh pr create --title "$PR_TITLE" --body "$(cat <<'EOF'
+gh pr create --repo "$ISSUE_OWNER/$ISSUE_REPO" --title "$PR_TITLE" --body "$(cat <<'EOF'
 <PR body>
 EOF
 )"
@@ -367,6 +372,12 @@ EOF
 - Before running this command, check the composed title/body for sensitive
   information (tokens, internal URLs, credentials) the same way Phase 11
   checks the Issue comment — the PR is also externally visible.
+- `--repo "$ISSUE_OWNER/$ISSUE_REPO"` is required: the PR must be created
+  against the repository the Issue actually lives in (set in Phase 2), not
+  wherever `gh`'s own fork/parent heuristic would default to. The head side
+  (the fork's branch) is resolved automatically by `gh`; if that resolution
+  fails, fall back to explicitly passing
+  `--head <origin-owner>:<branch>`.
 
 ## Phase 17: Write Session State
 
@@ -375,7 +386,7 @@ without parsing the transcript:
 
 ```bash
 mkdir -p ~/.claude/data && chmod 700 ~/.claude/data
-PR_URL=$(gh pr view --json url -q .url)
+PR_URL=$(gh pr view --repo "$ISSUE_OWNER/$ISSUE_REPO" --json url -q .url)
 if [ -z "$PR_URL" ]; then
   echo "ERROR: gh pr view returned an empty URL, not writing session-state.json" >&2
   exit 1

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -35,7 +35,7 @@ do not proceed and hit the failure several phases later.
 
 ## Progress Tracking
 
-Before Phase 1, create one task per phase below (Phase 1 through Phase 18)
+Before Phase 1, create one task per phase below (Phase 1 through Phase 19)
 with the Todo tool, subject = the phase title. This is a long, multi-phase
 flow spanning two approval gates and several delegated skills — track it
 explicitly so no phase gets skipped or forgotten mid-run, especially after a
@@ -418,6 +418,28 @@ instruction" guardrail doesn't apply. No separate confirmation is needed here
 because Phase 10 already approved the plan — this step just carries out the
 mechanical follow-through (fixing CI, resolving conflicts, addressing review
 feedback) without expanding scope beyond what was approved.
+
+## Phase 19: Launch Background Monitoring
+
+Immediately after Phase 18, launch the merge/close monitor in the
+background so cleanup happens even if the user merges or closes the PR
+outside this session:
+
+```bash
+PR_NUMBER=$(gh pr view --repo "$ISSUE_OWNER/$ISSUE_REPO" --json number -q .number)
+~/.claude/skills/wait-for-pr-close/scripts/wait-for-pr-close.sh "$PR_NUMBER" --repo "$ISSUE_OWNER/$ISSUE_REPO" &
+```
+
+Always pass `--repo "$ISSUE_OWNER/$ISSUE_REPO"` explicitly here, even in the
+non-fork case — omitting it makes `wait-for-pr-close.sh` fall back to the
+local `origin`, which is wrong whenever the fork scenario from Issue #171
+applies (the PR lives in `ISSUE_OWNER/ISSUE_REPO`, not `origin`).
+
+This is a fire-and-forget background launch, matching how
+`wait-for-copilot-review` is used elsewhere — the `issue-pr` flow is
+considered complete once this is launched. Detection and cleanup
+(`/pr-cleanup`) happen outside this session, in a fresh tmux prompt, once
+the monitor detects the PR closing.
 
 ## Notes
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -148,6 +148,20 @@ Invoke **superpowers:brainstorming** with the issue content as the starting
 problem. Relay any clarifying questions it raises to the user via
 AskUserQuestion. It produces a spec file under `docs/superpowers/specs/`.
 
+When invoking it, explicitly instruct it to write the spec document's body
+in the language required by the target project's CLAUDE.md (for this
+repository, Japanese — `会話は日本語で行う`). Code blocks, commands, and
+identifiers may stay in their original form. This must be stated explicitly
+in the prompt every time — do not assume the sub-skill infers it from
+context, since roughly one run in five otherwise defaults to English.
+
+Do not ask a content-free "may I proceed" confirmation between Phase 2 and
+this phase (e.g. "spec を作成してよいですか？"). Genuine requirement-
+clarifying questions (where the Issue's request could be interpreted two or
+more ways) are fine and expected via AskUserQuestion — the distinction is
+whether the question surfaces a real ambiguity to resolve, versus asking
+permission to do the next scheduled step with no new information attached.
+
 ## Phase 4: Review the Spec
 
 `rules/superpowers.md` already requires a sub-agent review of every spec
@@ -190,6 +204,11 @@ becomes a Confluence page update, not a new page).
 
 Invoke **superpowers:writing-plans** against the approved spec to produce a
 plan file under `docs/superpowers/plans/`.
+
+Same language instruction as Phase 3: explicitly tell it to write the plan
+document's body in the language required by the target project's CLAUDE.md
+(Japanese for this repository), with code blocks/commands/identifiers left
+in their original form.
 
 ## Phase 8: Review the Plan
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -194,11 +194,26 @@ unconditional hard gate you can't get past.
 
 ## Phase 6: Approve the Spec
 
-Use **AskUserQuestion** to get explicit spec approval ("Approve this spec /
-revise it") before moving on to Phase 7. No exceptions — not for "the spec is
-obviously fine" and not for "ask forgiveness after Phase 7 instead." If the
-user asks for changes, go back to Phase 3 and repeat Phases 3–6 (Phase 5
-becomes a Confluence page update, not a new page).
+Use **AskUserQuestion** to get explicit spec approval before moving on to
+Phase 7. No exceptions — not for "the spec is obviously fine" and not for
+"ask forgiveness after Phase 7 instead."
+
+The question text MUST include the Confluence URL captured in Phase 5. If
+Phase 5's Confluence upload failed and fell back per `rules/confluence.md`,
+you must have already reported that to the user before reaching this phase
+— do not silently ask for approval without ever having surfaced the failure.
+
+Fix the options to exactly these two (plus AskUserQuestion's built-in
+"Other" free-text, which covers ad-hoc revision requests):
+
+- "承認する" (Approve)
+- "ページコメントを参照して修正してほしい" (Revise based on page comments)
+
+If the second option is chosen, fetch the unresolved inline/footer comments
+on the Confluence page (`mcp__atlassian__getConfluencePageInlineComments`,
+`mcp__atlassian__getConfluencePageFooterComments`), incorporate them into
+the spec, and repeat Phases 3–6 (Phase 5 becomes a Confluence page update,
+not a new page).
 
 ## Phase 7: Write the Plan
 
@@ -230,9 +245,19 @@ one. Same fallback as Phase 5 if Confluence resolution fails.
 Use **AskUserQuestion** again for explicit plan approval before moving on to
 Phase 11 — the spec's approval in Phase 6 does not carry over, since a plan
 can diverge from its spec. "The spec was already approved so the plan is
-implied" is exactly the shortcut this gate blocks. If the user asks for
-changes, go back to Phase 7 and repeat Phases 7–10 (Phase 9 becomes a
-Confluence page update, not a new page).
+implied" is exactly the shortcut this gate blocks.
+
+Same requirements as Phase 6: the question text MUST include the Confluence
+URL captured in Phase 9 (report any upload failure to the user before this
+phase, per `rules/confluence.md`'s fallback), and the options are fixed to
+exactly:
+
+- "承認する" (Approve)
+- "ページコメントを参照して修正してほしい" (Revise based on page comments)
+
+If the second option is chosen, fetch the unresolved Confluence page
+comments, incorporate them into the plan, and repeat Phases 7–10 (Phase 9
+becomes a Confluence page update, not a new page).
 
 ## Phase 11: Comment on the Issue
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -35,8 +35,8 @@ do not proceed and hit the failure several phases later.
 
 ## Progress Tracking
 
-Before Phase 1, create one task per phase below (Phase 1 through Phase 19)
-with the Todo tool, subject = the phase title. This is a long, multi-phase
+Before Phase 1, create one task per phase below with the Todo tool, subject
+= the phase title. This is a long, multi-phase
 flow spanning two approval gates and several delegated skills — track it
 explicitly so no phase gets skipped or forgotten mid-run, especially after a
 revise-and-repeat loop (Phase 6 or Phase 10) or a context compaction.

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -78,13 +78,69 @@ runs inside the worktree created here.
 ## Phase 2: Fetch the Issue
 
 ```bash
-gh issue view "$ARGUMENTS" --json title,state,body,comments,author
+gh issue view "$ARGUMENTS" --json title,state,body,comments,author,url
 ```
 
 If this command fails (auth, network, issue doesn't exist) or the issue is
 not OPEN, stop here and report it to the user — do not guess at intent and
 continue. Turning a closed or nonexistent issue into a PR is not a warning-
 level situation, it's a reason to stop.
+
+Extract `ISSUE_OWNER` and `ISSUE_REPO` from the returned `url` field
+(`https://github.com/<owner>/<repo>/issues/<number>`):
+
+```bash
+ISSUE_URL=$(gh issue view "$ARGUMENTS" --json url -q .url)
+ISSUE_OWNER=$(echo "$ISSUE_URL" | grep -oP 'github\.com/\K[^/]+')
+ISSUE_REPO=$(echo "$ISSUE_URL" | grep -oP 'github\.com/[^/]+/\K[^/]+(?=/issues)')
+if [ -z "$ISSUE_OWNER" ] || [ -z "$ISSUE_REPO" ]; then
+  echo "ERROR: failed to extract owner/repo from Issue URL: $ISSUE_URL" >&2
+  exit 1
+fi
+```
+
+If extraction fails, stop and report it to the user — every later phase
+that targets a specific repository (`gh issue comment`, `gh pr create`,
+`gh pr view` from the new `wait-for-pr-close` phase) depends on
+`ISSUE_OWNER`/`ISSUE_REPO` being correct. **`ISSUE_OWNER`/`ISSUE_REPO` is
+the repository the Issue actually lives in — this is what determines the PR
+destination in every later phase, regardless of whether the local checkout
+is a fork.**
+
+### Rebase onto the correct base branch (fork scenario)
+
+`EnterWorktree` in Phase 1 created the working branch off
+`origin/<default-branch>`. If `ISSUE_OWNER/ISSUE_REPO` differs from the
+local `origin`'s owner/repo (a fork working on an upstream Issue), `origin`'s
+default branch may be stale relative to `ISSUE_OWNER/ISSUE_REPO`'s. Rebase
+onto the correct base immediately, before any spec/plan/implementation work
+begins:
+
+```bash
+ORIGIN_OWNER=$(gh repo view --json owner -q .owner.login)
+ORIGIN_REPO=$(gh repo view --json name -q .name)
+if [ "$ISSUE_OWNER/$ISSUE_REPO" != "$ORIGIN_OWNER/$ORIGIN_REPO" ]; then
+  # Reuse an existing remote pointing at ISSUE_OWNER/ISSUE_REPO, or add one.
+  REMOTE_NAME=$(git remote -v | grep -F "github.com/$ISSUE_OWNER/$ISSUE_REPO" | head -1 | cut -f1)
+  if [ -z "$REMOTE_NAME" ]; then
+    REMOTE_NAME="upstream"
+    if git remote get-url "$REMOTE_NAME" >/dev/null 2>&1; then
+      echo "ERROR: remote '$REMOTE_NAME' already exists but does not point at $ISSUE_OWNER/$ISSUE_REPO" >&2
+      exit 1
+    fi
+    git remote add "$REMOTE_NAME" "https://github.com/$ISSUE_OWNER/$ISSUE_REPO.git"
+  fi
+  DEFAULT_BRANCH=$(gh repo view "$ISSUE_OWNER/$ISSUE_REPO" --json defaultBranchRef -q .defaultBranchRef.name)
+  git fetch "$REMOTE_NAME" "$DEFAULT_BRANCH"
+  git reset --hard "$REMOTE_NAME/$DEFAULT_BRANCH"
+fi
+```
+
+This is safe because no implementation work has happened yet at this point
+in the flow — `git reset --hard` here discards nothing of value. If the
+`git remote add` step fails because a same-named remote already exists
+pointing elsewhere, stop and ask the user how to proceed rather than
+overwriting it.
 
 ## Phase 3: Write the Spec
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -35,11 +35,11 @@ do not proceed and hit the failure several phases later.
 
 ## Progress Tracking
 
-Before Phase 1, create one task per phase below with the Todo tool, subject
-= the phase title. This is a long, multi-phase
-flow spanning two approval gates and several delegated skills — track it
-explicitly so no phase gets skipped or forgotten mid-run, especially after a
-revise-and-repeat loop (Phase 6 or Phase 10) or a context compaction.
+Before Phase 1, create one task per phase below with the Todo tool,
+subject = the phase title. This is a long, multi-phase flow spanning two
+approval gates and several delegated skills — track it explicitly so no
+phase gets skipped or forgotten mid-run, especially after a revise-and-repeat
+loop (Phase 6 or Phase 10) or a context compaction.
 
 Mark each task `in_progress` immediately before starting that phase and
 `completed` immediately after finishing it — do not batch updates at the
@@ -90,9 +90,10 @@ Extract `ISSUE_OWNER` and `ISSUE_REPO` from the returned `url` field
 (`https://github.com/<owner>/<repo>/issues/<number>`):
 
 ```bash
+# grep -oP（PCRE）は macOS の BSD grep では動かないため sed -E で移植可能な形にする
 ISSUE_URL=$(gh issue view "$ARGUMENTS" --json url -q .url)
-ISSUE_OWNER=$(echo "$ISSUE_URL" | grep -oP 'github\.com/\K[^/]+')
-ISSUE_REPO=$(echo "$ISSUE_URL" | grep -oP 'github\.com/[^/]+/\K[^/]+(?=/issues)')
+ISSUE_OWNER=$(echo "$ISSUE_URL" | sed -E 's#.*github\.com/([^/]+)/.*#\1#')
+ISSUE_REPO=$(echo "$ISSUE_URL" | sed -E 's#.*github\.com/[^/]+/([^/]+)/issues/.*#\1#')
 if [ -z "$ISSUE_OWNER" ] || [ -z "$ISSUE_REPO" ]; then
   echo "ERROR: failed to extract owner/repo from Issue URL: $ISSUE_URL" >&2
   exit 1

--- a/home/dot_claude/skills/pr-cleanup/SKILL.md
+++ b/home/dot_claude/skills/pr-cleanup/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pr-cleanup
+description: Cleans up after a pull request is merged or closed — removes the worktree/branch, updates the local default branch, and syncs a fork if applicable. Triggered automatically by wait-for-pr-close, or run manually with /pr-cleanup <PR number or URL>.
+argument-hint: "[PR number or URL]"
+disable-model-invocation: false
+---
+
+# PR Cleanup
+
+Cleans up local state after a pull request has been merged or closed —
+including the case where the user merged/closed it outside this session
+(manually, or via another tool), which Claude Code has no way to observe
+directly. This is a generic cleanup skill, not specific to `issue-pr`: it
+can be invoked manually for any PR, or automatically by `wait-for-pr-close`.
+
+## Usage
+
+```
+/pr-cleanup <PR number or URL>
+```
+
+**Examples:**
+- `/pr-cleanup 123`
+- `/pr-cleanup https://github.com/owner/repo/pull/123`
+
+## Step 0: Resolve PR Info
+
+```bash
+PR_ARG="$ARGUMENTS"
+if echo "$PR_ARG" | grep -q 'github\.com'; then
+  OWNER=$(echo "$PR_ARG" | grep -oP 'github\.com/\K[^/]+')
+  REPO=$(echo "$PR_ARG" | grep -oP 'github\.com/[^/]+/\K[^/]+(?=/pull)')
+  PR_NUMBER=$(echo "$PR_ARG" | grep -oP '/pull/\K\d+')
+else
+  OWNER=$(gh repo view --json owner --jq '.owner.login')
+  REPO=$(gh repo view --json name --jq '.name')
+  PR_NUMBER="$PR_ARG"
+fi
+```
+
+## Step 1: Confirm the PR Is Actually Closed
+
+```bash
+gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json state,headRefName,baseRefName,url,headRepositoryOwner
+```
+
+If `state` is not `MERGED` or `CLOSED`, stop here and report it to the
+user — do not delete a branch backing a still-open PR just because this
+skill was invoked manually or by mistake.
+
+## Step 2: Remove the Worktree or Branch
+
+`ExitWorktree` only operates on a worktree created by `EnterWorktree` **in
+the current session**, and is a no-op otherwise. Because `pr-cleanup` is
+mainly triggered from a fresh session (a new tmux prompt spawned by
+`wait-for-pr-close`, or a manual run days later), check whether the current
+session actually owns a matching worktree before deciding which removal
+path to use:
+
+```bash
+HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefName -q .headRefName)
+```
+
+- **If this session's `EnterWorktree` created the worktree for `HEAD_REF`**
+  (i.e. you got here via Phase 19 of `issue-pr` continuing in the same
+  session, without a session break): call
+  `ExitWorktree(action: "remove", discard_changes: true)`. Passing
+  `discard_changes: true` without re-confirming with the user is safe and
+  required here — Step 1 already confirmed the PR is `MERGED`/`CLOSED`, so
+  the branch's content is either already incorporated upstream or
+  explicitly abandoned. This also covers the squash-merge case, where the
+  local branch looks like it has "uncommitted" changes relative to the
+  squashed commit even though nothing is actually lost.
+
+- **Otherwise (the common case — a fresh session, e.g. triggered by
+  `wait-for-pr-close`'s tmux notification, or a manual run in a new
+  session)**: `ExitWorktree` cannot see a worktree it did not create, so
+  fall back to raw `git worktree` commands:
+
+  ```bash
+  WORKTREE_PATH=$(git worktree list --porcelain | awk -v ref="refs/heads/$HEAD_REF" '
+    /^worktree /{path=$2} /^branch /{if ($2==ref) print path}')
+  if [ -n "$WORKTREE_PATH" ]; then
+    git worktree remove --force "$WORKTREE_PATH"
+  fi
+  ```
+
+  `--force` is required for the same reason `discard_changes: true` is
+  required in the `ExitWorktree` branch above — Step 1 already confirmed
+  the PR is `MERGED`/`CLOSED`, so any apparent uncommitted state (e.g. from
+  a squash merge) is safe to discard without asking the user again.
+
+If it's a plain branch (no worktree involved either way):
+
+```bash
+git branch -D "$HEAD_REF"
+```
+
+## Step 3: Update the Local Default Branch
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+git checkout "$DEFAULT_BRANCH"
+git pull
+```
+
+This always targets the local `origin`'s default branch — even when the PR
+itself was created against a different repository (the fork/upstream
+scenario from Issue #171), the worktree/branch being cleaned up lives in
+the local checkout, which is always `origin`.
+
+## Step 4: Sync the Fork (if applicable)
+
+```bash
+if gh repo view --json parent -q .parent 2>/dev/null | grep -qv '^null$'; then
+  gh repo sync
+fi
+```
+
+`gh repo view --json parent` returns `null` for non-fork repositories;
+`gh repo sync` is only run when a parent exists (i.e. `origin` is a fork).
+
+## Step 5: Report Completion
+
+Report to the user that cleanup completed (worktree/branch removed, default
+branch updated, fork synced if applicable). Do not send a duplicate Discord
+notification here — `wait-for-pr-close` already sent one on detection when
+this skill was triggered automatically.

--- a/home/dot_claude/skills/pr-cleanup/SKILL.md
+++ b/home/dot_claude/skills/pr-cleanup/SKILL.md
@@ -104,6 +104,11 @@ git checkout "$DEFAULT_BRANCH"
 git pull
 ```
 
+If `DEFAULT_BRANCH` comes back empty, or either command exits non-zero
+(e.g. uncommitted local changes blocking the checkout, a network failure on
+pull), stop here and report it to the user — do not continue to Step 4/5 and
+report cleanup as complete when the local checkout may still be out of sync.
+
 This always targets the local `origin`'s default branch — even when the PR
 itself was created against a different repository (the fork/upstream
 scenario from Issue #171), the worktree/branch being cleaned up lives in

--- a/home/dot_claude/skills/pr-cleanup/SKILL.md
+++ b/home/dot_claude/skills/pr-cleanup/SKILL.md
@@ -26,11 +26,12 @@ can be invoked manually for any PR, or automatically by `wait-for-pr-close`.
 ## Step 0: Resolve PR Info
 
 ```bash
+# grep -oP（PCRE）は macOS の BSD grep では動かないため sed -E で移植可能な形にする
 PR_ARG="$ARGUMENTS"
 if echo "$PR_ARG" | grep -q 'github\.com'; then
-  OWNER=$(echo "$PR_ARG" | grep -oP 'github\.com/\K[^/]+')
-  REPO=$(echo "$PR_ARG" | grep -oP 'github\.com/[^/]+/\K[^/]+(?=/pull)')
-  PR_NUMBER=$(echo "$PR_ARG" | grep -oP '/pull/\K\d+')
+  OWNER=$(echo "$PR_ARG" | sed -E 's#.*github\.com/([^/]+)/.*#\1#')
+  REPO=$(echo "$PR_ARG" | sed -E 's#.*github\.com/[^/]+/([^/]+)/pull/.*#\1#')
+  PR_NUMBER=$(echo "$PR_ARG" | sed -E 's#.*/pull/([0-9]+).*#\1#')
 else
   OWNER=$(gh repo view --json owner --jq '.owner.login')
   REPO=$(gh repo view --json name --jq '.name')

--- a/home/dot_claude/skills/wait-for-pr-close/SKILL.md
+++ b/home/dot_claude/skills/wait-for-pr-close/SKILL.md
@@ -33,7 +33,7 @@ omitted, the script targets the local `origin`.
 
 ### Detection Logic
 
-- Polls `gh pr view <PR_NUMBER> [--repo <owner>/<repo>] --json state,mergedAt,url`
+- Polls `gh pr view <PR_NUMBER> [--repo <owner>/<repo>] --json state`
 - **Check interval**: 30 seconds
 - **Max wait time**: 30 minutes (60 checks). On timeout, notifies via tmux
   and exits 0 (not an error) — the user can re-run this script later for a
@@ -83,5 +83,5 @@ rm ~/.claude/locks/wait-pr-close-<PR_NUMBER>.lock
 ### Manually Check PR State
 
 ```bash
-gh pr view <PR_NUMBER> [--repo <owner>/<repo>] --json state,mergedAt,url
+gh pr view <PR_NUMBER> [--repo <owner>/<repo>] --json state
 ```

--- a/home/dot_claude/skills/wait-for-pr-close/SKILL.md
+++ b/home/dot_claude/skills/wait-for-pr-close/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: wait-for-pr-close
+description: Waits in the background for a pull request to be merged or closed, then triggers /pr-cleanup on detection.
+argument-hint: "[PR number] [--repo owner/repo]"
+disable-model-invocation: false
+---
+
+# Wait for PR Close
+
+Automatically detects when a pull request transitions to `MERGED` or
+`CLOSED`, then hands off to `/pr-cleanup` so worktree/branch cleanup happens
+even when the user merges or closes the PR outside of this session (where
+Claude Code has no way to observe the event directly).
+
+## Usage
+
+```bash
+/wait-for-pr-close <PR_NUMBER> [--repo <owner>/<repo>]
+```
+
+Or run the script directly:
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/wait-for-pr-close.sh <PR_NUMBER> [--repo <owner>/<repo>] &
+```
+
+`--repo` is required whenever the target PR lives in a different repository
+than the local `origin` (the fork scenario from Issue #171 — `issue-pr`'s
+Phase 19 always passes it explicitly as `$ISSUE_OWNER/$ISSUE_REPO`). If
+omitted, the script targets the local `origin`.
+
+## Features
+
+### Detection Logic
+
+- Polls `gh pr view <PR_NUMBER> [--repo <owner>/<repo>] --json state,mergedAt,url`
+- **Check interval**: 30 seconds
+- **Max wait time**: 30 minutes (60 checks). On timeout, notifies via tmux
+  and exits 0 (not an error) — the user can re-run this script later for a
+  PR that takes longer to merge.
+
+### Detection Condition
+
+Exits successfully as soon as `state` is `MERGED` or `CLOSED`.
+
+### Background Execution
+
+- **Log file**: `~/.claude/logs/wait-pr-close-<PR_NUMBER>.log`
+- **Lock file**: `~/.claude/locks/wait-pr-close-<PR_NUMBER>.lock`
+- **Mutual exclusion**: flock prevents multiple concurrent instances for the
+  same PR number
+
+### On Detection
+
+1. Notify the user (via Discord notification script)
+2. Send `/pr-cleanup <PR_NUMBER_or_URL>` to the current tmux session so
+   Claude Code picks up cleanup automatically. When `--repo` was passed and
+   differs from the local `origin`, the URL form
+   (`https://github.com/<owner>/<repo>/pull/<PR_NUMBER>`) is sent instead of
+   the bare number, so `pr-cleanup` targets the correct repository.
+
+## Notes
+
+- Maximum wait time is 30 minutes; re-run manually for a PR that takes
+  longer.
+- Multiple instances for the same PR number are prevented by flock.
+- Check the log file for execution status.
+
+## Troubleshooting
+
+### Check Logs
+
+```bash
+tail -f ~/.claude/logs/wait-pr-close-<PR_NUMBER>.log
+```
+
+### Remove Lock File (emergency only)
+
+```bash
+rm ~/.claude/locks/wait-pr-close-<PR_NUMBER>.lock
+```
+
+### Manually Check PR State
+
+```bash
+gh pr view <PR_NUMBER> [--repo <owner>/<repo>] --json state,mergedAt,url
+```

--- a/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
+++ b/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 引数チェック（PR_NUMBER は必須、--repo は任意）
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <PR_NUMBER> [--repo <owner>/<repo>]" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+shift
+
+REPO_ARG=""
+REPO_SLUG=""
+if [[ $# -ge 2 && "$1" == "--repo" ]]; then
+  REPO_SLUG="$2"
+  REPO_ARG="--repo"
+fi
+
+# PR 番号の妥当性チェック
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Error: PR_NUMBER must be a number" >&2
+  exit 1
+fi
+
+# ディレクトリ作成
+LOG_DIR="$HOME/.claude/logs"
+LOCK_DIR="$HOME/.claude/locks"
+mkdir -p "$LOG_DIR" "$LOCK_DIR"
+
+LOG_FILE="$LOG_DIR/wait-pr-close-${PR_NUMBER}.log"
+LOCK_FILE="$LOCK_DIR/wait-pr-close-${PR_NUMBER}.lock"
+
+# ロックファイルのクリーンアップを設定
+# shellcheck disable=SC2317
+cleanup() {
+  rm -f "$LOCK_FILE"
+}
+trap cleanup EXIT
+
+# ロック取得（既に実行中の場合はエラー）
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+  echo "Already running for PR #${PR_NUMBER}" >&2
+  exit 1
+fi
+
+# ログ開始
+{
+  echo "=== $(date -Iseconds) ==="
+  echo "Waiting for PR #${PR_NUMBER} to be merged or closed"
+} >> "$LOG_FILE"
+
+# リポジトリ情報取得（--repo 指定があればそれを使う。なければローカル origin）
+if [[ -n "$REPO_SLUG" ]]; then
+  OWNER="${REPO_SLUG%%/*}"
+  REPO="${REPO_SLUG##*/}"
+else
+  OWNER=$(gh repo view --json owner --jq '.owner.login')
+  REPO=$(gh repo view --json name --jq '.name')
+fi
+
+echo "Repository: ${OWNER}/${REPO}" >> "$LOG_FILE"
+
+# 待機パラメータ
+MAX_WAIT=1800  # 30 分
+INTERVAL=30    # 30 秒
+ELAPSED=0
+
+# PR 状態を取得する関数
+get_pr_state() {
+  if [[ -n "$REPO_ARG" ]]; then
+    gh pr view "$PR_NUMBER" --repo "$REPO_SLUG" --json state -q .state 2>> "$LOG_FILE"
+  else
+    gh pr view "$PR_NUMBER" --json state -q .state 2>> "$LOG_FILE"
+  fi
+}
+
+# tmux セッションに通知を送る関数
+notify_tmux() {
+  local message="$1"
+  local session
+  if ! session=$(tmux display-message -p '#{session_name}' 2>/dev/null); then
+    return 0
+  fi
+  tmux send-keys -t "$session" "$message" && sleep 3 && tmux send-keys -t "$session" Enter
+}
+
+# Discord 通知を送る関数
+notify_discord() {
+  local title="$1"
+  local desc="$2"
+  local SCRIPT_DIR="$HOME/.claude/scripts/completion-notify"
+  if [[ -x "$SCRIPT_DIR/send-discord-notification.sh" ]]; then
+    local payload
+    payload=$(jq -n \
+      --arg title "$title" \
+      --arg desc "$desc" \
+      --arg url "https://github.com/${OWNER}/${REPO}/pull/${PR_NUMBER}" \
+      '{
+        embeds: [{
+          title: $title,
+          description: $desc,
+          url: $url,
+          color: 3447003
+        }]
+      }')
+    printf '%s\n' "${payload}" | "$SCRIPT_DIR/send-discord-notification.sh" >> "$LOG_FILE" 2>&1 &
+    echo "Discord notification sent" >> "$LOG_FILE"
+  fi
+}
+
+# 初回状態を取得
+if ! INITIAL_STATE=$(get_pr_state); then
+  echo "Error: Failed to get initial PR state" >> "$LOG_FILE"
+  echo "Error: Failed to get initial PR state" >&2
+  exit 1
+fi
+
+echo "Initial state: ${INITIAL_STATE}" >> "$LOG_FILE"
+
+# クリーンアップ呼び出し用のターゲット文字列を決定する
+# --repo が local origin と異なる場合は URL 形式、そうでなければ PR 番号のみ
+if [[ -n "$REPO_SLUG" ]]; then
+  CLEANUP_TARGET="https://github.com/${OWNER}/${REPO}/pull/${PR_NUMBER}"
+else
+  CLEANUP_TARGET="$PR_NUMBER"
+fi
+
+# 起動時点で既に MERGED/CLOSED の場合は即座に通知
+if [[ "$INITIAL_STATE" == "MERGED" || "$INITIAL_STATE" == "CLOSED" ]]; then
+  echo "PR is already ${INITIAL_STATE}" >> "$LOG_FILE"
+  DISCORD_MSG="PR #${PR_NUMBER} は既に ${INITIAL_STATE} 状態です。"
+  TMUX_CMD="/pr-cleanup ${CLEANUP_TARGET}"
+  echo "✅ ${DISCORD_MSG}"
+  echo "📝 ログ: ${LOG_FILE}"
+  notify_discord "PR Already ${INITIAL_STATE}" "${DISCORD_MSG}"
+  notify_tmux "${TMUX_CMD}"
+  exit 0
+fi
+
+# ポーリングループ
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+
+  if ! CURRENT_STATE=$(get_pr_state); then
+    echo "[$ELAPSED s] Warning: Failed to get current PR state" >> "$LOG_FILE"
+    continue
+  fi
+
+  echo "[$ELAPSED s] Current state: ${CURRENT_STATE}" >> "$LOG_FILE"
+
+  if [[ "$CURRENT_STATE" == "MERGED" || "$CURRENT_STATE" == "CLOSED" ]]; then
+    echo "PR transitioned to ${CURRENT_STATE}" >> "$LOG_FILE"
+
+    DISCORD_MSG="PR #${PR_NUMBER} が ${CURRENT_STATE} されました。"
+    TMUX_CMD="/pr-cleanup ${CLEANUP_TARGET}"
+    echo "✅ ${DISCORD_MSG}"
+    echo "📝 ログ: ${LOG_FILE}"
+    notify_discord "PR ${CURRENT_STATE}" "${DISCORD_MSG}"
+    notify_tmux "${TMUX_CMD}"
+    exit 0
+  fi
+done
+
+# タイムアウト
+TIMEOUT_MSG="PR #${PR_NUMBER}: ${MAX_WAIT} 秒以内にマージ/クローズが検知されませんでした。手動で確認してください。"
+echo "Timeout: No merge/close detected within ${MAX_WAIT}s" >> "$LOG_FILE"
+echo "⏱️ タイムアウト: ${TIMEOUT_MSG}"
+echo "📝 ログ: ${LOG_FILE}"
+notify_tmux "${TIMEOUT_MSG}"
+exit 0

--- a/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
+++ b/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -euo pipefail
 
@@ -32,19 +32,22 @@ mkdir -p "$LOG_DIR" "$LOCK_DIR"
 LOG_FILE="$LOG_DIR/wait-pr-close-${PR_NUMBER}.log"
 LOCK_FILE="$LOCK_DIR/wait-pr-close-${PR_NUMBER}.lock"
 
-# ロックファイルのクリーンアップを設定
-# shellcheck disable=SC2317
-cleanup() {
-  rm -f "$LOCK_FILE"
-}
-trap cleanup EXIT
-
 # ロック取得（既に実行中の場合はエラー）
 exec 200>"$LOCK_FILE"
 if ! flock -n 200; then
   echo "Already running for PR #${PR_NUMBER}" >&2
   exit 1
 fi
+
+# ロックファイルのクリーンアップを設定
+# ロック取得後に trap を張る。取得前に張ると、フロック競争に負けた側の
+# exit で勝った側のロックファイルが削除され、後続の別インスタンスが
+# 新しい inode に対して flock に成功し、多重起動排他が破られてしまう。
+# shellcheck disable=SC2317
+cleanup() {
+  rm -f "$LOCK_FILE"
+}
+trap cleanup EXIT
 
 # ログ開始
 {
@@ -121,7 +124,8 @@ fi
 echo "Initial state: ${INITIAL_STATE}" >> "$LOG_FILE"
 
 # クリーンアップ呼び出し用のターゲット文字列を決定する
-# --repo が local origin と異なる場合は URL 形式、そうでなければ PR 番号のみ
+# 新規セッションで起動される pr-cleanup はローカル origin の情報しか持たないため、
+# --repo でクロスリポジトリを指定した場合は PR 番号だけでは対象を解決できない
 if [[ -n "$REPO_SLUG" ]]; then
   CLEANUP_TARGET="https://github.com/${OWNER}/${REPO}/pull/${PR_NUMBER}"
 else


### PR DESCRIPTION
## 概要

`issue-pr` スキルに関する3件の Issue (#168, #169, #171) をまとめて1つの PR で対応する。

## 対応内容

### Issue #168: spec/plan の言語・承認確認の改善
- Phase 3（spec 作成）・Phase 7（plan 作成）に日本語で記載する旨の明示的な指示を追加
- spec 作成前に不要な「進めていいですか」的な確認をしないよう明記（要件確認の質問自体は許可）
- Phase 6（spec 承認）・Phase 10（plan 承認）の承認確認に Confluence の URL を必須で含めるよう修正し、選択肢を「承認する」/「ページコメントを参照して修正してほしい」に統一

### Issue #169: PR マージ/クローズのバックグラウンド監視とクリーンアップ
- 新規スキル `wait-for-pr-close` を追加。PR がマージ/クローズされるまで 30 秒間隔・最大 30 分でポーリングし、検知したら Discord 通知 + tmux 経由で `/pr-cleanup` を自動起動する
- 新規スキル `pr-cleanup` を追加。ワークツリー/ブランチの削除、ローカルのデフォルトブランチの更新、フォークの同期を行う汎用クリーンアップスキル（`issue-pr` 専用ではなく手動呼び出しも可能）
- `issue-pr/SKILL.md` に Phase 19「Launch Background Monitoring」を追加し、PR 作成後に `wait-for-pr-close` をバックグラウンド起動する

### Issue #171: フォークシナリオでの PR 作成先の明確化
- `issue-pr/SKILL.md` Phase 2 で Issue 自身が存在するリポジトリ（`ISSUE_OWNER`/`ISSUE_REPO`）を取得し、ローカルの `origin` がフォークで Issue が upstream にある場合は `upstream` リモートを追加/再利用してその defaultBranch にリベースするよう修正
- Phase 11（Issue コメント）・Phase 16（PR 作成）・Phase 17（PR 確認）で `--repo "$ISSUE_OWNER/$ISSUE_REPO"` を明示的に指定し、PR が Issue の存在するリポジトリに対して作成されるよう修正

## デプロイ後の注意

`chezmoi apply` 実行で以下が反映される:
- `~/.claude/skills/issue-pr/SKILL.md`（更新）
- `~/.claude/skills/wait-for-pr-close/`（新規）
- `~/.claude/skills/pr-cleanup/`（新規）

## レビュー対応

`/deep-review`（ローカル diff モード）を実施し、スコア 50 以上の指摘6件をすべて修正済み（shebang 統一、flock trap 順序修正、ドキュメント/実装の乖離解消、フェーズ数ハードコード除去、冗長コメント修正、エラーハンドリング追加）。

Closes #168
Closes #169
Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
