### PR TITLE
docs: コードコメント・ドキュメント類のデフォルト言語を英語にする

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -12,7 +12,7 @@
 ## Language
 
 - Respond in Japanese. Intermediate steps in English to save context.
-- Code comments: follow project CLAUDE.md; default Japanese. Error messages: English.
+- Code comments: follow project CLAUDE.md; default English. Error messages: English.
 - Half-width space between Japanese and alphanumeric characters.
 - **All Markdown under `~/.claude/` must be written in English.**
 

--- a/home/dot_claude/rules/coding-csharp.md
+++ b/home/dot_claude/rules/coding-csharp.md
@@ -85,7 +85,7 @@ paths:
   between using groups
 - Prefer expression-bodied members (`=>`) when the body fits on one line; prefer
   pattern matching, switch expressions, and target-typed `new()`
-- XML doc comments on public/exposed members, written in Japanese unless the
+- XML doc comments on public/exposed members, written in English unless the
   project's own CLAUDE.md says otherwise
 - Suppress a specific, justified diagnostic with
   `[SuppressMessage("Category", "RuleId:Name", Justification = "...")]` rather than a

--- a/home/dot_claude/rules/coding-py.md
+++ b/home/dot_claude/rules/coding-py.md
@@ -21,4 +21,4 @@ paths:
 
 ## Documentation
 
-- Write docstrings for all functions and classes. Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese
+- Write docstrings for all functions and classes. Language: follow the project CLAUDE.md if it specifies one; otherwise English

--- a/home/dot_claude/rules/coding-sh.md
+++ b/home/dot_claude/rules/coding-sh.md
@@ -8,7 +8,7 @@ paths:
 
 ## Documentation
 
-- Write function description comments. Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese
+- Write function description comments. Language: follow the project CLAUDE.md if it specifies one; otherwise English
 
 ## Error Messages
 

--- a/home/dot_claude/rules/coding-ts.md
+++ b/home/dot_claude/rules/coding-ts.md
@@ -16,13 +16,13 @@ paths:
 
 ## Documentation
 
-- Write and maintain JSDoc (docstring) for all functions, interfaces, and classes. Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese
+- Write and maintain JSDoc (docstring) for all functions, interfaces, and classes. Language: follow the project CLAUDE.md if it specifies one; otherwise English
 
   ```typescript
   /**
-   * ユーザーの認証状態を確認する。
-   * @param userId - 確認するユーザーの ID
-   * @returns 認証済みなら true、未認証なら false
+   * Checks whether the user is authenticated.
+   * @param userId - The ID of the user to check
+   * @returns true if authenticated, false otherwise
    */
   function isAuthenticated(userId: string): boolean { ... }
   ```

--- a/home/dot_claude/rules/issue-comment-docs.md
+++ b/home/dot_claude/rules/issue-comment-docs.md
@@ -45,7 +45,7 @@ After posting or updating, report **the URL only** — do not paste the document
 
 ## Document Language
 
-Confluence pages were viewed only by the user, so they followed the user's private language setting. GitHub Issue comments are **public**, and the target project's main language may differ from the user's private setting. Documents posted here must follow **the language specified by the target project's CLAUDE.md (or AGENTS.md, etc.)** — not the user's private language preference. Default to Japanese only if the project specifies no language. Code blocks, commands, and identifiers stay in their original form regardless of the body language.
+Confluence pages were viewed only by the user, so they followed the user's private language setting. GitHub Issue comments are **public**, and the target project's main language may differ from the user's private setting. Documents posted here must follow **the language specified by the target project's CLAUDE.md (or AGENTS.md, etc.)** — not the user's private language preference. Default to English only if the project specifies no language. Code blocks, commands, and identifiers stay in their original form regardless of the body language.
 
 This matches the instruction `issue-pr` already gives when invoking `superpowers:brainstorming`/`superpowers:writing-plans` to write the spec/plan documents ("the language required by the target project's CLAUDE.md").
 


### PR DESCRIPTION
## 概要

コード内コメントおよび Issue コメントとして投稿するドキュメント類(spec/plan/investigation)のデフォルト言語を、プロジェクト固有の指定がない場合の既定値として日本語から英語に変更する。

## 変更内容

- `home/dot_claude/CLAUDE.md`: Code comments のデフォルト言語を English に変更
- `home/dot_claude/rules/coding-py.md`: docstring のデフォルト言語を English に変更
- `home/dot_claude/rules/coding-sh.md`: 関数説明コメントのデフォルト言語を English に変更
- `home/dot_claude/rules/coding-ts.md`: JSDoc のデフォルト言語を English に変更し、例示コードも英語化
- `home/dot_claude/rules/coding-csharp.md`: XML doc comment のデフォルト言語を English に変更
- `home/dot_claude/rules/issue-comment-docs.md`: Issue コメント投稿ドキュメントのデフォルト言語を English に変更

commit message / PR body / Jira チケットのデフォルト言語、およびこのリポジトリ自身のプロジェクト固有ルール(`./CLAUDE.md`、`.github/copilot-instructions.md`)は変更対象外(スコープ外)。

Closes #234

Spec: [Issue comment URL](https://github.com/book000/dotfiles/issues/234#issuecomment-4948536614)
Plan: [Issue comment URL](https://github.com/book000/dotfiles/issues/234#issuecomment-4948543753)
