### PR TITLE
docs: コード・コメント・テスト・コミットが担う情報の層を明文化する

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -43,6 +43,7 @@ Not auto-loaded. Read the relevant file only when the situation applies:
 | When | Read |
 |---|---|
 | Checklists / Jira rules needed | `rules/workflow.md` |
+| Writing/reviewing code, comments, tests, commits | `rules/coding-common.md` |
 | Writing a spec or plan document | `rules/superpowers.md` |
 | Posting a spec/plan/investigation doc to a GitHub Issue | `rules/issue-comment-docs.md` |
 | Posting a spec/plan/investigation doc to Confluence | `rules/confluence.md` |

--- a/home/dot_claude/rules/coding-common.md
+++ b/home/dot_claude/rules/coding-common.md
@@ -30,4 +30,9 @@ Rules that apply regardless of language.
 - Insert a half-width space between Japanese and alphanumeric characters in comments and text
 - If existing error messages in a file have emoji prefixes, unify emoji usage across all error messages in that file
   - Use a single emoji that matches the content of the error message
-- Write concise comments: omit the self-evident, explain *why* not *what*, and never leave edit-history notes (e.g. "Deleted X") in code — history belongs in commit messages / PRs
+- Content layer — each artifact carries one distinct layer of information; do not duplicate a layer into another artifact:
+  - **Code** expresses *how*: the implementation steps themselves. If a comment is needed to understand the code, make the code clearer first instead of adding narration.
+  - **Code comments** express *why not*: rejected alternatives, workarounds, non-obvious constraints. A comment that only restates what the next line already shows is a violation — delete it instead of writing it.
+  - **Test code** expresses *what*: test/spec names and assertions state the behavior being verified, not the internal implementation steps.
+  - **Commit messages** express *why*: the description/body explains the motivation/reasoning for the change. The diff itself already shows *what* changed — do not restate it.
+- Never leave edit-history notes (e.g. "Deleted X") in code — history belongs in commit messages / PRs


### PR DESCRIPTION
## 概要

Claude Code が実装・コメント・テスト・コミットログを書く際、成果物ごとに担うべき情報の層を明文化した。

- **Code**: How(実装の手順そのもの)
- **Code comments**: Why not(却下した代替案・回避策・非自明な制約。次の行の言い換えになっているコメントは削除対象)
- **Test code**: What(検証している振る舞い)
- **Commit messages**: Why(変更の動機。diff 自体が What を示すため繰り返さない)

## 配置方針

- 過去の PR (#152, #224) で確立された「`CLAUDE.md` 本体は最小化し、詳細は `rules/*.md` に置く」という方針に合わせ、詳細は `home/dot_claude/rules/coding-common.md` に追加。
- `CLAUDE.md` 本体には Context loading 表への参照行を 1 行追加するのみ(61→62 行)。
- `rules/coding-common.md` は deep-review の CLAUDE.md 準拠チェックで常時読み込まれるため、通常のコードレビュー経路でも有効。

## 動作確認

- ドキュメントのみの変更のため、`chezmoi apply` や CI に影響する差分はなし。
- deep-review(ローカル diff モード)を実行し、履歴コンテキストレビューの指摘 (`CLAUDE.md` 肥大化) を受けて上記の配置に修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)