### PR TITLE
docs: Confluence アップロード時の文中改行禁止ルールを追記する

### DIFF
--- a/home/dot_claude/rules/confluence.md
+++ b/home/dot_claude/rules/confluence.md
@@ -77,3 +77,8 @@ Git/GitHub artifacts — only to documents whose primary purpose is to be read b
 - If MCP resolution (cloudId, space, page) fails, report the error to the user and ask how
   to proceed rather than guessing.
 - Uploaded content is still subject to `rules/security.md` — never include secrets.
+- **No mid-sentence line breaks in body text**: within a single Markdown paragraph, do not
+  insert a manual line break (hard-wrapping, e.g. at a fixed column width) in the middle of
+  a sentence. Write each sentence as one continuous line in the source Markdown; let the
+  renderer wrap it. This applies to prose paragraphs, not to intentionally structured
+  content (bullet lists, code blocks, tables), where one item/line per line is expected.

--- a/home/dot_claude/rules/confluence.md
+++ b/home/dot_claude/rules/confluence.md
@@ -77,8 +77,6 @@ Git/GitHub artifacts — only to documents whose primary purpose is to be read b
 - If MCP resolution (cloudId, space, page) fails, report the error to the user and ask how
   to proceed rather than guessing.
 - Uploaded content is still subject to `rules/security.md` — never include secrets.
-- **No mid-sentence line breaks in body text**: within a single Markdown paragraph, do not
-  insert a manual line break (hard-wrapping, e.g. at a fixed column width) in the middle of
-  a sentence. Write each sentence as one continuous line in the source Markdown; let the
-  renderer wrap it. This applies to prose paragraphs, not to intentionally structured
-  content (bullet lists, code blocks, tables), where one item/line per line is expected.
+- **No mid-sentence line breaks in body text**: within a single Markdown paragraph, do not insert a manual line break (hard-wrapping, e.g. at a fixed column width) in the middle of a sentence.
+  Write each sentence as one continuous line in the source Markdown; let the renderer wrap it.
+  This applies to prose paragraphs, not to intentionally structured content (bullet lists, code blocks, tables), where one item/line per line is expected.


### PR DESCRIPTION
## 概要

Confluence へアップロードする Markdown ドキュメント（spec/plan 等）の本文に、意味的に不自然な位置での手動改行（文中改行）が混入する問題への対処として、`rules/confluence.md` にルールを追記する。

## 変更内容

- 散文の段落内で、文の途中に手動改行を挿入しないルールを明記。
- 箇条書き・コードブロック・表など、意図的に1行1項目である構造化コンテンツは対象外であることを明記。

Issue #189 系列の作業中に発覚した、spec ドキュメント自体に文中改行が混入していた事例を受けての追加。