### PR TITLE
fix: limit-unlockedのリミット検出方式をtmux画面走査から会話ログ参照へ変更する

### DIFF
--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-# Claude Code のリミット到達・解除を tmux ペイン表示から検出し、Discord 通知とセッション再開を行う。
+# Claude Code のリミット到達・解除を、会話ログ (jsonl) に記録される構造化エラー情報から
+# 検出し、Discord 通知とセッション再開を行う。
+#
+# tmux ペインの画面表示テキストを走査する方式は、Bash ツール実行中などに前面プロセスや
+# 表示内容が一時的に切り替わることで誤検出（フラッピング）が起きるため採用しない。
+# 代わりに、tmux セッションが起動している claude プロセスの pid から会話ログの
+# jsonl ファイルを一意に特定し、その内容でリミット状態を判定する。
 cd "$(dirname "$0")" || exit 1
 
 mkdir -p "$HOME/.claude/scripts/limit-unlocked/data"
@@ -10,35 +16,96 @@ touch "$STATE_FILE"
 # shellcheck source=/dev/null
 source ./.env
 
-# Claude Code がリミット到達時にペインへ表示するバナー文言（セッション/ウィークリー両方、
-# および過去バージョンの "usage limit reached" 形式にも対応する）
-LIMIT_PATTERN="hit (your|its) (session|weekly) (usage )?limit|usage limit reached"
+# tmux セッション名から、対応する claude プロセスが書き込んでいる会話ログ (jsonl) の
+# パスを特定する。claude は CLAUDE_CONFIG_DIR ごと（例: ~/.claude と ~/.claude-work）に
+# sessions/<pid>.json（pid → sessionId/cwd の対応表）を別々に持つため両方を確認する。
+resolve_jsonl_path() {
+    local session="$1" pane_pid claude_pid config_dir session_file dir session_id cwd encoded_cwd
+
+    pane_pid=$(tmux display-message -t "$session" -p '#{pane_pid}' 2>/dev/null) || return 1
+    claude_pid=$(pgrep -P "$pane_pid" -f "^claude" | head -1)
+    [ -n "$claude_pid" ] || return 1
+
+    config_dir=$(tr '\0' '\n' < "/proc/${claude_pid}/environ" 2>/dev/null | sed -n 's/^CLAUDE_CONFIG_DIR=//p')
+    session_file=""
+    for dir in "$config_dir" "$HOME/.claude" "$HOME/.claude-work"; do
+        [ -n "$dir" ] || continue
+        if [ -f "$dir/sessions/${claude_pid}.json" ]; then
+            session_file="$dir/sessions/${claude_pid}.json"
+            break
+        fi
+    done
+    [ -n "$session_file" ] || return 1
+
+    session_id=$(jq -r '.sessionId // empty' "$session_file" 2>/dev/null)
+    cwd=$(jq -r '.cwd // empty' "$session_file" 2>/dev/null)
+    [ -n "$session_id" ] || return 1
+
+    # プロジェクトディレクトリ名は cwd の "/" と "." を "-" に置き換えたもの
+    encoded_cwd=$(echo "$cwd" | sed 's/[\/.]/-/g')
+    echo "$HOME/.claude/projects/${encoded_cwd}/${session_id}.jsonl"
+}
+
+# jsonl ファイルの直近の実メッセージ（assistant/user。system 等の内部イベントは無視する）を見て、
+# リミット到達中かどうかと再開予定時刻(epoch)を判定する。
+# 標準出力: "<is_limited:0|1>\t<reset_epoch>\t<reset_text>"
+check_limit_status() {
+    local jsonl="$1" last_msg is_err text ts reset_time tz reset_epoch msg_epoch fallback_seconds
+
+    [ -f "$jsonl" ] || { echo -e "0\t-\t-"; return; }
+
+    last_msg=$(jq -c 'select(.type == "assistant" or .type == "user")' "$jsonl" 2>/dev/null | tail -1)
+    [ -n "$last_msg" ] || { echo -e "0\t-\t-"; return; }
+
+    is_err=$(echo "$last_msg" | jq -r '((.isApiErrorMessage == true) and (.error == "rate_limit"))' 2>/dev/null)
+    if [ "$is_err" != "true" ]; then
+        echo -e "0\t-\t-"
+        return
+    fi
+
+    text=$(echo "$last_msg" | jq -r '.message.content[0].text // ""' 2>/dev/null)
+    ts=$(echo "$last_msg" | jq -r '.timestamp // ""' 2>/dev/null)
+    msg_epoch=$(date -d "$ts" +%s 2>/dev/null)
+
+    reset_time=$(echo "$text" | grep -oiE '[0-9]{1,2}:[0-9]{2}[ap]m' | head -1)
+    tz=$(echo "$text" | grep -oiE '\([^)]+\)' | head -1 | tr -d '()')
+    reset_epoch=""
+    if [ -n "$reset_time" ] && [ -n "$tz" ]; then
+        reset_epoch=$(TZ="$tz" date -d "$reset_time" +%s 2>/dev/null)
+        if [ -n "$msg_epoch" ] && [ -n "$reset_epoch" ] && [ "$reset_epoch" -le "$msg_epoch" ]; then
+            # 指定時刻が既に過ぎている場合は翌日分を指しているとみなす
+            reset_epoch=$(TZ="$tz" date -d "$reset_time tomorrow" +%s 2>/dev/null)
+        fi
+    fi
+
+    if [ -z "$reset_epoch" ] && [ -n "$msg_epoch" ]; then
+        # 文言からの時刻抽出に失敗した場合のフォールバック。
+        # weekly limit は 7 日、session limit は 5 時間で再開されるのが通例
+        if echo "$text" | grep -qi "weekly"; then
+            fallback_seconds=604800
+        else
+            fallback_seconds=18000
+        fi
+        reset_epoch=$((msg_epoch + fallback_seconds))
+    fi
+
+    echo -e "1\t${reset_epoch:--}\t${text}"
+}
 
 # 現在リミット中の tmux セッション一覧を検出し、$NEW_STATE_FILE に書き出す
 detect_limited_sessions() {
     : > "$NEW_STATE_FILE"
 
     for session in $(tmux list-sessions -F "#{session_name}" 2>/dev/null); do
-        cmd=$(tmux display-message -t "$session" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
-        if [ "$cmd" != "claude" ]; then
-            # Bash ツール実行中などは前面プロセスが一時的に claude 以外（bash 等）になる。
-            # この瞬間だけを見て「解除された」と誤判定すると、resume_session が誤発火して
-            # ユーザーの実ターミナルに誤ったキー入力を送ってしまうため、前回の記録があれば
-            # そのまま引き継ぎ、確実に claude 表示へ戻ったタイミングで再判定する
-            prev_line=$(awk -F'\t' -v s="$session" '$1 == s { print; exit }' "$STATE_FILE" 2>/dev/null)
-            [ -n "$prev_line" ] && echo "$prev_line" >> "$NEW_STATE_FILE"
-            continue
-        fi
+        local jsonl status_line is_limited reset_epoch reset_text cwd
+        jsonl=$(resolve_jsonl_path "$session") || continue
+
+        status_line=$(check_limit_status "$jsonl")
+        IFS=$'\t' read -r is_limited reset_epoch reset_text <<< "$status_line"
+        [ "$is_limited" = "1" ] || continue
 
         cwd=$(tmux display-message -t "$session" -p '#{pane_current_path}' 2>/dev/null || echo "unknown")
-        # -S を指定せず現在の可視画面のみを対象にする。スクロールバック履歴まで含めると、
-        # 過去の調査出力などに含まれる文言を誤検出する（例: このバナー文言自体を出力したログ）
-        pane_text=$(tmux capture-pane -t "$session" -p 2>/dev/null)
-
-        if echo "$pane_text" | grep -qiE "$LIMIT_PATTERN"; then
-            reset_info=$(echo "$pane_text" | grep -oiE "resets [0-9:]+[ap]m \([^)]+\)" | tail -1)
-            echo -e "${session}\t${cwd}\t${reset_info}" >> "$NEW_STATE_FILE"
-        fi
+        echo -e "${session}\t${cwd}\t${reset_epoch}\t${reset_text}" >> "$NEW_STATE_FILE"
     done
 
     sort -u "$NEW_STATE_FILE" -o "$NEW_STATE_FILE"
@@ -62,52 +129,59 @@ send_discord() {
     curl -s -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL" >/dev/null
 }
 
-# 指定した tmux セッションに再開キーを送る
+# 指定した tmux セッションに再開キーを送る。
+# ウィンドウ/ペイン番号を固定せずセッション名のみを指定し、tmux の base-index 設定
+# （0 始まりとは限らない）に依存せず常にアクティブなウィンドウ・ペインへ送信する
 resume_session() {
     local session="$1"
-    # ウィンドウ/ペイン番号を固定せずセッション名のみを指定する。
-    # tmux の base-index 設定（0 始まりとは限らない）に依存せず、
-    # 常にそのセッションの現在アクティブなウィンドウ・ペインへ送信するため
     tmux send-keys -t "$session" "続けてください"
     sleep 1
     tmux send-keys -t "$session" Enter
 }
 
-# セッション名・作業ディレクトリの組み合わせが対象ファイルに存在するか確認する
+# セッション名が対象ファイルに存在するか確認する
 session_recorded_in() {
-    local session="$1" cwd="$2" file="$3"
-    grep -qF "$(printf '%s\t%s' "$session" "$cwd")" "$file" 2>/dev/null
+    local session="$1" file="$2"
+    awk -F'\t' -v s="$session" '$1 == s { found=1 } END { exit !found }' "$file" 2>/dev/null
 }
 
 detect_limited_sessions
+now=$(date +%s)
 
 # 新規にリミットへ到達したセッションを通知する
-while IFS=$'\t' read -r session cwd reset_info; do
+while IFS=$'\t' read -r session cwd reset_epoch reset_text; do
     [ -n "$session" ] || continue
-    if ! session_recorded_in "$session" "$cwd" "$STATE_FILE"; then
+    if ! session_recorded_in "$session" "$STATE_FILE"; then
         echo "Limit detected: $session ($cwd)"
         description="${cwd} (session: ${session}) が利用制限に達しました。"
-        [ -n "$reset_info" ] && description="${description}"$'\n'"${reset_info}"
+        [ -n "$reset_text" ] && [ "$reset_text" != "-" ] && description="${description}"$'\n'"${reset_text}"
         send_discord \
             "Claude Code のリミット到達" \
             "$description" \
             15158332 # 赤系色
     fi
+
+    # 再開予定時刻を過ぎてもまだリミット中の場合は再開を試みる。
+    # 再開に成功していれば、次回ポーリング時には会話ログの直近メッセージが
+    # 送信した「続けてください」に置き換わり is_limited が自然に 0 になるため、
+    # 再開済みかどうかを別途記録しなくても二重送信にはならない
+    if [ "$reset_epoch" != "-" ] && [ "$now" -ge "$reset_epoch" ]; then
+        echo "Resuming: $session ($cwd)"
+        resume_session "$session"
+    fi
 done < "$NEW_STATE_FILE"
 
-# リミットが解除された（前回は記録されていたが今回は検出されなかった）セッションを通知・再開する
-while IFS=$'\t' read -r session cwd reset_info; do
+# リミットが解除された（前回は記録されていたが今回は検出されなかった）セッションを通知する
+while IFS=$'\t' read -r session cwd reset_epoch reset_text; do
     [ -n "$session" ] || continue
-    session_recorded_in "$session" "$cwd" "$NEW_STATE_FILE" && continue # まだリミット中
+    session_recorded_in "$session" "$NEW_STATE_FILE" && continue # まだリミット中
 
-    # tmux セッション自体が閉じられている場合は再開できないため通知のみスキップする
     if tmux has-session -t "$session" 2>/dev/null; then
         echo "Limit unlocked: $session ($cwd)"
         send_discord \
             "Claude Code のリミット解除" \
-            "${cwd} (session: ${session}) のリミットが経過し、再度利用可能になりました。" \
+            "${cwd} (session: ${session}) のリミットが解除されました。" \
             5814783 # 青系色
-        resume_session "$session"
     fi
 done < "$STATE_FILE"
 

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -1,107 +1,106 @@
 #!/bin/bash
+# Claude Code のリミット到達・解除を tmux ペイン表示から検出し、Discord 通知とセッション再開を行う。
 cd "$(dirname "$0")" || exit 1
 
-TARGET_DIR="$HOME/.claude/projects"
-CURRENT_TS=$(date +%s)
-
 mkdir -p "$HOME/.claude/scripts/limit-unlocked/data"
-PAST_FILE="$HOME/.claude/scripts/limit-unlocked/data/past.txt"
-FUTURE_FILE="$HOME/.claude/scripts/limit-unlocked/data/future.txt"
-NOTIFIED_FILE="$HOME/.claude/scripts/limit-unlocked/data/notified.txt"
+STATE_FILE="$HOME/.claude/scripts/limit-unlocked/data/limited_sessions.txt"
+NEW_STATE_FILE="${STATE_FILE}.new"
+touch "$STATE_FILE"
 
 # shellcheck source=/dev/null
 source ./.env
 
-: > "$PAST_FILE"
-: > "$FUTURE_FILE"
+# Claude Code がリミット到達時にペインへ表示するバナー文言（セッション/ウィークリー両方、
+# および過去バージョンの "usage limit reached" 形式にも対応する）
+LIMIT_PATTERN="hit (your|its) (session|weekly) (usage )?limit|usage limit reached"
 
-find "$TARGET_DIR" -type f -name "*.jsonl" | while read -r file; do
-    jq -c '
-      select(
-        .type == "assistant" and
-        .message.type == "message" and
-        (.message.content[0].text | type == "string") and
-        (.message.content[0].text | startswith("Claude AI usage limit reached|"))
-      ) |
-      {
-        cwd: .cwd,
-        ts: (.message.content[0].text | split("|")[1] | tonumber)
-      }
-    ' "$file" | while read -r line; do
-        cwd=$(echo "$line" | jq -r '.cwd')
-        ts=$(echo "$line" | jq -r '.ts')
+# 現在リミット中の tmux セッション一覧を検出し、$NEW_STATE_FILE に書き出す
+detect_limited_sessions() {
+    : > "$NEW_STATE_FILE"
 
-        if [ "$ts" -lt "$CURRENT_TS" ]; then
-            echo -e "$cwd\t$ts" >> "$PAST_FILE"
-        else
-            echo -e "$cwd\t$ts" >> "$FUTURE_FILE"
+    for session in $(tmux list-sessions -F "#{session_name}" 2>/dev/null); do
+        cmd=$(tmux display-message -t "$session" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
+        [ "$cmd" = "claude" ] || continue
+
+        cwd=$(tmux display-message -t "$session" -p '#{pane_current_path}' 2>/dev/null || echo "unknown")
+        # -S を指定せず現在の可視画面のみを対象にする。スクロールバック履歴まで含めると、
+        # 過去の調査出力などに含まれる文言を誤検出する（例: このバナー文言自体を出力したログ）
+        pane_text=$(tmux capture-pane -t "$session" -p 2>/dev/null)
+
+        if echo "$pane_text" | grep -qiE "$LIMIT_PATTERN"; then
+            reset_info=$(echo "$pane_text" | grep -oiE "resets [0-9:]+[ap]m \([^)]+\)" | tail -1)
+            echo -e "${session}\t${cwd}\t${reset_info}" >> "$NEW_STATE_FILE"
         fi
     done
-done
 
-# 重複除去
-sort -u "$PAST_FILE" -o "$PAST_FILE"
-sort -u "$FUTURE_FILE" -o "$FUTURE_FILE"
-
-echo "=== 過去のもの ==="
-cat "$PAST_FILE"
-echo "=== 未来のもの ==="
-cat "$FUTURE_FILE"
-
-# 初回実行確認
-if [ ! -f "$NOTIFIED_FILE" ]; then
-    cp "$PAST_FILE" "$NOTIFIED_FILE"
-    exit 0
-fi
-
-send_to_claude_sessions() {
-  for session in $(tmux list-sessions -F "#{session_name}"); do
-    cmd=$(tmux display-message -t "$session" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
-    if [[ "$cmd" == "claude" ]]; then
-      echo "Sending keys to session $session"
-      tmux send-keys -t "$session:0.0" "続けてください"
-      sleep 1
-      tmux send-keys -t "$session:0.0" Enter
-      sleep 1
-    fi
-  done
+    sort -u "$NEW_STATE_FILE" -o "$NEW_STATE_FILE"
 }
 
-# 未通知イベント検出
-NEW_NOTIFICATIONS=$(grep -Fvxf "$NOTIFIED_FILE" "$PAST_FILE")
-if [ -n "$NEW_NOTIFICATIONS" ]; then
-    echo "=== 新しい過去イベント ==="
-    echo "$NEW_NOTIFICATIONS"
+# Discord Embed 通知を送信する
+send_discord() {
+    local title="$1" description="$2" color="$3"
+    local content=""
+    [ -n "$MENTION_USER_ID" ] && content="<@${MENTION_USER_ID}>"
 
-    # Discord WebhookでEmbed通知
-    while IFS=$'\t' read -r cwd ts; do
-        TITLE="Claude Code のリミット解除"
-        DESCRIPTION="${cwd} のリミットが経過し、再度利用可能になりました。"
-        COLOR=5814783 # 青系色
+    local payload
+    payload=$(jq -n \
+        --arg content "$content" \
+        --arg title "$title" \
+        --arg description "$description" \
+        --argjson color "$color" \
+        '{content: $content, embeds: [{title: $title, description: $description, color: $color}]}'
+    )
 
-        if [ -n "$MENTION_USER_ID" ]; then
-            CONTENT="<@${MENTION_USER_ID}>"
-        else
-            CONTENT=""
-        fi
+    curl -s -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL" >/dev/null
+}
 
-        PAYLOAD=$(jq -n \
-            --arg content "$CONTENT" \
-            --arg title "$TITLE" \
-            --arg description "$DESCRIPTION" \
-            --argjson color $COLOR \
-            '{content: $content, embeds: [{title: $title, description: $description, color: $color}]}'
-        )
+# 指定した tmux セッションに再開キーを送る
+resume_session() {
+    local session="$1"
+    # ウィンドウ/ペイン番号を固定せずセッション名のみを指定する。
+    # tmux の base-index 設定（0 始まりとは限らない）に依存せず、
+    # 常にそのセッションの現在アクティブなウィンドウ・ペインへ送信するため
+    tmux send-keys -t "$session" "続けてください"
+    sleep 1
+    tmux send-keys -t "$session" Enter
+}
 
-        curl -s -H "Content-Type: application/json" \
-             -X POST \
-             -d "$PAYLOAD" \
-             "$DISCORD_WEBHOOK_URL" >/dev/null
-    done <<< "$NEW_NOTIFICATIONS"
+# セッション名・作業ディレクトリの組み合わせが対象ファイルに存在するか確認する
+session_recorded_in() {
+    local session="$1" cwd="$2" file="$3"
+    grep -qF "$(printf '%s\t%s' "$session" "$cwd")" "$file" 2>/dev/null
+}
 
-    # tmuxセッションに通知
-    send_to_claude_sessions
+detect_limited_sessions
 
-    # 通知済みファイル更新
-    echo "$NEW_NOTIFICATIONS" >> "$NOTIFIED_FILE"
-fi
+# 新規にリミットへ到達したセッションを通知する
+while IFS=$'\t' read -r session cwd reset_info; do
+    [ -n "$session" ] || continue
+    if ! session_recorded_in "$session" "$cwd" "$STATE_FILE"; then
+        echo "Limit detected: $session ($cwd)"
+        description="${cwd} (session: ${session}) が利用制限に達しました。"
+        [ -n "$reset_info" ] && description="${description}"$'\n'"${reset_info}"
+        send_discord \
+            "Claude Code のリミット到達" \
+            "$description" \
+            15158332 # 赤系色
+    fi
+done < "$NEW_STATE_FILE"
+
+# リミットが解除された（前回は記録されていたが今回は検出されなかった）セッションを通知・再開する
+while IFS=$'\t' read -r session cwd reset_info; do
+    [ -n "$session" ] || continue
+    session_recorded_in "$session" "$cwd" "$NEW_STATE_FILE" && continue # まだリミット中
+
+    # tmux セッション自体が閉じられている場合は再開できないため通知のみスキップする
+    if tmux has-session -t "$session" 2>/dev/null; then
+        echo "Limit unlocked: $session ($cwd)"
+        send_discord \
+            "Claude Code のリミット解除" \
+            "${cwd} (session: ${session}) のリミットが経過し、再度利用可能になりました。" \
+            5814783 # 青系色
+        resume_session "$session"
+    fi
+done < "$STATE_FILE"
+
+mv "$NEW_STATE_FILE" "$STATE_FILE"

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -18,9 +18,12 @@ source ./.env
 
 # tmux セッション名から、対応する claude プロセスが書き込んでいる会話ログ (jsonl) の
 # パスを特定する。claude は CLAUDE_CONFIG_DIR ごと（例: ~/.claude と ~/.claude-work）に
-# sessions/<pid>.json（pid → sessionId/cwd の対応表）を別々に持つため両方を確認する。
+# sessions/<pid>.json（pid → sessionId の対応表）を別々に持つため両方を確認する。
+# jsonl のパスは projects/<encoded-cwd>/<sessionId>.jsonl だが、cwd のエンコード規則
+# （記号の置き換え方）は非公開かつ実装依存のため自前で再現せず、sessionId (UUID で一意)
+# を find で直接検索することでエンコード方式のずれによる特定失敗を避ける。
 resolve_jsonl_path() {
-    local session="$1" pane_pid claude_pid config_dir session_file dir session_id cwd encoded_cwd
+    local session="$1" pane_pid claude_pid config_dir session_file dir session_id
 
     pane_pid=$(tmux display-message -t "$session" -p '#{pane_pid}' 2>/dev/null) || return 1
     claude_pid=$(pgrep -P "$pane_pid" -f "^claude" | head -1)
@@ -38,12 +41,12 @@ resolve_jsonl_path() {
     [ -n "$session_file" ] || return 1
 
     session_id=$(jq -r '.sessionId // empty' "$session_file" 2>/dev/null)
-    cwd=$(jq -r '.cwd // empty' "$session_file" 2>/dev/null)
     [ -n "$session_id" ] || return 1
 
-    # プロジェクトディレクトリ名は cwd の "/" と "." を "-" に置き換えたもの
-    encoded_cwd=$(echo "$cwd" | sed 's/[\/.]/-/g')
-    echo "$HOME/.claude/projects/${encoded_cwd}/${session_id}.jsonl"
+    local jsonl
+    jsonl=$(find "$HOME/.claude/projects" -maxdepth 2 -name "${session_id}.jsonl" -print -quit 2>/dev/null)
+    [ -n "$jsonl" ] || return 1
+    echo "$jsonl"
 }
 
 # jsonl ファイルの直近の実メッセージ（assistant/user。system 等の内部イベントは無視する）を見て、
@@ -54,7 +57,9 @@ check_limit_status() {
 
     [ -f "$jsonl" ] || { echo -e "0\t-\t-"; return; }
 
-    last_msg=$(jq -c 'select(.type == "assistant" or .type == "user")' "$jsonl" 2>/dev/null | tail -1)
+    # jsonl は会話全体（数MB〜数十MBになりうる）だが直近の実メッセージが分かればよいため、
+    # 末尾のみを走査対象にして cron の定期実行での毎回フルパースを避ける
+    last_msg=$(tail -n 50 "$jsonl" | jq -c 'select(.type == "assistant" or .type == "user")' 2>/dev/null | tail -1)
     [ -n "$last_msg" ] || { echo -e "0\t-\t-"; return; }
 
     is_err=$(echo "$last_msg" | jq -r '((.isApiErrorMessage == true) and (.error == "rate_limit"))' 2>/dev/null)
@@ -66,6 +71,11 @@ check_limit_status() {
     text=$(echo "$last_msg" | jq -r '.message.content[0].text // ""' 2>/dev/null)
     ts=$(echo "$last_msg" | jq -r '.timestamp // ""' 2>/dev/null)
     msg_epoch=$(date -d "$ts" +%s 2>/dev/null)
+
+    # text は会話ログ由来の自由形式文字列。タブ・改行を含み得るため、そのまま
+    # 状態ファイル（タブ区切り 1 行 1 レコード）へ埋め込むとレコード構造が壊れる。
+    # 通知文言としての可読性は保ったまま、区切り文字だけを空白に置き換える
+    text=$(echo "$text" | tr '\t\n' '  ')
 
     reset_time=$(echo "$text" | grep -oiE '[0-9]{1,2}:[0-9]{2}[ap]m' | head -1)
     tz=$(echo "$text" | grep -oiE '\([^)]+\)' | head -1 | tr -d '()')
@@ -82,9 +92,9 @@ check_limit_status() {
         # 文言からの時刻抽出に失敗した場合のフォールバック。
         # weekly limit は 7 日、session limit は 5 時間で再開されるのが通例
         if echo "$text" | grep -qi "weekly"; then
-            fallback_seconds=604800
+            fallback_seconds=$((7 * 24 * 3600)) # 7 日
         else
-            fallback_seconds=18000
+            fallback_seconds=$((5 * 3600)) # 5 時間
         fi
         reset_epoch=$((msg_epoch + fallback_seconds))
     fi
@@ -98,7 +108,15 @@ detect_limited_sessions() {
 
     for session in $(tmux list-sessions -F "#{session_name}" 2>/dev/null); do
         local jsonl status_line is_limited reset_epoch reset_text cwd
-        jsonl=$(resolve_jsonl_path "$session") || continue
+        jsonl=$(resolve_jsonl_path "$session")
+        if [ -z "$jsonl" ]; then
+            # pgrep や /proc/<pid>/environ の読み取りは一時的に失敗しうる（他ツール実行中の
+            # 前面プロセス切り替わり等）。特定失敗を「リミット解除」と誤認しないよう、
+            # 前回記録があればそのまま引き継ぐ（本当にリミット中でなければ次回以降の
+            # 検出で正しく除外される）
+            awk -F'\t' -v s="$session" '$1 == s { print; exit }' "$STATE_FILE" >> "$NEW_STATE_FILE"
+            continue
+        fi
 
         status_line=$(check_limit_status "$jsonl")
         IFS=$'\t' read -r is_limited reset_epoch reset_text <<< "$status_line"
@@ -165,7 +183,7 @@ while IFS=$'\t' read -r session cwd reset_epoch reset_text; do
     # 再開に成功していれば、次回ポーリング時には会話ログの直近メッセージが
     # 送信した「続けてください」に置き換わり is_limited が自然に 0 になるため、
     # 再開済みかどうかを別途記録しなくても二重送信にはならない
-    if [ "$reset_epoch" != "-" ] && [ "$now" -ge "$reset_epoch" ]; then
+    if [[ "$reset_epoch" =~ ^[0-9]+$ ]] && [ "$now" -ge "$reset_epoch" ]; then
         echo "Resuming: $session ($cwd)"
         resume_session "$session"
     fi

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -20,7 +20,15 @@ detect_limited_sessions() {
 
     for session in $(tmux list-sessions -F "#{session_name}" 2>/dev/null); do
         cmd=$(tmux display-message -t "$session" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
-        [ "$cmd" = "claude" ] || continue
+        if [ "$cmd" != "claude" ]; then
+            # Bash ツール実行中などは前面プロセスが一時的に claude 以外（bash 等）になる。
+            # この瞬間だけを見て「解除された」と誤判定すると、resume_session が誤発火して
+            # ユーザーの実ターミナルに誤ったキー入力を送ってしまうため、前回の記録があれば
+            # そのまま引き継ぎ、確実に claude 表示へ戻ったタイミングで再判定する
+            prev_line=$(awk -F'\t' -v s="$session" '$1 == s { print; exit }' "$STATE_FILE" 2>/dev/null)
+            [ -n "$prev_line" ] && echo "$prev_line" >> "$NEW_STATE_FILE"
+            continue
+        fi
 
         cwd=$(tmux display-message -t "$session" -p '#{pane_current_path}' 2>/dev/null || echo "unknown")
         # -S を指定せず現在の可視画面のみを対象にする。スクロールバック履歴まで含めると、


### PR DESCRIPTION
## 概要

Claude Code のリミット到達・解除を検出する `limit-unlocked` スクリプトについて、以下の問題を修正した。

1. **繰り返し通知(フラッピング)バグ**: tmux 画面走査方式で、Bash ツール実行中など前面プロセスが一時的に `claude` 以外になった際、セッションが検出対象から脱落し「解除」と誤認 → 誤通知・誤再開が発生していた。
2. **アーキテクチャ上の限界**: 画面走査は前面プロセスの一時的な切り替わりだけでなく、サブプロセスの出力で画面内容自体が変化しうるため、根本的に不安定。

## 変更内容

- 検出方式を tmux 画面走査から、会話ログ (jsonl) に記録される構造化エラー情報 (`isApiErrorMessage`/`error:"rate_limit"`) の参照に変更。
- tmux セッション → claude プロセス pid → (`CLAUDE_CONFIG_DIR` を考慮した) `sessions/<pid>.json` → `sessionId` という経路で、対象セッションの会話ログ jsonl を特定。
- jsonl ファイルパスの特定は、cwd のエンコード規則を自前で再現せず `sessionId` (UUID) による `find` 直接検索に変更し、エンコード方式のずれによる特定失敗を回避。
- `resolve_jsonl_path` が一時的に失敗した場合は前回の状態を引き継ぎ、誤って「解除」と判定しないようにした。
- 会話ログ由来のテキストに含まれうるタブ・改行を除去し、状態ファイル(TSV)のレコード構造破壊を防止。
- 再開予定時刻の数値検証を追加。
- jsonl 全体のフルパースをやめ、末尾のみ走査するようにしてコストを削減。
- 再開キー送信はウィンドウ/ペイン番号を固定せずセッション名のみで行い、tmux の `base-index` 設定に依存しないようにした。

## 動作確認

- 実際に稼働中の5つの tmux セッション（リミット到達中3件、非到達2件）に対し、関数レベルの検証および crontab 経由の実行で、検出・Discord通知・再開キー送信・状態ファイル更新が期待通り動作することを確認。
- `bash -n` / `shellcheck` / 既存テストスイート (`tests/unit/test_notifications.sh`) はいずれも問題なし。
- `/deep-review` (ローカル diff モード) を実施し、スコア 50 以上の指摘（誤解除の再発防止、jsonl パス特定の脆弱性、状態ファイルのレコード破壊リスク、パフォーマンス、コメントの陳腐化）をすべて修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)