### PR TITLE
fix: _claude_trust_cwd を CLAUDE_CONFIG_DIR を考慮した挙動に変更する

### DIFF
--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -10,12 +10,12 @@
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias claude 2>/dev/null
 # カレントディレクトリを Claude Code のワークスペース信頼済みディレクトリとして
-# ~/.claude.json に登録する。
+# ~/.claude.json（CLAUDE_CONFIG_DIR 設定時は $CLAUDE_CONFIG_DIR/.claude.json）に登録する。
 # Workspace Trust dialog の非永続化は --dangerously-skip-permissions 固有ではなく
 # Claude Code 全体の既知の問題（Issue #165 で検証済み）であり、hasTrustDialogAccepted が
 # 永続化されないと statusLine や hooks が無音でスキップされてしまう。auto モードでも同様に必要な対策。
 _claude_trust_cwd() {
-  local config="$HOME/.claude.json"
+  local config="${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json"
   [ -f "$config" ] || return 0
   command -v jq > /dev/null 2>&1 || return 0
   if [ "$(jq -r --arg p "$PWD" '.projects[$p].hasTrustDialogAccepted // false' "$config" 2> /dev/null)" != "true" ]; then

--- a/home/dot_claude/hooks/executable_trust-worktree-cwd.sh
+++ b/home/dot_claude/hooks/executable_trust-worktree-cwd.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # EnterWorktree の PostToolUse フックスクリプト。
 # フック入力 JSON の cwd (EnterWorktree 実行後の新しい作業ディレクトリ) を
-# Claude Code のワークスペース信頼済みディレクトリとして ~/.claude.json に登録する。
+# Claude Code のワークスペース信頼済みディレクトリとして
+# ~/.claude.json（CLAUDE_CONFIG_DIR 設定時は $CLAUDE_CONFIG_DIR/.claude.json）に登録する。
 # EnterWorktree はシェルラッパー (claude コマンド) 経由で起動されないため、
 # 90-ai-alias.zsh/sh の _claude_trust_cwd() が実行されず、
 # Workspace Trust dialog が発生する問題 (Issue #166) への対策。
@@ -13,7 +14,7 @@ CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2> /dev/null)
 
 [ -n "$CWD" ] || exit 0
 
-CONFIG="$HOME/.claude.json"
+CONFIG="${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json"
 [ -f "$CONFIG" ] || exit 0
 
 if [ "$(jq -r --arg p "$CWD" '.projects[$p].hasTrustDialogAccepted // false' "$CONFIG" 2> /dev/null)" != "true" ]; then

--- a/home/dot_zshrc.d/executable_90-ai-alias.zsh
+++ b/home/dot_zshrc.d/executable_90-ai-alias.zsh
@@ -10,12 +10,12 @@
 # 既存セッションで旧エイリアスが残存している場合に備えて、関数定義前に unalias する。
 unalias claude 2>/dev/null
 # カレントディレクトリを Claude Code のワークスペース信頼済みディレクトリとして
-# ~/.claude.json に登録する。
+# ~/.claude.json（CLAUDE_CONFIG_DIR 設定時は $CLAUDE_CONFIG_DIR/.claude.json）に登録する。
 # Workspace Trust dialog の非永続化は --dangerously-skip-permissions 固有ではなく
 # Claude Code 全体の既知の問題（Issue #165 で検証済み）であり、hasTrustDialogAccepted が
 # 永続化されないと statusLine や hooks が無音でスキップされてしまう。auto モードでも同様に必要な対策。
 _claude_trust_cwd() {
-  local config="$HOME/.claude.json"
+  local config="${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json"
   [ -f "$config" ] || return 0
   command -v jq > /dev/null 2>&1 || return 0
   if [ "$(jq -r --arg p "$PWD" '.projects[$p].hasTrustDialogAccepted // false' "$config" 2> /dev/null)" != "true" ]; then


### PR DESCRIPTION
## 概要

Closes #198

Trust dialog の事前承認を書き込む以下 3 箇所のスクリプトが `.claude.json` の場所を `$HOME/.claude.json` に決め打ちしており、`CLAUDE_CONFIG_DIR` を設定している環境（別アカウント運用など）で機能していなかった問題を修正する。

- `home/dot_zshrc.d/executable_90-ai-alias.zsh`
- `home/dot_bashrc.d/executable_90-ai-alias.sh`
- `home/dot_claude/hooks/executable_trust-worktree-cwd.sh`

## 変更内容

`.claude.json` のパス解決を `$HOME/.claude.json` から `${CLAUDE_CONFIG_DIR:-$HOME}/.claude.json` に変更し、あわせて説明コメントも更新した。`CLAUDE_CONFIG_DIR` 未設定時は従来通り `$HOME/.claude.json` にフォールバックするため後方互換性を維持する。

## 検証

- 3 ファイルとも `zsh -n` / `bash -n` の構文チェック OK
- `CLAUDE_CONFIG_DIR` 未設定・設定時の両方で手動実行し、意図した `.claude.json` が更新されることを確認
- Docker 上で `chezmoi apply` を実行し、`executable_` プレフィックス除去後も `CLAUDE_CONFIG_DIR` 対応が反映されていることを確認
- `/deep-review`(ローカル diff モード)実施済み、スコア 50 以上の指摘なし

## 参考資料

- Spec: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/6029580/Spec+-+Issue+198+_claude_trust_cwd+CLAUDE_CONFIG_DIR
- Plan: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/6029603/Plan+-+Issue+198+_claude_trust_cwd+CLAUDE_CONFIG_DIR

🤖 Generated with [Claude Code](https://claude.com/claude-code)