### PR TITLE
fix: resume時にrate-limit-optionsダイアログをEscapeで閉じてから再開する

### DIFF
--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -151,14 +151,11 @@ send_discord() {
 # ウィンドウ/ペイン番号を固定せずセッション名のみを指定し、tmux の base-index 設定
 # （0 始まりとは限らない）に依存せず常にアクティブなウィンドウ・ペインへ送信する
 #
-# リミット到達時、 Claude Code は "/rate-limit-options"
-# （"What do you want to do?" 選択メニュー）を自動的に開く。このメニューが残った
-# ままだと通常のテキスト入力を送っても再開に失敗する既知の挙動があるため
-# （詳細は anthropics/claude-code の Issue Tracker を参照）、ペイン内容に選択
-# メニューのテキストが実際に見つかった場合のみ、先に Escape を送ってメニューを
-# 閉じてから再開メッセージを送る。この確認は resume 時の一度きりであり、ファイル
-# 冒頭で述べた「画面走査を主判定方式にしない」方針（定期ポーリングでの誤検出
-# 防止が目的）とは矛盾しない
+# リミット到達時、 Claude Code は "What do you want to do?" という選択メニュー
+# （"/rate-limit-options"）を自動的に開き、残ったままだと通常のテキスト入力が
+# 効かなくなる既知の挙動があるため（詳細は anthropics/claude-code の Issue
+# Tracker を参照）、ペイン内容にそのメニューが実際に出ている場合のみ Escape で
+# 閉じてから再開メッセージを送る
 resume_session() {
     local session="$1" pane_content
 

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -153,15 +153,21 @@ send_discord() {
 #
 # リミット到達時、 Claude Code は "/rate-limit-options"
 # （"What do you want to do?" 選択メニュー）を自動的に開く。このメニューが残った
-# ままだと通常のテキスト入力を送っても再開に失敗する既知の挙動があるため、先に
-# Escape を送ってメニューを閉じてから再開メッセージを送る（既知の挙動の詳細は
-# anthropics/claude-code の Issue Tracker を参照）。メニューが表示されていない
-# 場合、 Escape の送信は実行中の応答を一時停止させる可能性があるが、この関数は
-# リミット中（＝応答生成中ではない）にのみ呼ばれるため無害
+# ままだと通常のテキスト入力を送っても再開に失敗する既知の挙動があるため
+# （詳細は anthropics/claude-code の Issue Tracker を参照）、ペイン内容に選択
+# メニューのテキストが実際に見つかった場合のみ、先に Escape を送ってメニューを
+# 閉じてから再開メッセージを送る。この確認は resume 時の一度きりであり、ファイル
+# 冒頭で述べた「画面走査を主判定方式にしない」方針（定期ポーリングでの誤検出
+# 防止が目的）とは矛盾しない
 resume_session() {
-    local session="$1"
-    tmux send-keys -t "$session" Escape
-    sleep 0.5
+    local session="$1" pane_content
+
+    pane_content=$(tmux capture-pane -t "$session" -p 2>/dev/null)
+    if echo "$pane_content" | grep -q "What do you want to do"; then
+        tmux send-keys -t "$session" Escape
+        sleep 0.5
+    fi
+
     tmux send-keys -t "$session" "続けてください"
     sleep 1
     tmux send-keys -t "$session" Enter

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -150,8 +150,18 @@ send_discord() {
 # 指定した tmux セッションに再開キーを送る。
 # ウィンドウ/ペイン番号を固定せずセッション名のみを指定し、tmux の base-index 設定
 # （0 始まりとは限らない）に依存せず常にアクティブなウィンドウ・ペインへ送信する
+#
+# リミット到達時、 Claude Code は "/rate-limit-options"
+# （"What do you want to do?" 選択メニュー）を自動的に開く。このメニューが残った
+# ままだと通常のテキスト入力を送っても再開に失敗する既知の挙動があるため、先に
+# Escape を送ってメニューを閉じてから再開メッセージを送る（既知の挙動の詳細は
+# anthropics/claude-code の Issue Tracker を参照）。メニューが表示されていない
+# 場合、 Escape の送信は実行中の応答を一時停止させる可能性があるが、この関数は
+# リミット中（＝応答生成中ではない）にのみ呼ばれるため無害
 resume_session() {
     local session="$1"
+    tmux send-keys -t "$session" Escape
+    sleep 0.5
     tmux send-keys -t "$session" "続けてください"
     sleep 1
     tmux send-keys -t "$session" Enter


### PR DESCRIPTION
## 概要

Claude Code は利用制限（session/weekly usage limit）到達時に、内部的に `/rate-limit-options` スラッシュコマンドを自動実行し、「What do you want to do?」という選択メニュー（rate-limit options dialog）を自動的に開く仕様がある。

このメニューが開いたままの状態だと、`check-notify.sh` の `resume_session()` が送信する通常のテキスト（「続けてください」）が正しく処理されず、再開に失敗する既知の挙動がある（`anthropics/claude-code` の Issue Tracker で複数報告あり: リミット解除後もメニューが残留し無駄なトークン消費や動作停止を招く不具合）。

## 変更内容

- `resume_session()` で、再開メッセージを送る前に `tmux capture-pane` でペイン内容を確認し、rate-limit-options メニューのテキスト（"What do you want to do"）が実際に表示されている場合のみ Escape キーを送って閉じるようにした。
  - 当初は無条件に Escape を送る実装だったが、「本当にダイアログが出ている保証がない」という指摘を受け、実際の表示内容を確認したうえでのみ Escape を送る方式に修正した。
  - この確認は resume 時の一度きりの判定であり、本スクリプトの主判定方式（jsonl 走査によるリミット状態検出）を画面走査に置き換えるものではない。ファイル冒頭のコメントで説明している「画面走査を主判定方式にしない」方針（定期ポーリングでの誤検出防止が目的）とは矛盾しない。

## 調査

- Web 調査により、Claude Code の rate-limit-options ダイアログの存在と、resume 後に ESC で閉じられることを確認（公式ドキュメントには選択肢の詳細な仕様の記載はなく、CHANGELOG・GitHub Issue・利用者記事から挙動を特定）。
- 本リポジトリの `/deep-review` をローカル差分モードで実行し、スコア 50 以上の指摘（コメント中の半角スペース欠落 2 件、引用句・括弧注釈の不自然な改行 2 件）を修正済み。

## 動作確認

- `bash -n` によるシンタックスチェックのみ実施（本番の rate limit 到達を意図的に再現するのは困難なため）。