### PR TITLE
fix: レートリミット解除後の再開メッセージをsystem-reminder形式に変更する

### DIFF
--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -205,8 +205,8 @@ while IFS=$'\t' read -r session cwd reset_epoch reset_text; do
 
     # 再開予定時刻を過ぎてもまだリミット中の場合は再開を試みる。
     # 再開に成功していれば、次回ポーリング時には会話ログの直近メッセージが
-    # 送信した system-reminder 形式の再開メッセージに置き換わり is_limited が
-    # 自然に 0 になるため、再開済みかどうかを別途記録しなくても二重送信にはならない
+    # 送信した system-reminder 形式の再開メッセージに置き換わり、
+    # is_limited が自然に 0 になるため、再開済みかどうかを別途記録しなくても二重送信にはならない
     if [[ "$reset_epoch" =~ ^[0-9]+$ ]] && [ "$now" -ge "$reset_epoch" ]; then
         echo "Resuming: $session ($cwd)"
         resume_session "$session"

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -205,8 +205,8 @@ while IFS=$'\t' read -r session cwd reset_epoch reset_text; do
 
     # 再開予定時刻を過ぎてもまだリミット中の場合は再開を試みる。
     # 再開に成功していれば、次回ポーリング時には会話ログの直近メッセージが
-    # 送信した「続けてください」に置き換わり is_limited が自然に 0 になるため、
-    # 再開済みかどうかを別途記録しなくても二重送信にはならない
+    # 送信した system-reminder 形式の再開メッセージに置き換わり is_limited が
+    # 自然に 0 になるため、再開済みかどうかを別途記録しなくても二重送信にはならない
     if [[ "$reset_epoch" =~ ^[0-9]+$ ]] && [ "$now" -ge "$reset_epoch" ]; then
         echo "Resuming: $session ($cwd)"
         resume_session "$session"

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -175,7 +175,7 @@ resume_session() {
         sleep 0.5
     fi
 
-    tmux send-keys -t "$session" "続けてください"
+    tmux send-keys -t "$session" "<system-reminder>Claude Code's rate limit has been lifted. Continue the task you were working on before the interruption.</system-reminder>"
     sleep 1
     tmux send-keys -t "$session" Enter
 }


### PR DESCRIPTION
## 概要

`resume_session` 関数がレートリミット解除後に tmux 経由で送信する再開メッセージを、曖昧な固定文言「続けてください」から、Claude Code のハーネス自身が使う `<system-reminder>` タグ形式を模した英語の1行メッセージに変更する。

## 変更内容

`home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh` の2箇所を変更:

- `resume_session` 関数内の送信文言を以下に置き換え:
  ```
  <system-reminder>Claude Code's rate limit has been lifted. Continue the task you were working on before the interruption.</system-reminder>
  ```
- 旧文言「続けてください」を引用していたコメント（新規リミット通知ループ内）を新文言に合わせて更新。

## 設計判断

- レートリミットが解除された事実の明示と、作業継続を促す指示文の2点のみを含める。レートリミットの種類（session/weekly）や元のリセット時刻文言は含めない（既存のDiscord通知に引き続き含まれる）。
- `tmux send-keys` は文字列中の改行を Enter キー入力として送信してしまうため、メッセージは1行に収める。
- 言語は英語。エージェント自身に向けたシステムレベルの通知であり、ハーネスが実際に使う英語のシステムリマインダーと同じトーン・言語に揃えることで、エージェントが正規の状態通知として認識しやすくする。
- 類似の自動再開ツール（claude-auto-retry, autoclaude, auto-claude-resume-after-limit-reset 等）を調査したが、いずれも単純な固定文言（`"continue"`）を送信するのみで、ハーネスのシステムリマインダー形式を模した例は見られなかった。
- tmux プロセスクラッシュ時の引き継ぎ・自動復帰は別Issueとしてスコープ外。

## 検証

- `bash -n` によるシンタックスチェック: エラーなし
- tmux ペインへの手動送信テストで、意図した1行のメッセージが改行やエンコード崩れなく送信されることを確認済み
- `/deep-review`（ローカル diff モード）実施済み。Score 50以上の指摘（コメントの改行位置）は修正済み

Closes #208

Spec: https://github.com/book000/dotfiles/issues/208#issuecomment-4895901000
Plan: https://github.com/book000/dotfiles/issues/208#issuecomment-4895927935