### PR TITLE
fix: tmuxセッション名が数字のみの場合に対象セッションを取り違えるバグを修正する

### DIFF
--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -172,9 +172,9 @@ send_discord() {
 resume_session() {
     local session="$1" pane_content
 
-    # "0" のような裸の数字セッション名は tmux に「未指定」とみなされ現在の
-    # セッションへフォールバックしてしまうため、末尾に ":" を付けてセッション名
-    # 指定であることを明示する（display-message と同様の理由）
+    # "0" のような裸の数字セッション名は tmux に「未指定」とみなされ
+    # 現在のセッションへフォールバックしてしまうため、末尾に ":" を付けて
+    # セッション名指定であることを明示する（display-message と同様の理由）
     pane_content=$(tmux capture-pane -t "${session}:" -p 2>/dev/null)
     if echo "$pane_content" | grep -q "What do you want to do"; then
         tmux send-keys -t "${session}:" Escape

--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -25,7 +25,10 @@ source ./.env
 resolve_jsonl_path() {
     local session="$1" pane_pid claude_pid config_dir session_file dir session_id
 
-    pane_pid=$(tmux display-message -t "$session" -p '#{pane_pid}' 2>/dev/null) || return 1
+    # tmux はターゲットが "0" のような裸の数字だと、セッション名ではなく
+    # 「未指定」とみなして現在アクティブなセッションへフォールバックしてしまう
+    # ため、末尾に ":" を付けてセッション名指定であることを明示する
+    pane_pid=$(tmux display-message -t "${session}:" -p '#{pane_pid}' 2>/dev/null) || return 1
     claude_pid=$(pgrep -P "$pane_pid" -f "^claude" | head -1)
     [ -n "$claude_pid" ] || return 1
 
@@ -123,7 +126,7 @@ detect_limited_sessions() {
         IFS=$'\t' read -r is_limited reset_epoch reset_text <<< "$status_line"
         [ "$is_limited" = "1" ] || continue
 
-        cwd=$(tmux display-message -t "$session" -p '#{pane_current_path}' 2>/dev/null || echo "unknown")
+        cwd=$(tmux display-message -t "${session}:" -p '#{pane_current_path}' 2>/dev/null || echo "unknown")
         echo -e "${session}\t${cwd}\t${reset_epoch}\t${reset_text}" >> "$NEW_STATE_FILE"
     done
 
@@ -169,15 +172,18 @@ send_discord() {
 resume_session() {
     local session="$1" pane_content
 
-    pane_content=$(tmux capture-pane -t "$session" -p 2>/dev/null)
+    # "0" のような裸の数字セッション名は tmux に「未指定」とみなされ現在の
+    # セッションへフォールバックしてしまうため、末尾に ":" を付けてセッション名
+    # 指定であることを明示する（display-message と同様の理由）
+    pane_content=$(tmux capture-pane -t "${session}:" -p 2>/dev/null)
     if echo "$pane_content" | grep -q "What do you want to do"; then
-        tmux send-keys -t "$session" Escape
+        tmux send-keys -t "${session}:" Escape
         sleep 0.5
     fi
 
-    tmux send-keys -t "$session" "<system-reminder>Claude Code's rate limit has been lifted. Continue the task you were working on before the interruption.</system-reminder>"
+    tmux send-keys -t "${session}:" "<system-reminder>Claude Code's rate limit has been lifted. Continue the task you were working on before the interruption.</system-reminder>"
     sleep 1
-    tmux send-keys -t "$session" Enter
+    tmux send-keys -t "${session}:" Enter
 }
 
 # セッション名が対象ファイルに存在するか確認する
@@ -218,7 +224,7 @@ while IFS=$'\t' read -r session cwd reset_epoch reset_text; do
     [ -n "$session" ] || continue
     session_recorded_in "$session" "$NEW_STATE_FILE" && continue # まだリミット中
 
-    if tmux has-session -t "$session" 2>/dev/null; then
+    if tmux has-session -t "${session}:" 2>/dev/null; then
         echo "Limit unlocked: $session ($cwd)"
         send_discord \
             "Claude Code のリミット解除" \


### PR DESCRIPTION
## 概要

`limit-unlocked/check-notify.sh` が、tmux セッション名が `"0"` のような裸の数字である場合に、対象セッションを取り違えて操作していたバグを修正する。

## 原因

tmux は `-t` のターゲットが `"0"` のような裸の数字だと、セッション名としてマッチさせず「未指定」とみなし、現在アクティブなセッションへフォールバックする挙動がある（tmux 3.6 で確認）。

```
target=0  -> セッション5, pane_pid 3184246   誤り（セッション0のはずが別セッションに化ける）
target=3  -> セッション3, pane_pid 2887886   正しい
target=5  -> セッション5, pane_pid 3184246   正しい
target=0: -> セッション0, pane_pid 2587031   コロンを付けると正しく解決
```

`"0"` のときだけ誤爆し、他の数字は問題ない。これにより `resolve_jsonl_path` / `detect_limited_sessions` / `resume_session` / 解除通知判定のすべての tmux 呼び出し（`display-message` / `capture-pane` / `send-keys` / `has-session`）が、セッション名 `"0"` に対して常に別セッションを操作しており、実際にリミット到達した会話へ一度も再開キーが送られていなかった。

## 修正内容

`tmux ... -t "$session"` を `tmux ... -t "${session}:"` に変更し、末尾のコロンでセッション名指定であることを明示する。対象は以下の4呼び出し(7箇所)。

- `resolve_jsonl_path` 内の `display-message`
- `detect_limited_sessions` 内の `display-message`
- `resume_session` 内の `capture-pane` / `send-keys` ×3
- 解除通知判定の `has-session`

## 検証

- 実環境の tmux セッション（0, 3, 5）で修正前後のターゲット解決結果を比較し、`":"` 付与で正しく解決することを確認。
- スクリプトの関数群を抽出し、`resolve_jsonl_path` がセッション0の実際の会話ログ（レートリミット到達中の fauxcord/issue-106 セッション）を正しく解決することを確認。
- `detect_limited_sessions` を実行し、リミット中セッションとして正しく検出・`resume_session` 呼び出しに至ることを確認（実際の tmux 操作はスタブ化してテスト）。
- `bash -n` で構文チェック。

## レビュー

`/deep-review`（ローカル diff モード）を実施。8つの観点（CLAUDE.md 準拠・bugs・git history・comment quality・security・performance・error handling・type/tests）で確認し、comment quality の指摘（新規コメント内の不自然な行中改行）を修正済み。他は問題なし。