### PR TITLE
fix: tmuxセレクタのcwd表示が~に固定される問題を修正する

### DIFF
--- a/home/dot_bash_profile.d/executable_10-tmux-selector.sh
+++ b/home/dot_bash_profile.d/executable_10-tmux-selector.sh
@@ -122,8 +122,9 @@ tmux_session_selector() {
 
         # TMUX_PROJECT_DIR が設定されていれば優先する。
         # pane_current_path はサブプロセスの影響で一時的に別ディレクトリを指すことがあるため信頼性が低い。
-        # 設定方法: tmux new-session -e TMUX_PROJECT_DIR="$(pwd)"
-        #           または tmux set-environment -t <session> TMUX_PROJECT_DIR "$(pwd)"
+        # 初期値は "Create New Session" 選択時に現在のディレクトリで設定され、
+        # 以降は dot_zshrc.d/executable_15-tmux-cwd.zsh・dot_bashrc.d/executable_15-tmux-cwd.sh の
+        # precmd/PROMPT_COMMAND フックがプロンプト表示のたびに実際のcwdへ更新し続ける。
         local project_dir
         project_dir="$(tmux show-environment -t "${sname}" TMUX_PROJECT_DIR 2>/dev/null)"
         if [[ "$project_dir" == TMUX_PROJECT_DIR=* ]]; then

--- a/home/dot_bash_profile.d/executable_10-tmux-selector.sh
+++ b/home/dot_bash_profile.d/executable_10-tmux-selector.sh
@@ -123,8 +123,8 @@ tmux_session_selector() {
         # TMUX_PROJECT_DIR が設定されていれば優先する。
         # pane_current_path はサブプロセスの影響で一時的に別ディレクトリを指すことがあるため信頼性が低い。
         # 初期値は "Create New Session" 選択時に現在のディレクトリで設定され、
-        # 以降は dot_zshrc.d/executable_15-tmux-cwd.zsh・dot_bashrc.d/executable_15-tmux-cwd.sh の
-        # precmd/PROMPT_COMMAND フックがプロンプト表示のたびに実際のcwdへ更新し続ける。
+        # 以降は ~/.zshrc.d/15-tmux-cwd.zsh・~/.bashrc.d/15-tmux-cwd.sh の
+        # precmd/PROMPT_COMMAND フックがプロンプト表示のたびに実際の cwd へ更新し続ける。
         local project_dir
         project_dir="$(tmux show-environment -t "${sname}" TMUX_PROJECT_DIR 2>/dev/null)"
         if [[ "$project_dir" == TMUX_PROJECT_DIR=* ]]; then

--- a/home/dot_bashrc.d/executable_15-tmux-cwd.sh
+++ b/home/dot_bashrc.d/executable_15-tmux-cwd.sh
@@ -14,6 +14,6 @@ if declare -p PROMPT_COMMAND 2>/dev/null | grep -q '^declare -a'; then
     PROMPT_COMMAND+=(__bashrc_update_tmux_project_dir)
   fi
 elif [[ "${PROMPT_COMMAND:-}" != *"__bashrc_update_tmux_project_dir"* ]]; then
-  # shellcheck disable=SC2178,SC2128 # このブランチはPROMPT_COMMANDが配列でない場合のみ通る（上のif条件で排他）
+  # shellcheck disable=SC2178,SC2128 # このブランチは PROMPT_COMMAND が配列でない場合のみ通る（上の if 条件で排他）
   PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND}; }__bashrc_update_tmux_project_dir"
 fi

--- a/home/dot_bashrc.d/executable_15-tmux-cwd.sh
+++ b/home/dot_bashrc.d/executable_15-tmux-cwd.sh
@@ -1,12 +1,18 @@
-# tmuxセッション選択UI（10-tmux-selector）のcwd表示を最新に保つため、
-# プロンプト表示のたびにTMUX_PROJECT_DIRをカレントディレクトリで更新する。
-# tmux外では何もしない。
+# tmux セッション選択UI（10-tmux-selector）の cwd 表示を最新に保つため、
+# プロンプト表示のたびに TMUX_PROJECT_DIR をカレントディレクトリで更新する。
+# tmux 外では何もしない。
 __bashrc_update_tmux_project_dir() {
   [[ -n "${TMUX:-}" ]] || return 0
   tmux set-environment TMUX_PROJECT_DIR "$PWD" 2>/dev/null
 }
 
-# PROMPT_COMMANDへの登録はidempotentに行う
-if [[ "${PROMPT_COMMAND:-}" != *"__bashrc_update_tmux_project_dir"* ]]; then
+# PROMPT_COMMAND への登録は idempotent に行う。
+# Bash 5.1+ では PROMPT_COMMAND が配列になり得るため、スカラーへの単純代入で
+# 他要素を破壊しないよう配列/スカラーそれぞれの形で分岐する。
+if declare -p PROMPT_COMMAND 2>/dev/null | grep -q '^declare -a'; then
+  if [[ ! " ${PROMPT_COMMAND[*]} " == *" __bashrc_update_tmux_project_dir "* ]]; then
+    PROMPT_COMMAND+=(__bashrc_update_tmux_project_dir)
+  fi
+elif [[ "${PROMPT_COMMAND:-}" != *"__bashrc_update_tmux_project_dir"* ]]; then
   PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND}; }__bashrc_update_tmux_project_dir"
 fi

--- a/home/dot_bashrc.d/executable_15-tmux-cwd.sh
+++ b/home/dot_bashrc.d/executable_15-tmux-cwd.sh
@@ -1,0 +1,12 @@
+# tmuxセッション選択UI（10-tmux-selector）のcwd表示を最新に保つため、
+# プロンプト表示のたびにTMUX_PROJECT_DIRをカレントディレクトリで更新する。
+# tmux外では何もしない。
+__bashrc_update_tmux_project_dir() {
+  [[ -n "${TMUX:-}" ]] || return 0
+  tmux set-environment TMUX_PROJECT_DIR "$PWD" 2>/dev/null
+}
+
+# PROMPT_COMMANDへの登録はidempotentに行う
+if [[ "${PROMPT_COMMAND:-}" != *"__bashrc_update_tmux_project_dir"* ]]; then
+  PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND}; }__bashrc_update_tmux_project_dir"
+fi

--- a/home/dot_bashrc.d/executable_15-tmux-cwd.sh
+++ b/home/dot_bashrc.d/executable_15-tmux-cwd.sh
@@ -14,5 +14,6 @@ if declare -p PROMPT_COMMAND 2>/dev/null | grep -q '^declare -a'; then
     PROMPT_COMMAND+=(__bashrc_update_tmux_project_dir)
   fi
 elif [[ "${PROMPT_COMMAND:-}" != *"__bashrc_update_tmux_project_dir"* ]]; then
+  # shellcheck disable=SC2178,SC2128 # このブランチはPROMPT_COMMANDが配列でない場合のみ通る（上のif条件で排他）
   PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND}; }__bashrc_update_tmux_project_dir"
 fi

--- a/home/dot_bashrc.d/executable_15-tmux-cwd.sh
+++ b/home/dot_bashrc.d/executable_15-tmux-cwd.sh
@@ -1,9 +1,13 @@
 # tmux セッション選択UI（10-tmux-selector）の cwd 表示を最新に保つため、
 # プロンプト表示のたびに TMUX_PROJECT_DIR をカレントディレクトリで更新する。
 # tmux 外では何もしない。
+# $PWD が前回実行時から変化していない場合は tmux コマンドの起動自体を
+# スキップし、プロンプト表示のたびに外部コマンドが走ることによる遅延を避ける。
 __bashrc_update_tmux_project_dir() {
   [[ -n "${TMUX:-}" ]] || return 0
+  [[ "$PWD" == "${__BASHRC_TMUX_PROJECT_DIR_LAST:-}" ]] && return 0
   tmux set-environment TMUX_PROJECT_DIR "$PWD" 2>/dev/null
+  __BASHRC_TMUX_PROJECT_DIR_LAST="$PWD"
 }
 
 # PROMPT_COMMAND への登録は idempotent に行う。

--- a/home/dot_zshrc.d/executable_15-tmux-cwd.zsh
+++ b/home/dot_zshrc.d/executable_15-tmux-cwd.zsh
@@ -1,0 +1,11 @@
+# tmuxセッション選択UI（10-tmux-selector）のcwd表示を最新に保つため、
+# プロンプト表示のたびにTMUX_PROJECT_DIRをカレントディレクトリで更新する。
+# tmux外では何もしない。
+_update_tmux_project_dir() {
+  [[ -n "${TMUX:-}" ]] || return 0
+  tmux set-environment TMUX_PROJECT_DIR "$PWD" 2>/dev/null
+}
+
+# add-zsh-hookを用いてprecmdフックにidempotentに登録する
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _update_tmux_project_dir

--- a/home/dot_zshrc.d/executable_15-tmux-cwd.zsh
+++ b/home/dot_zshrc.d/executable_15-tmux-cwd.zsh
@@ -1,11 +1,11 @@
-# tmuxセッション選択UI（10-tmux-selector）のcwd表示を最新に保つため、
-# プロンプト表示のたびにTMUX_PROJECT_DIRをカレントディレクトリで更新する。
-# tmux外では何もしない。
+# tmux セッション選択UI（10-tmux-selector）の cwd 表示を最新に保つため、
+# プロンプト表示のたびに TMUX_PROJECT_DIR をカレントディレクトリで更新する。
+# tmux 外では何もしない。
 _update_tmux_project_dir() {
   [[ -n "${TMUX:-}" ]] || return 0
   tmux set-environment TMUX_PROJECT_DIR "$PWD" 2>/dev/null
 }
 
-# add-zsh-hookを用いてprecmdフックにidempotentに登録する
+# add-zsh-hook を用いて precmd フックに idempotent に登録する
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd _update_tmux_project_dir

--- a/home/dot_zshrc.d/executable_15-tmux-cwd.zsh
+++ b/home/dot_zshrc.d/executable_15-tmux-cwd.zsh
@@ -1,9 +1,13 @@
 # tmux セッション選択UI（10-tmux-selector）の cwd 表示を最新に保つため、
 # プロンプト表示のたびに TMUX_PROJECT_DIR をカレントディレクトリで更新する。
 # tmux 外では何もしない。
+# $PWD が前回実行時から変化していない場合は tmux コマンドの起動自体を
+# スキップし、プロンプト表示のたびに外部コマンドが走ることによる遅延を避ける。
 _update_tmux_project_dir() {
   [[ -n "${TMUX:-}" ]] || return 0
+  [[ "$PWD" == "${_TMUX_PROJECT_DIR_LAST:-}" ]] && return 0
   tmux set-environment TMUX_PROJECT_DIR "$PWD" 2>/dev/null
+  _TMUX_PROJECT_DIR_LAST="$PWD"
 }
 
 # add-zsh-hook を用いて precmd フックに idempotent に登録する


### PR DESCRIPTION
## 概要

tmux セッションセレクタ（SSH ログイン時に起動する fzf UI）で、ほぼ全セッションの cwd 表示が `~` に固定されてしまう問題を修正する。

## 原因

PR #154 で導入された `TMUX_PROJECT_DIR` は、セッション作成時（`tmux new-session -e "TMUX_PROJECT_DIR=$(pwd)"`）の一度きりのスナップショットであり、その後セッション内で `cd` しても更新される経路が存在しなかった。

自動起動フローの都合上、セレクタでの「Create New Session」選択はログイン直後・`$HOME` にいる状態で行われることが多く、`TMUX_PROJECT_DIR=$HOME` が永久に焼き付けられていた。表示ロジックは `TMUX_PROJECT_DIR` を `pane_current_path`（実際の cwd）より常に優先するため、結果として cwd 表示がほぼ全セッションで `~` に固定されていた。

## 修正内容

- `home/dot_zshrc.d/executable_15-tmux-cwd.zsh`: `precmd` フック（`add-zsh-hook`）を追加し、プロンプト表示のたびに `TMUX_PROJECT_DIR` を実際の cwd で更新する（tmux 外では no-op）。
- `home/dot_bashrc.d/executable_15-tmux-cwd.sh`: 同等の `PROMPT_COMMAND` フックを追加。Bash 5.1+ で `PROMPT_COMMAND` が配列の場合も既存要素を破壊しないよう分岐。
- `home/dot_bash_profile.d/executable_10-tmux-selector.sh`: 上記機構を指すコメントを更新（chezmoi デプロイ後の実パスに合わせて `executable_` プレフィックスを除去）。

## 動作確認

- `bash -n` / `zsh -n` で構文チェック済み。
- 隔離ソケット（`tmux -L test-cwd-verify*`）上でペイン内から `tmux set-environment TMUX_PROJECT_DIR "$PWD"` を実行し、対象セッションの環境変数が正しく更新されることを確認（実セッションには非接触）。
- `PROMPT_COMMAND` フックの分岐を、未設定/スカラー既存/配列/冪等性の 4 パターンでサブシェル実行確認済み。

## レビュー

`/deep-review`（ローカル diff モード）を実施。score ≥ 50 の指摘 3 件（半角スペース欠落・コメント内のデプロイ後パス不一致・`PROMPT_COMMAND` 配列対応）を修正済み。
