### PR TITLE
fix: Stop hookのsession-state.jsonをセッションIDでスコープし、レビュー警告の対応不要メモリ機構を追加

### DIFF
--- a/home/dot_claude/hooks/executable_deep-review-require-fixes.sh
+++ b/home/dot_claude/hooks/executable_deep-review-require-fixes.sh
@@ -29,12 +29,14 @@ STATE_TTL=86400
 CURRENT_TIME=$(date +%s)
 STATE_AGE=$(( CURRENT_TIME - STATE_TIMESTAMP ))
 
-# セッション ID が不一致 → 別セッションの古いデータ → TTL に関わらず信頼しない
-if [[ -n "$SESSION_ID" && -n "$STATE_SESSION" && "$SESSION_ID" != "$STATE_SESSION" ]]; then
+# セッション ID が一致しない、または SESSION_ID はあるのに STATE_SESSION が
+# 空（旧形式ファイル、他セッション由来の可能性あり）の場合は信頼しない
+if [[ -n "$SESSION_ID" && "$SESSION_ID" != "$STATE_SESSION" ]]; then
     exit 0
 fi
 
-# セッション ID が一致、または一方が空（後方互換）の場合は TTL のみで判定する
+# ここに到達するのは、SESSION_ID が一致した場合、または SESSION_ID 自体が
+# 空（stdin から取得できなかった後方互換ケース）の場合のみ。TTL で判定する
 if [[ "$STATE_AGE" -gt "$STATE_TTL" ]]; then
     exit 0
 fi

--- a/home/dot_claude/hooks/executable_deep-review-require-fixes.sh
+++ b/home/dot_claude/hooks/executable_deep-review-require-fixes.sh
@@ -29,12 +29,14 @@ STATE_TTL=86400
 CURRENT_TIME=$(date +%s)
 STATE_AGE=$(( CURRENT_TIME - STATE_TIMESTAMP ))
 
-# セッション ID が不一致かつ TTL 超過 → 別セッションの古いデータ → ブロックしない
-# セッション ID が一致する、または TTL 以内なら現在のセッションのデータとして扱う
+# セッション ID が不一致 → 別セッションの古いデータ → TTL に関わらず信頼しない
 if [[ -n "$SESSION_ID" && -n "$STATE_SESSION" && "$SESSION_ID" != "$STATE_SESSION" ]]; then
-    if [[ "$STATE_AGE" -gt "$STATE_TTL" ]]; then
-        exit 0
-    fi
+    exit 0
+fi
+
+# セッション ID が一致、または一方が空（後方互換）の場合は TTL のみで判定する
+if [[ "$STATE_AGE" -gt "$STATE_TTL" ]]; then
+    exit 0
 fi
 
 # スコア 50 以上の指摘が残っている場合はセッション終了をブロックする

--- a/home/dot_claude/hooks/executable_mark-review-declined.sh
+++ b/home/dot_claude/hooks/executable_mark-review-declined.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# ユーザーが明示的にレビュー未解決警告への対応を拒否した際、
+# 同一セッション内で同じ PR について再警告しないよう記録する。
+# require-review-thread-fixes.sh の Stop hook から参照される。
+
+PR_NUMBER="${1:?Usage: mark-review-declined.sh <PR_NUMBER>}"
+SESSION_ID="${CLAUDE_CODE_SESSION_ID:?CLAUDE_CODE_SESSION_ID is not set}"
+DATA_DIR="$HOME/.claude/data"
+DECLINE_FILE="$DATA_DIR/review-declined-${SESSION_ID}.json"
+
+mkdir -p "$DATA_DIR" && chmod 700 "$DATA_DIR"
+
+EXISTING=$(cat "$DECLINE_FILE" 2>/dev/null || echo '{"declined_prs":[]}')
+jq --argjson pr "$PR_NUMBER" '.declined_prs |= (. + [$pr] | unique)' <<< "$EXISTING" \
+    > "$DECLINE_FILE"
+chmod 600 "$DECLINE_FILE"
+
+echo "PR #${PR_NUMBER} marked as declined for this session (${SESSION_ID})."

--- a/home/dot_claude/hooks/executable_mark-review-declined.sh
+++ b/home/dot_claude/hooks/executable_mark-review-declined.sh
@@ -6,14 +6,31 @@
 
 PR_NUMBER="${1:?Usage: mark-review-declined.sh <PR_NUMBER>}"
 SESSION_ID="${CLAUDE_CODE_SESSION_ID:?CLAUDE_CODE_SESSION_ID is not set}"
+
+# PR_NUMBER が数値でない場合、jq --argjson に渡すと不正な JSON として失敗する。
+# シェルリダイレクトは jq の成否に関わらずファイルを先に truncate してしまうため、
+# 検証を怠ると既存の declined_prs が失われる。
+if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR_NUMBER must be a positive integer, got: ${PR_NUMBER}" >&2
+    exit 1
+fi
+
 DATA_DIR="$HOME/.claude/data"
 DECLINE_FILE="$DATA_DIR/review-declined-${SESSION_ID}.json"
+TMP_FILE="${DECLINE_FILE}.tmp.$$"
 
 mkdir -p "$DATA_DIR" && chmod 700 "$DATA_DIR"
 
 EXISTING=$(cat "$DECLINE_FILE" 2>/dev/null || echo '{"declined_prs":[]}')
-jq --argjson pr "$PR_NUMBER" '.declined_prs |= (. + [$pr] | unique)' <<< "$EXISTING" \
-    > "$DECLINE_FILE"
+# 一時ファイルに書き出してから mv することで、jq 失敗時に既存ファイルを
+# 空で上書きしてしまう事態を防ぐ（アトミックな置き換え）
+if ! jq --argjson pr "$PR_NUMBER" '.declined_prs |= (. + [$pr] | unique)' <<< "$EXISTING" \
+    > "$TMP_FILE"; then
+    echo "Error: failed to update ${DECLINE_FILE}" >&2
+    rm -f "$TMP_FILE"
+    exit 1
+fi
+mv "$TMP_FILE" "$DECLINE_FILE"
 chmod 600 "$DECLINE_FILE"
 
 echo "PR #${PR_NUMBER} marked as declined for this session (${SESSION_ID})."

--- a/home/dot_claude/hooks/executable_mark-review-declined.sh
+++ b/home/dot_claude/hooks/executable_mark-review-declined.sh
@@ -15,6 +15,13 @@ if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
+# SESSION_ID をそのままファイル名に埋め込むため、パス区切り文字や `..` を
+# 含む値を拒否する（ディレクトリトラバーサル対策）
+if [[ ! "$SESSION_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "Error: CLAUDE_CODE_SESSION_ID contains invalid characters" >&2
+    exit 1
+fi
+
 DATA_DIR="$HOME/.claude/data"
 DECLINE_FILE="$DATA_DIR/review-declined-${SESSION_ID}.json"
 TMP_FILE="${DECLINE_FILE}.tmp.$$"
@@ -23,14 +30,24 @@ mkdir -p "$DATA_DIR" && chmod 700 "$DATA_DIR"
 
 EXISTING=$(cat "$DECLINE_FILE" 2>/dev/null || echo '{"declined_prs":[]}')
 # 一時ファイルに書き出してから mv することで、jq 失敗時に既存ファイルを
-# 空で上書きしてしまう事態を防ぐ（アトミックな置き換え）
-if ! jq --argjson pr "$PR_NUMBER" '.declined_prs |= (. + [$pr] | unique)' <<< "$EXISTING" \
-    > "$TMP_FILE"; then
+# 空で上書きしてしまう事態を防ぐ（アトミックな置き換え）。
+# declined_prs が欠落・null・配列以外（壊れたデータ）の場合も [] として
+# 復旧できるよう type チェックしてから追加する
+if ! jq --argjson pr "$PR_NUMBER" \
+    '.declined_prs = ((if (.declined_prs | type) == "array" then .declined_prs else [] end) + [$pr] | unique)' \
+    <<< "$EXISTING" > "$TMP_FILE"; then
     echo "Error: failed to update ${DECLINE_FILE}" >&2
     rm -f "$TMP_FILE"
     exit 1
 fi
-mv "$TMP_FILE" "$DECLINE_FILE"
-chmod 600 "$DECLINE_FILE"
+if ! mv "$TMP_FILE" "$DECLINE_FILE"; then
+    echo "Error: failed to move ${TMP_FILE} to ${DECLINE_FILE}" >&2
+    rm -f "$TMP_FILE"
+    exit 1
+fi
+if ! chmod 600 "$DECLINE_FILE"; then
+    echo "Error: failed to set permissions on ${DECLINE_FILE}" >&2
+    exit 1
+fi
 
 echo "PR #${PR_NUMBER} marked as declined for this session (${SESSION_ID})."

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -63,6 +63,16 @@ else
     exit 0
 fi
 
+# --- 「対応不要」メモリ機構のチェック ---
+# ユーザーが明示的に mark-review-declined.sh を実行済みの PR は再警告しない
+DECLINE_FILE="$HOME/.claude/data/review-declined-${SESSION_ID}.json"
+if [[ -n "$SESSION_ID" && -f "$DECLINE_FILE" ]]; then
+    IS_DECLINED=$(jq --argjson pr "$PR_NUMBER" '.declined_prs // [] | any(. == $pr)' "$DECLINE_FILE" 2>/dev/null)
+    if [[ "$IS_DECLINED" == "true" ]]; then
+        exit 0
+    fi
+fi
+
 # --- owner/repo 解決 ---
 
 REMOTE_URL=$(git remote get-url origin 2>/dev/null)
@@ -166,6 +176,14 @@ gh api graphql -f query='mutation { resolveReviewThread(input: { threadId: \"<TH
 
 - ❌ issue コメントとして投稿 → \`addPullRequestReviewThreadReply\` を使用してください
 - ❌ 返信後に resolve していない → 返信後は必ず \`resolveReviewThread\` を実行してください
+
+## このセッション内でこの PR の警告を今後表示しない場合
+
+\`\`\`bash
+bash ~/.claude/hooks/mark-review-declined.sh ${PR_NUMBER}
+\`\`\`
+
+（このセッションが終了するまで、この PR に限定して再警告を抑止します。全チェックを毎回スキップする \`SKIP_REVIEW_CHECK=1\` とは異なります）
 
 ## 緊急スキップ
 

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -32,9 +32,11 @@ if [[ -f "$STATE_FILE" ]]; then
     CURRENT_TIME=$(date +%s)
     STATE_AGE=$(( CURRENT_TIME - STATE_TIMESTAMP ))
     if [[ "$STATE_AGE" -le "$STATE_TTL" ]]; then
-        # session_id が両者とも取得できていて値が異なる場合は、TTL 以内でも
-        # 他セッションのデータとみなして採用しない
-        if [[ -z "$SESSION_ID" || -z "$STATE_SESSION" || "$SESSION_ID" == "$STATE_SESSION" ]]; then
+        # 双方が空（session_id 導入前の完全な後方互換ケース）、または値が一致する
+        # 場合のみ信頼する。SESSION_ID はあるのに STATE_SESSION が空（旧形式ファイル）
+        # の場合は他セッション由来の可能性があるため採用せず、transcript パースへ
+        # フォールバックする
+        if [[ ( -z "$SESSION_ID" && -z "$STATE_SESSION" ) || "$SESSION_ID" == "$STATE_SESSION" ]]; then
             PR_URL=$(jq -r '.pr_url // ""' "$STATE_FILE" 2>/dev/null)
         fi
     fi

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -32,7 +32,7 @@ if [[ -f "$STATE_FILE" ]]; then
     CURRENT_TIME=$(date +%s)
     STATE_AGE=$(( CURRENT_TIME - STATE_TIMESTAMP ))
     if [[ "$STATE_AGE" -le "$STATE_TTL" ]]; then
-        # session_id が両者とも取得できていて値が異なる場合は、TTL以内でも
+        # session_id が両者とも取得できていて値が異なる場合は、TTL 以内でも
         # 他セッションのデータとみなして採用しない
         if [[ -z "$SESSION_ID" || -z "$STATE_SESSION" || "$SESSION_ID" == "$STATE_SESSION" ]]; then
             PR_URL=$(jq -r '.pr_url // ""' "$STATE_FILE" 2>/dev/null)

--- a/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
+++ b/home/dot_claude/hooks/executable_require-review-thread-fixes.sh
@@ -16,6 +16,7 @@ STATE_FILE="$HOME/.claude/data/session-state.json"
 # stdin から JSON を読み込む
 INPUT=$(cat)
 TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
 
 # --- PR URL 解決 ---
 
@@ -24,13 +25,18 @@ PR_URL=""
 STATE_TTL=86400
 
 # 優先 1: ステートファイル（スキルが書き出した構造化データ）
-# セッション ID が一致、またはタイムスタンプが TTL 以内であれば有効と見なす
+# TTL 以内かつ session_id が一致（または一方が空なら後方互換で許容）の場合のみ信頼する
 if [[ -f "$STATE_FILE" ]]; then
+    STATE_SESSION=$(jq -r '.session_id // ""' "$STATE_FILE" 2>/dev/null)
     STATE_TIMESTAMP=$(jq -r '.timestamp // 0' "$STATE_FILE" 2>/dev/null)
     CURRENT_TIME=$(date +%s)
     STATE_AGE=$(( CURRENT_TIME - STATE_TIMESTAMP ))
     if [[ "$STATE_AGE" -le "$STATE_TTL" ]]; then
-        PR_URL=$(jq -r '.pr_url // ""' "$STATE_FILE" 2>/dev/null)
+        # session_id が両者とも取得できていて値が異なる場合は、TTL以内でも
+        # 他セッションのデータとみなして採用しない
+        if [[ -z "$SESSION_ID" || -z "$STATE_SESSION" || "$SESSION_ID" == "$STATE_SESSION" ]]; then
+            PR_URL=$(jq -r '.pr_url // ""' "$STATE_FILE" 2>/dev/null)
+        fi
     fi
 fi
 

--- a/home/dot_claude/rules/workflow.md
+++ b/home/dot_claude/rules/workflow.md
@@ -17,6 +17,13 @@ Rules and checklists for the full development workflow.
 **Rationale**: Unresolved threads silently block merge and create follow-up debt.  
 **Escape**: `SKIP_REVIEW_CHECK=1` for genuine false positives only.
 
+**Explicit decline handling**: If the user explicitly declines to address the Stop
+hook's unresolved-review-thread warning for a specific PR, run
+`bash ~/.claude/hooks/mark-review-declined.sh <PR_NUMBER>` before ending the
+turn. This suppresses re-warning for that PR within the current session only
+(it does not persist across sessions) and is distinct from the blanket
+`SKIP_REVIEW_CHECK=1` escape, which skips all checks every time.
+
 ## ADR-003: deep-review score ≥ 50 findings must be fixed before PR creation
 
 **Decision**: `/deep-review` must pass (no score ≥ 50 findings) before creating a PR.  

--- a/home/dot_claude/rules/workflow.md
+++ b/home/dot_claude/rules/workflow.md
@@ -17,12 +17,7 @@ Rules and checklists for the full development workflow.
 **Rationale**: Unresolved threads silently block merge and create follow-up debt.  
 **Escape**: `SKIP_REVIEW_CHECK=1` for genuine false positives only.
 
-**Explicit decline handling**: If the user explicitly declines to address the Stop
-hook's unresolved-review-thread warning for a specific PR, run
-`bash ~/.claude/hooks/mark-review-declined.sh <PR_NUMBER>` before ending the
-turn. This suppresses re-warning for that PR within the current session only
-(it does not persist across sessions) and is distinct from the blanket
-`SKIP_REVIEW_CHECK=1` escape, which skips all checks every time.
+**Explicit decline handling**: If the user explicitly declines to address the Stop hook's unresolved-review-thread warning for a specific PR, run `bash ~/.claude/hooks/mark-review-declined.sh <PR_NUMBER>` before ending the turn. This suppresses re-warning for that PR within the current session only (it does not persist across sessions) and is distinct from the blanket `SKIP_REVIEW_CHECK=1` escape, which skips all checks every time.
 
 ## ADR-003: deep-review score ≥ 50 findings must be fixed before PR creation
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -426,8 +426,8 @@ if [ -z "$PR_URL" ]; then
   echo "ERROR: gh pr view returned an empty URL, not writing session-state.json" >&2
   exit 1
 fi
-if ! jq -n --arg pr_url "$PR_URL" --argjson timestamp "$(date +%s)" \
-    '{"pr_url": $pr_url, "timestamp": $timestamp}' \
+if ! jq -n --arg pr_url "$PR_URL" --arg session_id "${CLAUDE_CODE_SESSION_ID:-}" --argjson timestamp "$(date +%s)" \
+    '{"pr_url": $pr_url, "session_id": $session_id, "timestamp": $timestamp}' \
     > ~/.claude/data/session-state.json; then
   echo "ERROR: failed to write session-state.json" >&2
   exit 1

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -288,8 +288,8 @@ without parsing the transcript:
 ```bash
 mkdir -p ~/.claude/data && chmod 700 ~/.claude/data
 PR_URL=$(gh pr view --json url -q .url)
-jq -n --arg pr_url "$PR_URL" --argjson timestamp "$(date +%s)" \
-    '{"pr_url": $pr_url, "timestamp": $timestamp}' \
+jq -n --arg pr_url "$PR_URL" --arg session_id "${CLAUDE_CODE_SESSION_ID:-}" --argjson timestamp "$(date +%s)" \
+    '{"pr_url": $pr_url, "session_id": $session_id, "timestamp": $timestamp}' \
     > ~/.claude/data/session-state.json
 chmod 600 ~/.claude/data/session-state.json
 ```

--- a/home/dot_claude/skills/ticket-pr/SKILL.md
+++ b/home/dot_claude/skills/ticket-pr/SKILL.md
@@ -288,11 +288,22 @@ without parsing the transcript:
 ```bash
 mkdir -p ~/.claude/data && chmod 700 ~/.claude/data
 PR_URL=$(gh pr view --json url -q .url)
-jq -n --arg pr_url "$PR_URL" --arg session_id "${CLAUDE_CODE_SESSION_ID:-}" --argjson timestamp "$(date +%s)" \
+if [ -z "$PR_URL" ]; then
+  echo "ERROR: gh pr view returned an empty URL, not writing session-state.json" >&2
+  exit 1
+fi
+if ! jq -n --arg pr_url "$PR_URL" --arg session_id "${CLAUDE_CODE_SESSION_ID:-}" --argjson timestamp "$(date +%s)" \
     '{"pr_url": $pr_url, "session_id": $session_id, "timestamp": $timestamp}' \
-    > ~/.claude/data/session-state.json
+    > ~/.claude/data/session-state.json; then
+  echo "ERROR: failed to write session-state.json" >&2
+  exit 1
+fi
 chmod 600 ~/.claude/data/session-state.json
 ```
+
+If `PR_URL` comes back empty or the `jq` write fails, stop and report it
+instead of leaving a stale/empty state file — hooks read this file without
+parsing the transcript, so a silently broken write here breaks them too.
 
 ### After PR Creation
 


### PR DESCRIPTION
## 概要

Stop hook (`require-review-thread-fixes.sh` / `deep-review-require-fixes.sh`) が参照する `~/.claude/data/session-state.json` / `deep-review-state.json` は単一のグローバルファイルで、`session_id` によるスコープがなかったため、並行して複数の Claude Code セッションが動いていると、あるセッションの Stop hook が無関係な別セッションの PR のレビュー未解決スレッドを警告してしまう不具合があった。

併せて、ユーザーが明示的に「この PR の警告には対応しない」と判断した場合に、同一セッション内でその PR について再警告されないようにする「対応不要」メモリ機構を追加した。

Closes #196
Closes #197

## 変更内容

- `session-state.json` の書き込み側 (`issue-pr` / `ticket-pr` スキル) に `session_id` フィールドを追加
- `require-review-thread-fixes.sh`: `session-state.json` 読み取り時に `session_id` が一致する場合のみ信頼するよう厳密化(一致しない場合は TTL に関わらず不採用)
- `deep-review-require-fixes.sh`: 同様の `session_id` 不一致時の判定漏れ(TTL 以内なら誤って信頼してしまうバグ)を修正
- 新規 `mark-review-declined.sh`: ユーザーが明示的に警告への対応を拒否した PR をセッションスコープで記録し、以降の Stop hook 実行でその PR への再警告を抑止する仕組みを追加(セッションをまたいでは永続化しない)
- `require-review-thread-fixes.sh` に上記の declined チェックとブロックメッセージへの案内を追加
- `home/dot_claude/rules/workflow.md` の ADR-002 に運用ルールを追記

## 動作確認

- 別セッション ID の `session-state.json` / `deep-review-state.json` が存在しても、TTL 以内でも誤って採用されないことを確認(修正前は誤って採用されるバグを再現済み)
- 同一セッション ID では従来通り正しく解決されることを確認(回帰なし)
- `session_id` フィールドを持たない旧形式ファイルとの後方互換性を確認
- `mark-review-declined.sh` の正常系・重複実行・複数 PR 記録・セッションをまたいだ非永続化を確認
- `mark-review-declined.sh` に不正な `PR_NUMBER` を渡した場合にエラー終了し、既存の記録を破壊しないことを確認(deep-review 指摘の修正含む)
- declined 記録済み PR では `require-review-thread-fixes.sh` が GraphQL 呼び出し前に終了することを確認
- 変更した hook スクリプト全体で `shellcheck` が警告なしで通過することを確認
- Docker 上で `chezmoi apply --dry-run` を実行し、全ファイルが正しくデプロイされることを確認
- `/deep-review`(ローカル diff モード)を実施し、スコア 50 以上の指摘 1 件を含む計 3 件を修正済み

Spec: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/5898436/Spec+-+Issue+196+197+Stop+hook
Plan: https://tomacheese.atlassian.net/wiki/spaces/Main/pages/5963988/Plan+-+Issue+196+197+Stop+hook