### PR TITLE
feat: deep-review のレビュアーをファイル化し、プロジェクト独自観点の拡張ポイントを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,17 +235,37 @@ Jira チケットを確認し、対応のためのブランチを作成して PR
 
 ### レビュー観点
 
-| 観点 | 内容 |
-|---|---|
-| CLAUDE.md 準拠 | CLAUDE.md / rules の指示との整合性 |
-| バグ・正確性 | 変更差分中心の大きなバグの検出 |
-| git 履歴 | blame・log を踏まえた問題 |
-| 過去 PR コメント | 同ファイルへの過去の指摘との照合（PR モードのみ）|
-| コード内コメント整合 | docstring・コメントの指示との整合 |
-| セキュリティ | 入力検証・認可・シークレット漏洩・AI-PR 固有リスク |
-| パフォーマンス | 不要ループ・N+1・ホットパスへの影響 |
-| サイレント障害 | エラー握り潰し・不適切なフォールバック |
-| 型設計・テスト | 不変条件の表現・重要パスのテスト欠如 |
+固定レビュアー9件は `home/dot_claude/skills/deep-review/reviewers/*.md` に1ファイル1観点で定義されており、`chezmoi apply` で `~/.claude/skills/deep-review/reviewers/*.md` にデプロイされる。
+
+| 観点 | 内容 | 定義ファイル |
+|---|---|---|
+| CLAUDE.md 準拠 | CLAUDE.md / rules の指示との整合性 | `reviewers/a-claude-md-compliance.md` |
+| バグ・正確性 | 変更差分中心の大きなバグの検出 | `reviewers/b-bugs-correctness.md` |
+| git 履歴 | blame・log を踏まえた問題 | `reviewers/c-git-history.md` |
+| 過去 PR コメント | 同ファイルへの過去の指摘との照合（PR モードのみ）| `reviewers/d-past-pr-comments.md` |
+| コード内コメント整合 | docstring・コメントの指示との整合 | `reviewers/e-code-comment-quality.md` |
+| セキュリティ | 入力検証・認可・シークレット漏洩・AI-PR 固有リスク | `reviewers/f-security.md` |
+| パフォーマンス | 不要ループ・N+1・ホットパスへの影響 | `reviewers/g-performance.md` |
+| サイレント障害 | エラー握り潰し・不適切なフォールバック | `reviewers/h-error-handling.md` |
+| 型設計・テスト | 不変条件の表現・重要パスのテスト欠如 | `reviewers/i-type-design-tests.md` |
+
+### プロジェクト固有レビュアーの追加
+
+`deep-review` を使う各リポジトリは、固定9観点に加えて自リポジトリ独自のレビュー観点を追加できる。レビュー対象リポジトリのルート（`git rev-parse --show-toplevel` で解決）に `.claude/deep-review-reviewers/*.md` を配置すると、`/deep-review` 実行時に自動検出されて既存レビュアーと並列に起動される。
+
+```markdown
+---
+name: my-custom-rule
+title: 独自の観点
+applies_to: all        # all | pr-only（省略時は all）
+---
+
+## Scope
+
+このプロジェクト固有のレビュー観点をここに記述する。
+```
+
+追加数に厳密な上限はないが、目安として +3 程度を推奨する（4件以上検出された場合は `/deep-review` 実行時に一言案内が表示されるのみで、処理は継続する）。
 
 ### 強制対応フック
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Jira チケットを確認し、対応のためのブランチを作成して PR
 
 ### レビュー観点
 
-固定レビュアー9件は `home/dot_claude/skills/deep-review/reviewers/*.md` に1ファイル1観点で定義されており、`chezmoi apply` で `~/.claude/skills/deep-review/reviewers/*.md` にデプロイされる。
+固定レビュアー 9 件は `home/dot_claude/skills/deep-review/reviewers/*.md` に 1 ファイル 1 観点で定義されており、`chezmoi apply` で `~/.claude/skills/deep-review/reviewers/*.md` にデプロイされる。
 
 | 観点 | 内容 | 定義ファイル |
 |---|---|---|
@@ -251,7 +251,7 @@ Jira チケットを確認し、対応のためのブランチを作成して PR
 
 ### プロジェクト固有レビュアーの追加
 
-`deep-review` を使う各リポジトリは、固定9観点に加えて自リポジトリ独自のレビュー観点を追加できる。レビュー対象リポジトリのルート（`git rev-parse --show-toplevel` で解決）に `.claude/deep-review-reviewers/*.md` を配置すると、`/deep-review` 実行時に自動検出されて既存レビュアーと並列に起動される。
+`deep-review` を使う各リポジトリは、固定 9 観点に加えて自リポジトリ独自のレビュー観点を追加できる。レビュー対象リポジトリのルート（`git rev-parse --show-toplevel` で解決）に `.claude/deep-review-reviewers/*.md` を配置すると、`/deep-review` 実行時に自動検出されて既存レビュアーと並列に起動される。
 
 ```markdown
 ---
@@ -265,7 +265,7 @@ applies_to: all        # all | pr-only（省略時は all）
 このプロジェクト固有のレビュー観点をここに記述する。
 ```
 
-追加数に厳密な上限はないが、目安として +3 程度を推奨する（4件以上検出された場合は `/deep-review` 実行時に一言案内が表示されるのみで、処理は継続する）。
+追加数に厳密な上限はないが、目安として +3 程度を推奨する（4 件以上検出された場合は `/deep-review` 実行時に一言案内が表示されるのみで、処理は継続する）。
 
 ### 強制対応フック
 

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-review
-description: Deep code review of a GitHub PR or the local working diff. Runs independent, scoped sub-agent reviews defined in reviewers/*.md (CLAUDE.md adherence, bugs, git history, security incl. AI-PR risks, performance, silent failures, type design, tests) plus any project-specific reviewers found under <repo-root>/.claude/deep-review-reviewers/, scores each finding 0-100 for confidence, reports only findings with score >= 50, and for the user's own PRs auto-fixes, commits, pushes, and updates the PR body.
+description: Deep code review of a GitHub PR or the local working diff. Runs independent, scoped sub-agent reviews defined in reviewers/*.md plus any project-specific reviewers found under <repo-root>/.claude/deep-review-reviewers/, scores each finding 0-100 for confidence, reports only findings with score >= 50, and for the user's own PRs auto-fixes, commits, pushes, and updates the PR body.
 argument-hint: "[PR number or URL | omit to review the local working diff]"
 disable-model-invocation: false
 effort: high

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-review
-description: Deep code review of a GitHub PR or the local working diff. Runs independent, scoped sub-agent reviews (CLAUDE.md adherence, bugs, git history, security incl. AI-PR risks, performance, silent failures, type design, tests), scores each finding 0-100 for confidence, reports only findings with score >= 50, and for the user's own PRs auto-fixes, commits, pushes, and updates the PR body.
+description: Deep code review of a GitHub PR or the local working diff. Runs independent, scoped sub-agent reviews defined in reviewers/*.md (CLAUDE.md adherence, bugs, git history, security incl. AI-PR risks, performance, silent failures, type design, tests) plus any project-specific reviewers found under <repo-root>/.claude/deep-review-reviewers/, scores each finding 0-100 for confidence, reports only findings with score >= 50, and for the user's own PRs auto-fixes, commits, pushes, and updates the PR body.
 argument-hint: "[PR number or URL | omit to review the local working diff]"
 disable-model-invocation: false
 effort: high
@@ -44,9 +44,30 @@ Launch a Haiku sub-agent to retrieve and return:
 
 ### Step 4: Parallel perspective reviews
 
-**Launch the following 9 independent sub-agents (general-purpose) in parallel.**
+**Load reviewer definitions, then launch one independent general-purpose sub-agent per loaded reviewer, all in parallel.**
 
-Pass each agent: the diff, the change summary, and the list of CLAUDE.md / rules paths.
+1. Read every file under `~/.claude/skills/deep-review/reviewers/*.md` (the fixed reviewers, one file per perspective).
+2. Resolve the reviewed repository root with `git rev-parse --show-toplevel`. If `<root>/.claude/deep-review-reviewers/*.md` exists, read every file in it too (project-specific reviewers). If the directory does not exist, skip this step silently — no error.
+3. Filter by mode: in Local diff mode, exclude any reviewer file whose frontmatter `applies_to` is `pr-only`.
+4. If 4 or more project-specific reviewer files were found in step 2, print a one-line notice before proceeding, e.g.: "Note: N project-specific reviewers detected under .claude/deep-review-reviewers/; ~3 is the recommended guideline." This is advisory only — do not enforce a hard cap, proceed with all of them.
+5. Each reviewer file uses this format:
+
+   ```markdown
+   ---
+   id: <one-letter id, fixed reviewers only>
+   name: <slug>
+   title: <display title>
+   applies_to: all | pr-only
+   ---
+
+   ## Scope
+
+   <scope text, passed verbatim to the sub-agent>
+   ```
+
+   If `applies_to` is missing, empty, or not one of `all`/`pr-only`, treat it as `all`.
+
+6. Pass each sub-agent: the diff, the change summary, the list of CLAUDE.md / rules paths, the shared false-positive suppression instructions below, and the `## Scope` body of its reviewer file.
 Each agent returns findings as: *problem summary + evidence + file:line reference*.
 
 **Instructions passed to every agent (false-positive suppression):**
@@ -55,49 +76,13 @@ Do NOT report the following:
 - Pre-existing issues on lines not touched by this PR
 - Issues that linters, type checkers, or CI already catch (formatting, import errors, type errors, etc.)
 - Intentionally suppressed issues (lint-ignore comments, etc.)
-- General code quality concerns (test coverage, documentation) unless explicitly required in CLAUDE.md or explicitly listed as a specific agent's scope below (e.g. Agent e's redundant/stale-comment checks)
+- General code quality concerns (test coverage, documentation) unless explicitly required in CLAUDE.md or explicitly listed as a specific reviewer's scope (e.g. the `e-code-comment-quality.md` reviewer's redundant/stale-comment checks)
 - Functional changes that are clearly intentional given the broader context
 - Anything asserted without a concrete `file:line` citation
 
-**Agent scopes:**
+**Fixed reviewers:** see `~/.claude/skills/deep-review/reviewers/*.md` for the full list and scope of each (`a-claude-md-compliance`, `b-bugs-correctness`, `c-git-history`, `d-past-pr-comments` [PR mode only], `e-code-comment-quality`, `f-security`, `g-performance`, `h-error-handling`, `i-type-design-tests`).
 
-- **Agent a (CLAUDE.md compliance)**: Read the CLAUDE.md and rules files. Flag violations of instructions that are explicitly stated there. Remember: CLAUDE.md is guidance for Claude writing code, so not every rule applies during review. Only flag what CLAUDE.md explicitly calls out.
-
-- **Agent b (bugs / correctness)**: Shallow scan of the diff for large, obvious bugs. Avoid reading context beyond the changed lines. Skip nitpicks.
-
-- **Agent c (git history / blame)**: Check `git blame` and `git log` for changed files. Report issues only when historical context reveals a problem that is not visible from the diff alone.
-
-- **Agent d (past PR comments) [PR mode only]**: Find recently merged PRs that touched the same files (`gh pr list --state merged`). Check their review comments for concerns that may also apply here.
-
-- **Agent e (code-comment quality)**: Read code comments and docstrings in changed files. These checks are explicitly in scope for this agent, so the shared "general code quality concerns" suppression above does not apply to them. Flag:
-  - Cases where the implementation contradicts what a comment describes.
-  - Redundant comments that merely restate what the code already makes obvious (e.g. a comment saying "increment i by 1" directly above `i++`).
-  - Comments prone to becoming stale — descriptions of specific values, counts, enumerated lists, or implementation details duplicated from the code, which are likely to drift out of sync when the code changes.
-
-  If the same redundant/stale-prone pattern repeats many times in the diff, report it once with one or two representative `file:line` examples rather than listing every occurrence.
-
-- **Agent f (security)**: Check for:
-  - Missing input validation / sanitisation (XSS, SQL injection, etc.)
-  - Authorisation checks missing or at the wrong layer
-  - Hardcoded secrets, tokens, or API keys; sensitive data in logs
-  - **AI-PR specific risks:**
-    - Unvalidated external input interpolated into prompts (prompt injection)
-    - GitHub tokens with over-broad scopes
-    - Model output executed as shell commands without validation
-
-- **Agent g (performance)**: Check for:
-  - Unnecessary loops, duplicate queries (N+1), etc.
-  - Impact on hot paths or background jobs
-  - Synchronous operations that could easily be async
-
-- **Agent h (error handling / silent failures)**: Check for:
-  - Swallowed errors (empty catch blocks, `|| true`, etc.)
-  - Inappropriate fallbacks that hide real failures
-  - Loss of error information (discarded stack traces, etc.)
-
-- **Agent i (type design / tests)**: Check for:
-  - Type invariants not expressed correctly (null/undefined leaking into types, etc.)
-  - Missing tests for new features or critical paths — only when CLAUDE.md explicitly requires tests
+**Project-specific reviewers:** any repository can add up to roughly 3 additional reviewer files (soft guideline, not enforced) under `.claude/deep-review-reviewers/*.md` in its own repo root, using the same frontmatter format as above (`id` may be omitted for project-specific reviewers).
 
 ### Step 5: Confidence scoring
 
@@ -115,7 +100,7 @@ Score the issue on a scale of 0-100 based on your level of confidence that it is
 
 For issues sourced from CLAUDE.md, double-check that the CLAUDE.md actually mentions that specific issue before scoring high.
 
-Findings from an agent's explicitly listed scope (e.g. Agent e's redundant/stale-comment checks) are not "unscoped stylistic nitpicks" for the purpose of the 25-point band above — score them on the same real-world-impact basis as any other finding (how likely the comment is to mislead a future reader or drift from the code it describes).
+Findings from a reviewer's explicitly listed scope (e.g. the `e-code-comment-quality.md` reviewer's redundant/stale-comment checks) are not "unscoped stylistic nitpicks" for the purpose of the 25-point band above — score them on the same real-world-impact basis as any other finding (how likely the comment is to mislead a future reader or drift from the code it describes).
 
 Each agent must return the score in the format: `Score: <0-100>`
 (The Stop hook extracts scores using this exact format.)

--- a/home/dot_claude/skills/deep-review/reviewers/a-claude-md-compliance.md
+++ b/home/dot_claude/skills/deep-review/reviewers/a-claude-md-compliance.md
@@ -1,0 +1,10 @@
+---
+id: a
+name: claude-md-compliance
+title: CLAUDE.md compliance
+applies_to: all
+---
+
+## Scope
+
+Read the CLAUDE.md and rules files. Flag violations of instructions that are explicitly stated there. Remember: CLAUDE.md is guidance for Claude writing code, so not every rule applies during review. Only flag what CLAUDE.md explicitly calls out.

--- a/home/dot_claude/skills/deep-review/reviewers/b-bugs-correctness.md
+++ b/home/dot_claude/skills/deep-review/reviewers/b-bugs-correctness.md
@@ -1,0 +1,10 @@
+---
+id: b
+name: bugs-correctness
+title: Bugs / correctness
+applies_to: all
+---
+
+## Scope
+
+Shallow scan of the diff for large, obvious bugs. Avoid reading context beyond the changed lines. Skip nitpicks.

--- a/home/dot_claude/skills/deep-review/reviewers/c-git-history.md
+++ b/home/dot_claude/skills/deep-review/reviewers/c-git-history.md
@@ -1,0 +1,10 @@
+---
+id: c
+name: git-history
+title: Git history / blame
+applies_to: all
+---
+
+## Scope
+
+Check `git blame` and `git log` for changed files. Report issues only when historical context reveals a problem that is not visible from the diff alone.

--- a/home/dot_claude/skills/deep-review/reviewers/d-past-pr-comments.md
+++ b/home/dot_claude/skills/deep-review/reviewers/d-past-pr-comments.md
@@ -1,0 +1,10 @@
+---
+id: d
+name: past-pr-comments
+title: Past PR comments
+applies_to: pr-only
+---
+
+## Scope
+
+Find recently merged PRs that touched the same files (`gh pr list --state merged`). Check their review comments for concerns that may also apply here.

--- a/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
+++ b/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
@@ -1,0 +1,16 @@
+---
+id: e
+name: code-comment-quality
+title: Code-comment quality
+applies_to: all
+---
+
+## Scope
+
+Read code comments and docstrings in changed files. These checks are explicitly in scope for this agent, so the shared "general code quality concerns" suppression in SKILL.md does not apply to them. Flag:
+
+- Cases where the implementation contradicts what a comment describes.
+- Redundant comments that merely restate what the code already makes obvious (e.g. a comment saying "increment i by 1" directly above `i++`).
+- Comments prone to becoming stale — descriptions of specific values, counts, enumerated lists, or implementation details duplicated from the code, which are likely to drift out of sync when the code changes.
+
+If the same redundant/stale-prone pattern repeats many times in the diff, report it once with one or two representative `file:line` examples rather than listing every occurrence.

--- a/home/dot_claude/skills/deep-review/reviewers/f-security.md
+++ b/home/dot_claude/skills/deep-review/reviewers/f-security.md
@@ -1,0 +1,18 @@
+---
+id: f
+name: security
+title: Security
+applies_to: all
+---
+
+## Scope
+
+Check for:
+
+- Missing input validation / sanitisation (XSS, SQL injection, etc.)
+- Authorisation checks missing or at the wrong layer
+- Hardcoded secrets, tokens, or API keys; sensitive data in logs
+- **AI-PR specific risks:**
+  - Unvalidated external input interpolated into prompts (prompt injection)
+  - GitHub tokens with over-broad scopes
+  - Model output executed as shell commands without validation

--- a/home/dot_claude/skills/deep-review/reviewers/g-performance.md
+++ b/home/dot_claude/skills/deep-review/reviewers/g-performance.md
@@ -1,0 +1,14 @@
+---
+id: g
+name: performance
+title: Performance
+applies_to: all
+---
+
+## Scope
+
+Check for:
+
+- Unnecessary loops, duplicate queries (N+1), etc.
+- Impact on hot paths or background jobs
+- Synchronous operations that could easily be async

--- a/home/dot_claude/skills/deep-review/reviewers/h-error-handling.md
+++ b/home/dot_claude/skills/deep-review/reviewers/h-error-handling.md
@@ -1,0 +1,14 @@
+---
+id: h
+name: error-handling
+title: Error handling / silent failures
+applies_to: all
+---
+
+## Scope
+
+Check for:
+
+- Swallowed errors (empty catch blocks, `|| true`, etc.)
+- Inappropriate fallbacks that hide real failures
+- Loss of error information (discarded stack traces, etc.)

--- a/home/dot_claude/skills/deep-review/reviewers/i-type-design-tests.md
+++ b/home/dot_claude/skills/deep-review/reviewers/i-type-design-tests.md
@@ -1,0 +1,13 @@
+---
+id: i
+name: type-design-tests
+title: Type design / tests
+applies_to: all
+---
+
+## Scope
+
+Check for:
+
+- Type invariants not expressed correctly (null/undefined leaking into types, etc.)
+- Missing tests for new features or critical paths — only when CLAUDE.md explicitly requires tests


### PR DESCRIPTION
## 概要

Closes #191

`deep-review` スキルの `SKILL.md` にインライン記述されていた9つの固定レビュー観点（Agent a〜i）を `home/dot_claude/skills/deep-review/reviewers/*.md` の定義ファイルへ切り出し、レビュー対象リポジトリ側で独自レビュアーを追加できる拡張ポイント（`.claude/deep-review-reviewers/*.md`）を設けました。

## 変更内容

- `home/dot_claude/skills/deep-review/reviewers/` に9件の固定レビュアー定義ファイル（frontmatter + `## Scope`）を新規追加
- `home/dot_claude/skills/deep-review/SKILL.md` の Step 4 を、`reviewers/*.md` とプロジェクト固有の `.claude/deep-review-reviewers/*.md` を読み込んでサブエージェントを起動するローダー方式に書き換え
- `README.md` にレビュー観点と定義ファイルの対応表、プロジェクト固有レビュアー追加方法のセクションを追記

## 設計上のポイント

- `Skill` ツールからの呼び出しは引き続き単一の `skill_name: deep-review` であり、`deep-review-immediate-fix.sh` / `deep-review-require-fixes.sh` フックの判定ロジック・`Score: <number>` 抽出契約には影響しません（個々のレビュアーを独立した Claude Code Skill として直接起動する変更ではありません）。
- 既存 Agent a〜i の観点テキストは意味を変えずに移設しています。
- プロジェクト固有レビュアーの追加数に厳密な上限はなく、+3件程度を目安とするソフトガイドラインです（4件以上でも処理は継続、案内メッセージが出るのみ）。

## 検証

- Docker 上（alpine + chezmoi）で `chezmoi apply` を実行し、`reviewers/*.md` 9件と更新後の `SKILL.md` が正しくデプロイされることを確認
- `reviewers/*.md` 全ファイルの frontmatter（`applies_to` を含む）を grep で検証し、`d-past-pr-comments.md` のみ `applies_to: pr-only` であることを確認
- `SKILL.md` に旧インライン記述（`Agent a (CLAUDE.md compliance)` 等）が残っていないことを確認
- 新しい Step 4 ローダーロジックのシミュレーションと、8種の固定レビュアー（PR専用の `d` を除く）に相当するサブエージェントを実際にこの差分に対して起動し、全て "No issues found" であることを確認

## ドキュメント

- Spec: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/5898279/Spec+-+deep-review+Issue+191
- Plan: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/6029446/Plan+-+deep-review+Issue+191

🤖 Generated with [Claude Code](https://claude.com/claude-code)