### PR TITLE
feat: wait-for-pr-close の待機時間を環境変数で可変にする

### DIFF
--- a/home/dot_claude/skills/wait-for-pr-close/SKILL.md
+++ b/home/dot_claude/skills/wait-for-pr-close/SKILL.md
@@ -38,8 +38,9 @@ omitted, the script targets the local `origin`.
   `WAIT_FOR_PR_CLOSE_INTERVAL` environment variable (seconds).
 - **Max wait time**: 24 hours (86400 seconds) by default. Override with the
   `WAIT_FOR_PR_CLOSE_MAX_WAIT` environment variable (seconds). Both
-  variables must be positive integers; invalid values cause the script to
-  exit with an error. On timeout, notifies via tmux and exits 0 (not an
+  variables must be positive decimal integers with no leading zero (e.g. `10`,
+  not `010`); invalid values cause the script to exit with an error. On
+  timeout, notifies via tmux and exits 0 (not an
   error) — the user can re-run this script later for a PR that takes even
   longer to merge.
 

--- a/home/dot_claude/skills/wait-for-pr-close/SKILL.md
+++ b/home/dot_claude/skills/wait-for-pr-close/SKILL.md
@@ -34,10 +34,14 @@ omitted, the script targets the local `origin`.
 ### Detection Logic
 
 - Polls `gh pr view <PR_NUMBER> [--repo <owner>/<repo>] --json state`
-- **Check interval**: 30 seconds
-- **Max wait time**: 30 minutes (60 checks). On timeout, notifies via tmux
-  and exits 0 (not an error) — the user can re-run this script later for a
-  PR that takes longer to merge.
+- **Check interval**: 30 seconds by default. Override with the
+  `WAIT_FOR_PR_CLOSE_INTERVAL` environment variable (seconds).
+- **Max wait time**: 24 hours (86400 seconds) by default. Override with the
+  `WAIT_FOR_PR_CLOSE_MAX_WAIT` environment variable (seconds). Both
+  variables must be positive integers; invalid values cause the script to
+  exit with an error. On timeout, notifies via tmux and exits 0 (not an
+  error) — the user can re-run this script later for a PR that takes even
+  longer to merge.
 
 ### Detection Condition
 
@@ -61,8 +65,9 @@ Exits successfully as soon as `state` is `MERGED` or `CLOSED`.
 
 ## Notes
 
-- Maximum wait time is 30 minutes; re-run manually for a PR that takes
-  longer.
+- Maximum wait time is 24 hours by default (`WAIT_FOR_PR_CLOSE_MAX_WAIT`);
+  re-run manually or increase the environment variable for a PR that takes
+  even longer.
 - Multiple instances for the same PR number are prevented by flock.
 - Check the log file for execution status.
 

--- a/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
+++ b/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
@@ -76,13 +76,13 @@ ELAPSED=0
 # 先頭 0 埋めの値（例: 010）は後段の算術展開 $(( )) で 8 進数として解釈され、
 # 意図しない値やエラーになるため、10 進数として先頭 0 を持たない形式のみ許可する
 if ! [[ "$MAX_WAIT" =~ ^(0|[1-9][0-9]*)$ ]] || [[ "$MAX_WAIT" -le 0 ]]; then
-  echo "Error: WAIT_FOR_PR_CLOSE_MAX_WAIT must be a positive integer" >> "$LOG_FILE"
-  echo "Error: WAIT_FOR_PR_CLOSE_MAX_WAIT must be a positive integer" >&2
+  echo "Error: WAIT_FOR_PR_CLOSE_MAX_WAIT must be a positive decimal integer with no leading zero, got: ${MAX_WAIT}" >> "$LOG_FILE"
+  echo "Error: WAIT_FOR_PR_CLOSE_MAX_WAIT must be a positive decimal integer with no leading zero, got: ${MAX_WAIT}" >&2
   exit 1
 fi
 if ! [[ "$INTERVAL" =~ ^(0|[1-9][0-9]*)$ ]] || [[ "$INTERVAL" -le 0 ]]; then
-  echo "Error: WAIT_FOR_PR_CLOSE_INTERVAL must be a positive integer" >> "$LOG_FILE"
-  echo "Error: WAIT_FOR_PR_CLOSE_INTERVAL must be a positive integer" >&2
+  echo "Error: WAIT_FOR_PR_CLOSE_INTERVAL must be a positive decimal integer with no leading zero, got: ${INTERVAL}" >> "$LOG_FILE"
+  echo "Error: WAIT_FOR_PR_CLOSE_INTERVAL must be a positive decimal integer with no leading zero, got: ${INTERVAL}" >&2
   exit 1
 fi
 

--- a/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
+++ b/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
@@ -66,10 +66,21 @@ fi
 
 echo "Repository: ${OWNER}/${REPO}" >> "$LOG_FILE"
 
-# 待機パラメータ
-MAX_WAIT=1800  # 30 分
-INTERVAL=30    # 30 秒
+# 待機パラメータ（環境変数で上書き可能。未設定時のデフォルトは
+# WAIT_FOR_PR_CLOSE_MAX_WAIT=86400（24 時間）、WAIT_FOR_PR_CLOSE_INTERVAL=30（30 秒））
+MAX_WAIT="${WAIT_FOR_PR_CLOSE_MAX_WAIT:-86400}"
+INTERVAL="${WAIT_FOR_PR_CLOSE_INTERVAL:-30}"
 ELAPSED=0
+
+# 待機パラメータの妥当性チェック（不正値をサイレントに無視しない）
+if ! [[ "$MAX_WAIT" =~ ^[0-9]+$ ]] || [[ "$MAX_WAIT" -le 0 ]]; then
+  echo "Error: WAIT_FOR_PR_CLOSE_MAX_WAIT must be a positive integer" >&2
+  exit 1
+fi
+if ! [[ "$INTERVAL" =~ ^[0-9]+$ ]] || [[ "$INTERVAL" -le 0 ]]; then
+  echo "Error: WAIT_FOR_PR_CLOSE_INTERVAL must be a positive integer" >&2
+  exit 1
+fi
 
 # PR 状態を取得する関数
 get_pr_state() {
@@ -145,8 +156,8 @@ if [[ "$INITIAL_STATE" == "MERGED" || "$INITIAL_STATE" == "CLOSED" ]]; then
 fi
 
 # ポーリングループ
-while [ $ELAPSED -lt $MAX_WAIT ]; do
-  sleep $INTERVAL
+while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+  sleep "$INTERVAL"
   ELAPSED=$((ELAPSED + INTERVAL))
 
   if ! CURRENT_STATE=$(get_pr_state); then

--- a/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
+++ b/home/dot_claude/skills/wait-for-pr-close/scripts/executable_wait-for-pr-close.sh
@@ -73,11 +73,15 @@ INTERVAL="${WAIT_FOR_PR_CLOSE_INTERVAL:-30}"
 ELAPSED=0
 
 # 待機パラメータの妥当性チェック（不正値をサイレントに無視しない）
-if ! [[ "$MAX_WAIT" =~ ^[0-9]+$ ]] || [[ "$MAX_WAIT" -le 0 ]]; then
+# 先頭 0 埋めの値（例: 010）は後段の算術展開 $(( )) で 8 進数として解釈され、
+# 意図しない値やエラーになるため、10 進数として先頭 0 を持たない形式のみ許可する
+if ! [[ "$MAX_WAIT" =~ ^(0|[1-9][0-9]*)$ ]] || [[ "$MAX_WAIT" -le 0 ]]; then
+  echo "Error: WAIT_FOR_PR_CLOSE_MAX_WAIT must be a positive integer" >> "$LOG_FILE"
   echo "Error: WAIT_FOR_PR_CLOSE_MAX_WAIT must be a positive integer" >&2
   exit 1
 fi
-if ! [[ "$INTERVAL" =~ ^[0-9]+$ ]] || [[ "$INTERVAL" -le 0 ]]; then
+if ! [[ "$INTERVAL" =~ ^(0|[1-9][0-9]*)$ ]] || [[ "$INTERVAL" -le 0 ]]; then
+  echo "Error: WAIT_FOR_PR_CLOSE_INTERVAL must be a positive integer" >> "$LOG_FILE"
   echo "Error: WAIT_FOR_PR_CLOSE_INTERVAL must be a positive integer" >&2
   exit 1
 fi


### PR DESCRIPTION
## 概要

`wait-for-pr-close.sh` の待機パラメータ（最大待機時間・ポーリング間隔）を環境変数で可変にし、デフォルトの最大待機時間を 30 分から 24 時間に変更します。

Closes #175

## 変更内容

- `MAX_WAIT`（最大待機時間）を環境変数 `WAIT_FOR_PR_CLOSE_MAX_WAIT` で上書き可能にし、デフォルトを 1800 秒（30 分）から 86400 秒（24 時間）に変更
- `INTERVAL`（ポーリング間隔）を環境変数 `WAIT_FOR_PR_CLOSE_INTERVAL` で上書き可能にし、デフォルトは 30 秒のまま維持
- 両環境変数に正の整数以外（非数値・0 以下・先頭 0 埋め）が指定された場合はサイレントに無視せず、エラーメッセージを出力してスクリプトを終了するバリデーションを追加
  - 先頭 0 埋めの値（例: `010`）は後段の bash 算術展開で 8 進数として誤解釈されるため、正規表現で明示的に拒否
  - バリデーションエラーはログファイルにも記録し、バックグラウンド実行時の原因追跡を可能にする
- `SKILL.md` の Detection Logic / Notes セクションを新しいデフォルト値と環境変数の説明に更新

## 呼び出し元との互換性

引数シグネチャ（`<PR_NUMBER> [--repo <owner>/<repo>]`）に変更はないため、`issue-pr` スキル Phase 19 など既存の呼び出し元は無修正で動作します。

## 動作確認

- `shellcheck` / `bash -n` によるチェック: クリーン
- デフォルト値・環境変数による上書き・不正値（非数値、0 以下、先頭 0 埋め）でのエラー終了を実スクリプト実行で確認
- 存在しない PR 番号に対する実行でエラーハンドリングを確認
- Docker（Alpine）コンテナ上での構文チェックを確認
- deep-review（ローカル diff モード）を実施し、スコア 50 以上の指摘（先頭 0 埋め値の 8 進数誤解釈、バリデーションエラーのログ未記録）を修正済み

## 参考ドキュメント

- Spec: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/4161539/Spec+-+Issue+175+wait-for-pr-close
- Plan: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/4227074/Plan+-+Issue+175+wait-for-pr-close