### PR TITLE
fix: gclがforkリポジトリ未作成時に誤ったエラーを出して失敗する不具合を修正する

### DIFF
--- a/home/dot_bashrc.d/executable_40-ghq.sh
+++ b/home/dot_bashrc.d/executable_40-ghq.sh
@@ -82,8 +82,7 @@ ghc() {
       # 出力と終了コードを分けて取得し、終了コードで確実に not_found を判定する
       local fork_check_output
       local fork_check
-      fork_check_output=$(gh api "repos/$current_user/${repo_name#*/}" --jq 'if .fork and .parent.full_name == "'"$repo_name"'" then "true" else "false" end' 2>/dev/null)
-      if [[ $? -ne 0 ]]; then
+      if ! fork_check_output=$(gh api "repos/$current_user/${repo_name#*/}" --jq 'if .fork and .parent.full_name == "'"$repo_name"'" then "true" else "false" end' 2>/dev/null); then
         fork_check="not_found"
       else
         fork_check="$fork_check_output"

--- a/home/dot_bashrc.d/executable_40-ghq.sh
+++ b/home/dot_bashrc.d/executable_40-ghq.sh
@@ -78,8 +78,16 @@ ghc() {
       fi
 
       # Fork が既に存在するかチェック（.fork フラグと .parent を確認）
+      # gh api は 404 でもエラーレスポンスに --jq フィルタを適用した上で非ゼロ終了するため、
+      # 出力と終了コードを分けて取得し、終了コードで確実に not_found を判定する
+      local fork_check_output
       local fork_check
-      fork_check=$(gh api "repos/$current_user/${repo_name#*/}" --jq 'if .fork and .parent.full_name == "'"$repo_name"'" then "true" else "false" end' 2>/dev/null || echo "not_found")
+      fork_check_output=$(gh api "repos/$current_user/${repo_name#*/}" --jq 'if .fork and .parent.full_name == "'"$repo_name"'" then "true" else "false" end' 2>/dev/null)
+      if [[ $? -ne 0 ]]; then
+        fork_check="not_found"
+      else
+        fork_check="$fork_check_output"
+      fi
 
       if [[ "$fork_check" == "not_found" ]]; then
         echo "Creating fork..."

--- a/home/dot_zshrc.d/executable_40-ghq.zsh
+++ b/home/dot_zshrc.d/executable_40-ghq.zsh
@@ -82,8 +82,7 @@ ghc() {
       # 出力と終了コードを分けて取得し、終了コードで確実に not_found を判定する
       local fork_check_output
       local fork_check
-      fork_check_output=$(gh api "repos/$current_user/${repo_name#*/}" --jq 'if .fork and .parent.full_name == "'"$repo_name"'" then "true" else "false" end' 2>/dev/null)
-      if [[ $? -ne 0 ]]; then
+      if ! fork_check_output=$(gh api "repos/$current_user/${repo_name#*/}" --jq 'if .fork and .parent.full_name == "'"$repo_name"'" then "true" else "false" end' 2>/dev/null); then
         fork_check="not_found"
       else
         fork_check="$fork_check_output"

--- a/home/dot_zshrc.d/executable_40-ghq.zsh
+++ b/home/dot_zshrc.d/executable_40-ghq.zsh
@@ -78,8 +78,16 @@ ghc() {
       fi
 
       # Fork が既に存在するかチェック（.fork フラグと .parent を確認）
+      # gh api は 404 でもエラーレスポンスに --jq フィルタを適用した上で非ゼロ終了するため、
+      # 出力と終了コードを分けて取得し、終了コードで確実に not_found を判定する
+      local fork_check_output
       local fork_check
-      fork_check=$(gh api "repos/$current_user/${repo_name#*/}" --jq 'if .fork and .parent.full_name == "'"$repo_name"'" then "true" else "false" end' 2>/dev/null || echo "not_found")
+      fork_check_output=$(gh api "repos/$current_user/${repo_name#*/}" --jq 'if .fork and .parent.full_name == "'"$repo_name"'" then "true" else "false" end' 2>/dev/null)
+      if [[ $? -ne 0 ]]; then
+        fork_check="not_found"
+      else
+        fork_check="$fork_check_output"
+      fi
 
       if [[ "$fork_check" == "not_found" ]]; then
         echo "Creating fork..."


### PR DESCRIPTION
## 概要

`gcl`(`ghc`のエイリアス)コマンドが、fork リポジトリがまだ作成されていない場合に誤ったエラーメッセージを出して失敗する不具合を修正しました。

## 原因

`ghc`関数内で fork の存在確認を行う際、以下のようにフォールバックしていました。

```bash
fork_check=$(gh api "repos/$current_user/$repo" --jq '...' 2>/dev/null || echo "not_found")
```

`gh api`は HTTP 404(fork が未作成)の場合でも、エラーレスポンスボディを標準出力に出力した上で非ゼロ終了します。そのため `||` のフォールバックによる `"not_found"` の追記と合わさり、`fork_check`が「JSONエラーボディ + not_found」という2部構成の文字列になってしまい、`"not_found"`とも`"true"`/`"false"`とも一致せず、誤って「forkは存在するが親リポジトリが異なる」という`else`分岐に落ちて失敗していました。

## 修正内容

`gh api`の標準出力と終了コードを分離して取得し、終了コードが非ゼロの場合は出力内容を破棄して`"not_found"`として確実に扱うように修正しました。

対象ファイル(bash/zsh双方に同一ロジックが重複しているため両方修正):

- `home/dot_bashrc.d/executable_40-ghq.sh`
- `home/dot_zshrc.d/executable_40-ghq.zsh`

## 検証

`gh`コマンドをモックし、以下3パターンで動作確認済み:

- fork未作成(404) → 正しく「フォーク作成」に進む(修正前は誤ったエラーで失敗していた)
- fork既存(true) → 「Fork already exists.」
- forkでないリポジトリが存在(false) → 「exists but is not a fork」エラー(正しい挙動)

bash版・zsh版の両方で同様に確認済みです。

Closes #216