### PR TITLE
refactor: Issue紐付きのspec/plan投稿先をConfluenceからGitHub Issueコメントに変更する

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -52,3 +52,4 @@ Use the Todo tool for all multi-step work without omission.
 @RTK.md
 @rules/superpowers.md
 @rules/confluence.md
+@rules/issue-comment-docs.md

--- a/home/dot_claude/rules/confluence.md
+++ b/home/dot_claude/rules/confluence.md
@@ -6,6 +6,10 @@ Rules for sharing user-facing Markdown deliverables via Confluence.
 
 ## When to Apply
 
+**Scope carve-out**: if the document is tied to a GitHub Issue (e.g. `issue-pr`
+execution, brainstorming conducted directly on a GitHub Issue), follow
+`rules/issue-comment-docs.md` instead — that case is out of scope for this file.
+
 Applies to Markdown documents created for the user to read or review as a deliverable:
 
 - Investigation results
@@ -22,9 +26,9 @@ Git/GitHub artifacts — only to documents whose primary purpose is to be read b
    hostname first, otherwise use `mcp__atlassian__getAccessibleAtlassianResources`.
 2. **Determine space and parent page automatically — do not ask the user except in the fallback cases below.**
    - **Repository name source**: use `ISSUE_OWNER`/`ISSUE_REPO` as already resolved by the
-     calling flow (`issue-pr`, `ticket-pr`, or the `rules/superpowers.md` spec/plan upload
-     step) — the repository the Issue/ticket actually belongs to. Do not derive this from
-     the local `git` `origin`/`upstream` remotes.
+     calling flow (`ticket-pr`, or the `rules/superpowers.md` spec/plan upload step for
+     documents not tied to a GitHub Issue) — the repository the Issue/ticket actually
+     belongs to. Do not derive this from the local `git` `origin`/`upstream` remotes.
    - **Repository space search**: call `mcp__atlassian__getConfluenceSpaces` and look for a
      space whose `name` or `key` contains the repository name (e.g. `dotfiles`),
      case-insensitive substring match.
@@ -61,16 +65,17 @@ Git/GitHub artifacts — only to documents whose primary purpose is to be read b
 
 ## Interaction with Other Skills
 
-- **`issue-pr` / `ticket-pr`**: after uploading a deliverable document (spec/plan for
-  `issue-pr`, the requirements document for `ticket-pr`) to Confluence, the GitHub Issue
-  comment / Jira ticket comment must contain the Confluence URL plus a short summary only
-  — not the full document body. Phase numbers are deliberately not pinned here since both
-  skills renumber their own phases independently of this rule; see each skill's own
-  SKILL.md for its current phase numbers (`ticket-pr`'s upload+comment step is its
-  Phase 6 as of this writing).
-- **`rules/superpowers.md` spec/plan review workflow**: after the sub-agent review is
-  complete, upload the reviewed document to Confluence before presenting it to the user, and
-  give the user the Confluence URL alongside the local file path.
+- **`ticket-pr`**: after uploading the requirements document to Confluence, the Jira
+  ticket comment must contain the Confluence URL plus a short summary only — not the full
+  document body. The phase number is deliberately not pinned here since the skill
+  renumbers its own phases independently of this rule; see its own SKILL.md for the
+  current phase number (`ticket-pr`'s upload+comment step is its Phase 6 as of this
+  writing).
+- **`rules/superpowers.md` spec/plan review workflow**: for spec/plan documents not tied
+  to a GitHub Issue, after the sub-agent review is complete, upload the reviewed document
+  to Confluence before presenting it to the user, and give the user the Confluence URL
+  alongside the local file path. For documents tied to a GitHub Issue, follow
+  `rules/issue-comment-docs.md` instead.
 
 ## Notes
 

--- a/home/dot_claude/rules/confluence.md
+++ b/home/dot_claude/rules/confluence.md
@@ -69,8 +69,7 @@ Git/GitHub artifacts — only to documents whose primary purpose is to be read b
   ticket comment must contain the Confluence URL plus a short summary only — not the full
   document body. The phase number is deliberately not pinned here since the skill
   renumbers its own phases independently of this rule; see its own SKILL.md for the
-  current phase number (`ticket-pr`'s upload+comment step is its Phase 6 as of this
-  writing).
+  current phase number.
 - **`rules/superpowers.md` spec/plan review workflow**: for spec/plan documents not tied
   to a GitHub Issue, after the sub-agent review is complete, upload the reviewed document
   to Confluence before presenting it to the user, and give the user the Confluence URL

--- a/home/dot_claude/rules/issue-comment-docs.md
+++ b/home/dot_claude/rules/issue-comment-docs.md
@@ -1,0 +1,55 @@
+# GitHub Issue Comment Documentation Rules
+
+Rules for posting spec/plan/investigation documents as GitHub Issue comments, for work tied to a GitHub Issue.
+
+---
+
+## When to Apply
+
+Applies to Markdown documents created for the user to read or review as a deliverable, **when the work is tied to a GitHub Issue** (e.g. `issue-pr` execution, brainstorming conducted directly on a GitHub Issue):
+
+- Investigation results
+- Spec files (`docs/superpowers/specs/*.md`)
+- Plan files (`docs/superpowers/plans/*.md`)
+- Other standalone write-ups intended for the user, tied to that Issue
+
+Does not apply to:
+
+- Work not tied to a GitHub Issue (Jira-linked `ticket-pr` work, standalone investigations, pre-Issue discussions) — follow `rules/confluence.md` instead.
+- Commit messages, PR bodies, code comments, or other routine Git/GitHub artifacts.
+
+## Procedure
+
+### Initial post
+
+Create a new comment on the Issue and capture its comment ID from the returned URL. `--body-file` reads the body directly from disk, so it never costs extra tokens — do not pass the body as a string argument instead.
+
+```bash
+url=$(gh issue comment "<issue-number>" --repo "<owner>/<repo>" --body-file <path>)
+comment_id=${url##*issuecomment-}
+```
+
+### Update
+
+Spec and plan documents are each posted as their own, separate comment. When revising one of them, update it by its own comment ID — **do not use `--edit-last`**. `--edit-last` targets "the last comment posted by the current user" on the whole Issue; if spec and plan are posted in sequence, using `--edit-last` for the plan would silently overwrite the spec's comment instead of updating the plan's own comment.
+
+```bash
+gh api "repos/<owner>/<repo>/issues/comments/<comment_id>" -X PATCH -F body=@<path>
+```
+
+`-F body=@<path>` reads the body from the file directly, same token-free property as `--body-file`.
+
+### Reporting
+
+After posting or updating, report **the URL only** — do not paste the document body again in chat or in another comment (same policy as `rules/confluence.md`).
+
+## Document Language
+
+Confluence pages were viewed only by the user, so they followed the user's private language setting. GitHub Issue comments are **public**, and the target project's main language may differ from the user's private setting. Documents posted here must follow **the language specified by the target project's CLAUDE.md (or AGENTS.md, etc.)** — not the user's private language preference. Default to Japanese only if the project specifies no language. Code blocks, commands, and identifiers stay in their original form regardless of the body language.
+
+This matches the instruction `issue-pr`'s Phase 3/7 already give when invoking `superpowers:brainstorming`/`superpowers:writing-plans` ("the language required by the target project's CLAUDE.md").
+
+## Notes
+
+- Verify no sensitive information (tokens, passwords, internal URLs, credentials) is included before posting — same check required before any Confluence/Jira post (see `rules/security.md`).
+- If `gh issue comment` / `gh api` fails (auth, network, permission), report it to the user rather than silently continuing — a missing comment breaks the link between the Issue and its spec/plan.

--- a/home/dot_claude/rules/issue-comment-docs.md
+++ b/home/dot_claude/rules/issue-comment-docs.md
@@ -31,7 +31,7 @@ comment_id=${url##*issuecomment-}
 
 ### Update
 
-Spec and plan documents are each posted as their own, separate comment. When revising one of them, update it by its own comment ID — **do not use `--edit-last`**. `--edit-last` targets "the last comment posted by the current user" on the whole Issue; if spec and plan are posted in sequence, using `--edit-last` for the plan would silently overwrite the spec's comment instead of updating the plan's own comment.
+Spec and plan documents are each posted as their own, separate comment. When revising one of them, update it by its own comment ID — **do not use `--edit-last`**. `--edit-last` targets "the last comment posted by the current user" on the whole Issue; if spec and plan are posted in sequence (spec first, then plan), the plan comment becomes the last one — so later using `--edit-last` to revise the spec would silently overwrite the plan's comment instead of updating the spec's own comment.
 
 ```bash
 gh api "repos/<owner>/<repo>/issues/comments/<comment_id>" -X PATCH -F body=@<path>

--- a/home/dot_claude/rules/issue-comment-docs.md
+++ b/home/dot_claude/rules/issue-comment-docs.md
@@ -47,7 +47,7 @@ After posting or updating, report **the URL only** — do not paste the document
 
 Confluence pages were viewed only by the user, so they followed the user's private language setting. GitHub Issue comments are **public**, and the target project's main language may differ from the user's private setting. Documents posted here must follow **the language specified by the target project's CLAUDE.md (or AGENTS.md, etc.)** — not the user's private language preference. Default to Japanese only if the project specifies no language. Code blocks, commands, and identifiers stay in their original form regardless of the body language.
 
-This matches the instruction `issue-pr`'s Phase 3/7 already give when invoking `superpowers:brainstorming`/`superpowers:writing-plans` ("the language required by the target project's CLAUDE.md").
+This matches the instruction `issue-pr` already gives when invoking `superpowers:brainstorming`/`superpowers:writing-plans` to write the spec/plan documents ("the language required by the target project's CLAUDE.md").
 
 ## Notes
 

--- a/home/dot_claude/rules/superpowers.md
+++ b/home/dot_claude/rules/superpowers.md
@@ -33,9 +33,13 @@ you MUST dispatch a sub-agent to review the document and apply fixes.
    changes look correct.
 4. If the sub-agent reports ambiguities, resolve them with the user via
    AskUserQuestion before proceeding.
-5. Only after all issues are resolved, upload the document to Confluence
-   following `rules/confluence.md`, then present the user with the local
-   file path and the Confluence URL.
+5. Only after all issues are resolved, post or upload the document:
+   - If the document is tied to a GitHub Issue (e.g. `issue-pr` execution,
+     brainstorming conducted directly on a GitHub Issue), follow
+     `rules/issue-comment-docs.md` and present the user with the local file
+     path and the Issue comment URL.
+   - Otherwise, follow `rules/confluence.md` and present the user with the
+     local file path and the Confluence URL.
 
 ### Clarifying questions
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -11,7 +11,8 @@ This skill is a GitHub-specific orchestrator on top of superpowers: it chains
 spec → plan → implementation → PR, with an explicit user-approval gate after
 the spec and after the plan, then runs implementation and testing without
 re-confirming every step. It does not reimplement spec/plan authoring,
-review, or Confluence upload — those stay in superpowers.
+review, or Issue-comment posting — those stay in superpowers /
+`rules/issue-comment-docs.md`.
 
 Approval here is done via **AskUserQuestion**, not Claude Code's native Plan
 Mode — Plan Mode only allows a single read-only-until-ExitPlanMode gate, and
@@ -64,7 +65,7 @@ runs inside the worktree created here.
      `worktree-issue-<number>`, branched from `origin/<default-branch>` per
      `EnterWorktree`'s default `baseRef: fresh`).
    - Immediately after success, record the actual current branch name via
-     `git branch --show-current` — Phase 12 needs this exact value to know
+     `git branch --show-current` — Phase 11 needs this exact value to know
      which branch to rename, since the harness's naming convention for that
      branch is not a hard guarantee.
    - If `EnterWorktree` fails because the session is already inside another
@@ -181,22 +182,35 @@ user the automatic review didn't run, and ask how they want to proceed. "It
 didn't fire so I'll just do it myself" reintroduces the reimplementation this
 phase exists to avoid.
 
-## Phase 5: Upload the Spec to Confluence
+## Phase 5: Post the Spec as an Issue Comment
 
-`rules/confluence.md` already requires uploading spec files to Confluence
-before presenting them to the user — this fires automatically once Phase 4's
-review is clean. Do not reimplement the upload procedure here; just capture
-the resulting Confluence URL, you need it for Phase 11.
+`rules/issue-comment-docs.md` covers this case (the spec is tied to this
+Issue) — follow its procedure directly:
+
+```bash
+url=$(gh issue comment "$ARGUMENTS" --repo "$ISSUE_OWNER/$ISSUE_REPO" --body-file <spec-file-path>)
+SPEC_COMMENT_URL="$url"
+SPEC_COMMENT_ID=${url##*issuecomment-}
+```
+
+Capture `SPEC_COMMENT_URL`/`SPEC_COMMENT_ID` — you need the URL for Phase 6
+and the ID for any later revision.
 
 If this is a revision (you're back here after Phase 6 sent you to repeat
-Phases 3–6), `rules/confluence.md` requires updating the existing spec page
-via `updateConfluencePage`, not creating a new one — carry the page ID
-forward from the first pass.
+Phases 3–6), update the existing comment by its ID instead of creating a new
+one:
 
-If Confluence/Atlassian resolution fails (no cloudId, no space configured,
-MCP unavailable), follow `rules/confluence.md`'s own fallback: report the
-error to the user and ask how to proceed. Don't treat Confluence as an
-unconditional hard gate you can't get past.
+```bash
+gh api "repos/$ISSUE_OWNER/$ISSUE_REPO/issues/comments/$SPEC_COMMENT_ID" -X PATCH -F body=@<spec-file-path>
+```
+
+Do not use `--edit-last` — it targets "the last comment posted by the
+current user" on the whole Issue, and would silently overwrite the plan's
+comment (Phase 9) if the plan was already posted before a spec revision.
+
+If `gh issue comment` / `gh api` fails (auth, network, permission), follow
+`rules/issue-comment-docs.md`'s own fallback: report the error to the user
+and ask how to proceed.
 
 ## Phase 6: Approve the Spec
 
@@ -204,25 +218,27 @@ Use **AskUserQuestion** to get explicit spec approval before moving on to
 Phase 7. No exceptions — not for "the spec is obviously fine" and not for
 "ask forgiveness after Phase 7 instead."
 
-The question text MUST include the Confluence URL captured in Phase 5. If
-Phase 5's Confluence upload failed and fell back per `rules/confluence.md`,
-you must have already reported that to the user before reaching this phase
-— do not silently ask for approval without ever having surfaced the failure.
+The question text MUST include the Issue comment URL (`SPEC_COMMENT_URL`)
+captured in Phase 5. If Phase 5's post failed and fell back per
+`rules/issue-comment-docs.md`, you must have already reported that to the
+user before reaching this phase — do not silently ask for approval without
+ever having surfaced the failure.
 
 Fix the options to exactly these two (plus AskUserQuestion's built-in
-"Other" free-text, which covers ad-hoc revision requests). Note:
-AskUserQuestion's `options` array requires at least 2 entries — passing
-only 1 fails with `Too small: expected array to have >=2 items`, so always
-pass both of the following, never just one:
+"Other" free-text, which covers ad-hoc revision requests — e.g. the user
+typing what to change directly). Note: AskUserQuestion's `options` array
+requires at least 2 entries — passing only 1 fails with `Too small:
+expected array to have >=2 items`, so always pass both of the following,
+never just one:
 
 - "承認する" (Approve)
-- "ページコメントを参照して修正してほしい" (Revise based on page comments)
+- "修正してほしい(Otherで内容を指示)" (Revise — specify what via Other)
 
-If the second option is chosen, fetch the unresolved inline/footer comments
-on the Confluence page (`mcp__atlassian__getConfluencePageInlineComments`,
-`mcp__atlassian__getConfluencePageFooterComments`), incorporate them into
-the spec, and repeat Phases 3–6 (Phase 5 becomes a Confluence page update,
-not a new page).
+If the second option is chosen, ask the user via the "Other" free-text field
+what to revise (there is no page-comment mechanism on a GitHub Issue
+comment the way there was on a Confluence page), incorporate the requested
+changes into the spec, and repeat Phases 3–6 (Phase 5 becomes an Issue
+comment update via `SPEC_COMMENT_ID`, not a new comment).
 
 ## Phase 7: Write the Plan
 
@@ -245,13 +261,29 @@ fires automatically. Wait for it and confirm the result before moving on. If
 it doesn't fire, same rule as Phase 4 — stop and ask the user, don't do the
 review yourself.
 
-## Phase 9: Upload the Plan to Confluence
+## Phase 9: Post the Plan as an Issue Comment
 
-Same as Phase 5, for the plan file: `rules/confluence.md`'s upload fires
-automatically once the review is clean. Capture the resulting Confluence URL
-for Phase 11. Same revision rule as Phase 5: if this is a repeat after Phase
-10 sent you back, update the existing plan page instead of creating a new
-one. Same fallback as Phase 5 if Confluence resolution fails.
+Same as Phase 5, for the plan file — follow `rules/issue-comment-docs.md`
+directly:
+
+```bash
+url=$(gh issue comment "$ARGUMENTS" --repo "$ISSUE_OWNER/$ISSUE_REPO" --body-file <plan-file-path>)
+PLAN_COMMENT_URL="$url"
+PLAN_COMMENT_ID=${url##*issuecomment-}
+```
+
+This must be a **new** comment, separate from `SPEC_COMMENT_ID` — never
+reuse or overwrite the spec's comment.
+
+Same revision rule as Phase 5: if this is a repeat after Phase 10 sent you
+back, update the existing plan comment by its own ID instead of creating a
+new one:
+
+```bash
+gh api "repos/$ISSUE_OWNER/$ISSUE_REPO/issues/comments/$PLAN_COMMENT_ID" -X PATCH -F body=@<plan-file-path>
+```
+
+Same fallback as Phase 5 if the post fails.
 
 ## Phase 10: Approve the Plan
 
@@ -260,47 +292,21 @@ Phase 11 — the spec's approval in Phase 6 does not carry over, since a plan
 can diverge from its spec. "The spec was already approved so the plan is
 implied" is exactly the shortcut this gate blocks.
 
-Same requirements as Phase 6: the question text MUST include the Confluence
-URL captured in Phase 9 (report any upload failure to the user before this
-phase, per `rules/confluence.md`'s fallback), and the options are fixed to
-exactly (both entries required — AskUserQuestion rejects a single-entry
-`options` array):
+Same requirements as Phase 6: the question text MUST include the Issue
+comment URL (`PLAN_COMMENT_URL`) captured in Phase 9 (report any post
+failure to the user before this phase, per `rules/issue-comment-docs.md`'s
+fallback), and the options are fixed to exactly (both entries required —
+AskUserQuestion rejects a single-entry `options` array):
 
 - "承認する" (Approve)
-- "ページコメントを参照して修正してほしい" (Revise based on page comments)
+- "修正してほしい(Otherで内容を指示)" (Revise — specify what via Other)
 
-If the second option is chosen, fetch the unresolved Confluence page
-comments, incorporate them into the plan, and repeat Phases 7–10 (Phase 9
-becomes a Confluence page update, not a new page).
+If the second option is chosen, ask the user via "Other" what to revise,
+incorporate the requested changes into the plan, and repeat Phases 7–10
+(Phase 9 becomes an Issue comment update via `PLAN_COMMENT_ID`, not a new
+comment).
 
-## Phase 11: Comment on the Issue
-
-Post the spec and plan summaries plus their Confluence URLs as an Issue
-comment — not the full document bodies:
-
-```bash
-gh issue comment "$ARGUMENTS" --repo "$ISSUE_OWNER/$ISSUE_REPO" --body "$(cat <<'EOF'
-[short summary]
-
-Spec: [Confluence URL]
-Plan: [Confluence URL]
-EOF
-)"
-```
-
-`--repo` is required here — without it, `gh issue comment` resolves the
-target repository from the local `origin`, which is wrong whenever
-`ISSUE_OWNER/ISSUE_REPO` (set in Phase 2) differs from `origin` (the fork
-scenario this Issue set targets).
-
-Verify no sensitive information is included before posting.
-
-If `gh issue comment` fails (auth, network, permission), do not silently move
-on to Phase 12 — stop and report it to the user. Without this comment, the
-issue has no link back to the Confluence spec/plan, and that record is not
-worth losing quietly.
-
-## Phase 12: Create Branch
+## Phase 11: Create Branch
 
 `EnterWorktree` (Phase 1) already created a branch off
 `origin/<default-branch>` — this phase renames that branch to a Conventional
@@ -324,9 +330,9 @@ explicit two-argument form of `git branch -m` (rename `<worktree_branch_name>`
 to `<branch_name>`) rather than the one-argument form that renames whatever
 branch is currently checked out — the one-argument form would silently rename
 the wrong branch if the checked-out branch changed between Phase 1 and
-Phase 12. Before running the command, compare `<worktree_branch_name>` against
+Phase 11. Before running the command, compare `<worktree_branch_name>` against
 the current `git branch --show-current` output; if they don't match (e.g. the
-user manually switched branches between Phase 1 and Phase 12), stop and ask
+user manually switched branches between Phase 1 and Phase 11), stop and ask
 the user how to proceed instead of overwriting whatever they were doing.
 
 If `git branch -m <branch_name>` fails because `<branch_name>` already exists
@@ -334,7 +340,7 @@ If `git branch -m <branch_name>` fails because `<branch_name>` already exists
 would silently merge two unrelated branches' history under one name. Stop
 and ask the user whether to reuse, delete, or rename.
 
-## Phase 13: Execute the Plan
+## Phase 12: Execute the Plan
 
 Invoke **superpowers:executing-plans** (or
 **superpowers:subagent-driven-development** for independent tasks) against
@@ -345,23 +351,23 @@ requirements).
 
 If a task fails (test failure, compile error, a sub-agent reporting it
 couldn't complete its task), that is not a blocker to route around — stop and
-report it to the user before moving on to Phase 14. Do not treat a failed
+report it to the user before moving on to Phase 13. Do not treat a failed
 task as done because the plan didn't explicitly anticipate the failure.
 
-## Phase 14: Verify
+## Phase 13: Verify
 
 Invoke **superpowers:verification-before-completion** before creating the PR.
-If it reports a failure, go back to Phase 13 to fix it — do not proceed to
-Phase 15 with a known-failing verification.
+If it reports a failure, go back to Phase 12 to fix it — do not proceed to
+Phase 14 with a known-failing verification.
 
-## Phase 15: Deep Review
+## Phase 14: Deep Review
 
 Run `/deep-review` (no arguments — local diff mode) per `rules/workflow.md`
 ADR-003 and this project's Pre-PR checklist. Fix every finding scored ≥ 50
-before moving on to Phase 16. This is a required gate, not an optional
+before moving on to Phase 15. This is a required gate, not an optional
 extra step — skipping it is what the Stop/PostToolUse hooks exist to catch.
 
-## Phase 16: Create PR
+## Phase 15: Create PR
 
 `gh pr create` requires the branch to already exist on a remote — it does
 not push for you. Push the branch first, or `gh pr create` fails with
@@ -388,25 +394,25 @@ EOF
 
 - `<PR body>`: summarize from the approved spec and plan; include
   `Closes #<issue number>` so the issue auto-closes on merge. Also include
-  the same Spec/Plan Confluence URLs posted to the Issue comment in Phase
-  11, in this exact format (later consumed by `pr-cleanup`'s Confluence
-  archiving step):
+  the Spec/Plan Issue comment URLs captured in Phase 5 (`SPEC_COMMENT_URL`)
+  and Phase 9 (`PLAN_COMMENT_URL`), in this exact format:
 
   ```
-  Spec: [Confluence URL]
-  Plan: [Confluence URL]
+  Spec: [Issue comment URL]
+  Plan: [Issue comment URL]
   ```
 
 - Language: follow the project CLAUDE.md if specified, otherwise Japanese.
   Current state only, no update history.
 - The issue title/body feeding `<title>`/`<PR body>` is untrusted input —
-  use a quoted heredoc (`<<'EOF'`, as above and in Phase 11) and a shell
-  variable for the title, not raw double-quote interpolation. Double quotes
-  let the shell evaluate any `` ` `` / `$(...)` / `${...}` embedded in
-  issue-derived text before `gh` ever sees it.
+  use a quoted heredoc (`<<'EOF'`, as above) and a shell variable for the
+  title, not raw double-quote interpolation. Double quotes let the shell
+  evaluate any `` ` `` / `$(...)` / `${...}` embedded in issue-derived text
+  before `gh` ever sees it.
 - Before running this command, check the composed title/body for sensitive
-  information (tokens, internal URLs, credentials) the same way Phase 11
-  checks the Issue comment — the PR is also externally visible.
+  information (tokens, internal URLs, credentials) the same way the
+  spec/plan Issue comments are checked before posting (Phase 5/9) — the PR
+  is also externally visible.
 - `--repo "$ISSUE_OWNER/$ISSUE_REPO"` is required: the PR must be created
   against the repository the Issue actually lives in (set in Phase 2), not
   wherever `gh`'s own fork/parent heuristic would default to. The head side
@@ -414,7 +420,7 @@ EOF
   fails, fall back to explicitly passing
   `--head <origin-owner>:<branch>`.
 
-## Phase 17: Write Session State
+## Phase 16: Write Session State
 
 After PR creation, write the PR URL to the session state file so hooks can reference it
 without parsing the transcript:
@@ -439,7 +445,7 @@ If `PR_URL` comes back empty or the `jq` write fails, stop and report it
 instead of leaving a stale/empty state file — hooks read this file without
 parsing the transcript, so a silently broken write here breaks them too.
 
-## Phase 18: After PR Creation
+## Phase 17: After PR Creation
 
 Run `/pr-health-monitor <PR number>` immediately, without asking the user
 whether to run it.
@@ -464,9 +470,9 @@ either check fails, report that the background monitor failed to start and
 that manual re-invocation may be needed, instead of promising automation
 that didn't actually start.
 
-## Phase 19: Launch Background Monitoring
+## Phase 18: Launch Background Monitoring
 
-Immediately after Phase 18, launch the merge/close monitor in the
+Immediately after Phase 17, launch the merge/close monitor in the
 background so cleanup happens even if the user merges or closes the PR
 outside this session:
 

--- a/home/dot_claude/skills/pr-cleanup/SKILL.md
+++ b/home/dot_claude/skills/pr-cleanup/SKILL.md
@@ -49,82 +49,6 @@ If `state` is not `MERGED` or `CLOSED`, stop here and report it to the
 user — do not delete a branch backing a still-open PR just because this
 skill was invoked manually or by mistake.
 
-## Step 1.5: Archive Confluence Spec/Plan Pages
-
-Run this whenever Step 1 passed (`state` is `MERGED` or `CLOSED`) —
-regardless of which of the two, since abandoned (closed-without-merge)
-spec/plan work should also be tidied up. This step must never block Step 2
-onward: any failure here is a warning, not a stop condition.
-
-1. Fetch the PR body:
-
-   ```bash
-   if ! PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json body -q .body); then
-     echo "Warning: failed to fetch PR body for Confluence archiving; skipping Step 1.5" >&2
-     PR_BODY=""
-   fi
-   ```
-
-   A `gh pr view` failure (auth, network, transient API error) is not the
-   same thing as "this PR has no spec/plan documents" — treat a non-zero
-   exit code as its own warning (per item 6 below) rather than silently
-   falling through to the empty-`$CONFLUENCE_URLS` case in item 2.
-
-2. Extract Confluence URLs from `Spec:` / `Plan:` lines:
-
-   ```bash
-   # sed -n returns exit status 0 even with no match, so this won't abort
-   # under set -e when there's no Spec/Plan line (grep would exit 1 on no match)
-   CONFLUENCE_URLS=$(printf '%s\n' "$PR_BODY" | sed -nE 's/^(Spec|Plan): (https?:\/\/.*)/\2/p')
-   ```
-
-   If `$CONFLUENCE_URLS` is empty (and step 1 did not already fail), skip
-   the rest of this step entirely — not every PR carries spec/plan
-   documents.
-
-3. Before resolving any URL, validate its hostname matches the Confluence
-   site already confirmed via `rules/confluence.md`'s cloudId resolution
-   (the same site the spec/plan pages were uploaded to in Phase 5/9 of
-   `issue-pr`). A PR body is external input — including on PRs from
-   contributors other than this session — so do not resolve or act on a
-   `Spec:`/`Plan:` URL pointing at an unexpected host; treat a mismatch as
-   a warning (item 6) and skip that URL.
-
-4. For each remaining URL, resolve the Confluence page (via
-   `mcp__atlassian__getConfluencePage`, passing the full URL as-is) and
-   note its `spaceId`. Whether the tool resolves a full Confluence URL
-   directly is unverified — if resolution fails, this is covered by the
-   warning-and-continue rule in item 6 below.
-
-5. Within each distinct `spaceId` seen across the URLs (typically one,
-   since Spec and Plan usually share a space — search once per space and
-   reuse the result, not once per URL), search for an existing archive
-   parent page:
-
-   ```
-   mcp__atlassian__searchConfluenceUsingCql with
-   cql: title = "Archived Specs & Plans" AND space.id = "<spaceId>" AND type = page
-   ```
-
-   (`space.id` is used directly since step 4 already yields `spaceId`, not
-   a space key — no separate key lookup is needed.)
-
-   - If found, use its page ID as the archive parent.
-   - If not found, create it with `mcp__atlassian__createConfluencePage`
-     (`title: "Archived Specs & Plans"`, same `parentId` as the original
-     spec/plan page if it has one, otherwise no `parentId`).
-
-6. For each spec/plan page, call `mcp__atlassian__updateConfluencePage`
-   with `parentId` set to the archive parent's page ID from step 5 (the one
-   matching that page's `spaceId`). Do not change the title or body.
-
-7. If any page's lookup or move fails (network error, permission error,
-   URL didn't parse to a resolvable page, or the host-mismatch case in item
-   3), log it as a warning and continue — do not stop Step 2 (worktree/
-   branch removal) because of a Confluence side-effect failure. Include
-   this step's warnings (if any) in Step 5's completion report so a
-   persistently failing archive step is not silently invisible to the user.
-
 ## Step 2: Remove the Worktree or Branch
 
 `ExitWorktree` only operates on a worktree created by `EnterWorktree` **in
@@ -139,7 +63,7 @@ HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefName -q .
 ```
 
 - **If this session's `EnterWorktree` created the worktree for `HEAD_REF`**
-  (i.e. you got here via Phase 19 of `issue-pr` continuing in the same
+  (i.e. you got here via Phase 18 of `issue-pr` continuing in the same
   session, without a session break): call
   `ExitWorktree(action: "remove", discard_changes: true)`. Passing
   `discard_changes: true` without re-confirming with the user is safe and
@@ -205,10 +129,6 @@ fi
 ## Step 5: Report Completion
 
 Report to the user that cleanup completed (worktree/branch removed, default
-branch updated, fork synced if applicable). If Step 1.5 logged any warnings
-(Confluence page lookup/move failures, host mismatches), include them here
-too — Step 1.5 is warning-only and never blocks cleanup, but that also means
-this is the only place its failures reach the user; do not let them go
-unreported. Do not send a duplicate Discord notification here —
-`wait-for-pr-close` already sent one on detection when this skill was
-triggered automatically.
+branch updated, fork synced if applicable). Do not send a duplicate Discord
+notification here — `wait-for-pr-close` already sent one on detection when
+this skill was triggered automatically.


### PR DESCRIPTION
## 概要

GitHub Issueに紐づく作業(`issue-pr`等)のspec/plan文書の投稿先を、Confluenceから GitHub Issueコメントに変更する。

Confluence MCPは本文を文字列引数として渡す必要があり、LLMのトークンを消費していた。`gh issue comment --body-file` / `gh api ... -F body=@path` はファイルから直接読み込むため、この問題を回避できる。

- 初回投稿: `gh issue comment <n> --body-file <path>` で新規コメントを作成し、返り値のURLからコメントIDを取得
- 更新: `gh api repos/{owner}/{repo}/issues/comments/<comment_id> -X PATCH -F body=@<path>` でコメントIDを明示指定して更新(`--edit-last`は誤って別ドキュメントのコメントを上書きするリスクがあるため使用しない)
- spec, planはそれぞれ別コメントとして投稿する
- ドキュメント言語: Confluence(閲覧者=自分限定)は利用者の言語設定に従っていたが、GitHub Issueコメントは公開されるため、対象プロジェクトのCLAUDE.md(未指定時は日本語)に従う方針に変更

`ticket-pr`(Jira紐付き、GitHub Issueが存在しない)は対象外で、Confluenceのまま変更していない。

## 変更ファイル

- 新規: `home/dot_claude/rules/issue-comment-docs.md` — GitHub Issueコメント投稿の手順・言語方針を定義
- `home/dot_claude/rules/confluence.md` — GitHub Issue紐付きケースをスコープ除外し、新ルールファイルへ誘導
- `home/dot_claude/rules/superpowers.md` — spec/planアップロード手順をIssueコメント/Confluenceで分岐
- `home/dot_claude/CLAUDE.md` — 新ルールファイルのinclude追加
- `home/dot_claude/skills/issue-pr/SKILL.md` — Phase 5/6/9/10/11をIssueコメント方式に変更、Phase番号を1-18に再採番
- `home/dot_claude/skills/pr-cleanup/SKILL.md` — Confluenceアーカイブ処理(Step 1.5)を削除

opengist(Issueに紐づかないケースの代替先)は別Issue #205としてスコープ外。

Spec: https://github.com/book000/dotfiles/issues/204#issuecomment-4887393588
Plan: https://github.com/book000/dotfiles/issues/204#issuecomment-4887431411

Closes #204