### PR TITLE
refactor: 常時 import 系を整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ applies_to: all        # all | pr-only（省略時は all）
 
 ## `rtk` スキル
 
-`rtk`(Rust Token Killer)メタコマンドのリファレンス。
+`rtk` (Rust Token Killer) メタコマンドのリファレンス。
 `home/dot_claude/skills/rtk/SKILL.md` として管理され、`chezmoi apply` で `~/.claude/skills/rtk/SKILL.md` にデプロイされる。
 
 通常のシェルコマンドは Claude Code の hook 経由で自動的に `rtk` 経由へ書き換えられるため常時ドキュメント化は不要だが、`rtk gain` などのメタコマンドはこの skill が唯一のリファレンスであり、必要な場面でのみ読み込まれる。

--- a/README.md
+++ b/README.md
@@ -296,3 +296,19 @@ applies_to: all        # all | pr-only（省略時は all）
 - **乖離度に応じた判断**: 既存 `CLAUDE.md` とベストプラクティスとの乖離が大きい場合は全面的に書き直し、小さい場合は部分修正にとどめる（既存ファイルがない場合は新規作成）
 - **承認フローなし**: 対象ディレクトリが git 管理下であることを前提に、変更内容は `git diff`（新規作成時は `git status`）で事後確認する運用とし、実行前の承認は求めない
 - **対象は CLAUDE.md のみ**: `AGENTS.md` 等の他のエージェント設定ファイルは対象外（将来の拡張候補）
+
+## `rtk` スキル
+
+`rtk`(Rust Token Killer)メタコマンドのリファレンス。
+`home/dot_claude/skills/rtk/SKILL.md` として管理され、`chezmoi apply` で `~/.claude/skills/rtk/SKILL.md` にデプロイされる。
+
+通常のシェルコマンドは Claude Code の hook 経由で自動的に `rtk` 経由へ書き換えられるため常時ドキュメント化は不要だが、`rtk gain` などのメタコマンドはこの skill が唯一のリファレンスであり、必要な場面でのみ読み込まれる。
+
+### 使い方
+
+```bash
+rtk gain              # トークン削減量の分析結果を表示
+rtk gain --history     # コマンド使用履歴と削減量を表示
+rtk discover           # Claude Code の履歴から見逃された削減機会を分析
+rtk proxy <cmd>        # フィルタなしで生コマンドを実行(デバッグ用)
+```

--- a/home/dot_claude/.gitignore
+++ b/home/dot_claude/.gitignore
@@ -27,5 +27,4 @@ plugins/repos/
 !.gitignore
 !README.md
 !CLAUDE.md
-!RTK.md
 !private_settings.json

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -36,7 +36,19 @@
 | `/handle-pr-reviews <URL>` | Reply and resolve review threads |
 | `/wait-for-copilot-review <number>` | Background wait for Copilot review |
 
-See @rules/workflow.md for checklists and Jira rules.
+See `rules/workflow.md` for checklists and Jira rules.
+
+## Context loading
+
+Not auto-loaded. Read the relevant file only when the situation applies:
+
+| When | Read |
+|---|---|
+| Checklists / Jira rules needed | `rules/workflow.md` |
+| Writing a spec or plan document | `rules/superpowers.md` |
+| Posting a spec/plan/investigation doc to a GitHub Issue | `rules/issue-comment-docs.md` |
+| Posting a spec/plan/investigation doc to Confluence | `rules/confluence.md` |
+| Using an `rtk` meta command (`gain`, `discover`, `proxy`) | `rtk` skill |
 
 ## Tracking
 
@@ -49,7 +61,3 @@ Use the Todo tool for all multi-step work without omission.
 - chezmoi: `executable_` prefix is stripped at deploy — reference scripts without it in settings/configs.
 
 @CLAUDE.local.md
-@RTK.md
-@rules/superpowers.md
-@rules/confluence.md
-@rules/issue-comment-docs.md

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -36,8 +36,6 @@
 | `/handle-pr-reviews <URL>` | Reply and resolve review threads |
 | `/wait-for-copilot-review <number>` | Background wait for Copilot review |
 
-See `rules/workflow.md` for checklists and Jira rules.
-
 ## Context loading
 
 Not auto-loaded. Read the relevant file only when the situation applies:

--- a/home/dot_claude/skills/rtk/SKILL.md
+++ b/home/dot_claude/skills/rtk/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: rtk
+description: Reference for rtk (Rust Token Killer) meta commands — rtk gain / gain --history / discover / proxy. Use when the user wants token-savings analytics, usage history, or to run a raw command without the transparent git/... rewrite hook.
+disable-model-invocation: false
+---
+
 # RTK - Rust Token Killer
 
 **Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
@@ -26,4 +32,5 @@ which rtk             # Verify correct binary
 All other commands are automatically rewritten by the Claude Code hook.
 Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
 
-Refer to CLAUDE.md for full command reference.
+This skill is the sole reference for `rtk` meta commands; it is loaded on
+demand instead of always being present in context.


### PR DESCRIPTION
Closes #219

## 概要

`home/dot_claude/CLAUDE.md` の末尾 `@import` による常時読み込みを廃止し、必要な場面でのみ読み込む「Context loading」表に置き換えた。

## 変更内容

- `home/dot_claude/CLAUDE.md`: `@RTK.md` / `@rules/superpowers.md` / `@rules/confluence.md` / `@rules/issue-comment-docs.md` の常時読み込みを削除し、`## Context loading` 表を新設(`@CLAUDE.local.md` は対象外のまま維持)
- `home/dot_claude/RTK.md` → `home/dot_claude/skills/rtk/SKILL.md` へ移行(新規 skill 化)
- `README.md`: `rtk` skill の説明を追記
- `home/dot_claude/.gitignore`: `RTK.md` 削除に伴うダングリング whitelist エントリ (`!RTK.md`) を除去

## 検証

- `tests/integration/test_chezmoi_apply.sh` を実行し、既存の統合テストが通ることを確認
- 一時 `$HOME` での `chezmoi apply` により、以下を確認:
  - `~/.claude/CLAUDE.md` に Context loading 表が反映される
  - `~/.claude/skills/rtk/SKILL.md` が配置される
  - `~/.claude/RTK.md` が再生成されない
  - `@CLAUDE.local.md` は変更されない
- `/deep-review`(local diff mode): score ≥ 50 の指摘なし

## 関連ドキュメント

- Spec: https://github.com/book000/dotfiles/issues/219#issuecomment-4928748680
- Plan: https://github.com/book000/dotfiles/issues/219#issuecomment-4928796903
