### PR TITLE
feat: roots を導入し gcd でモノレポのルート探索に対応する

### DIFF
--- a/home/dot_bashrc.d/executable_40-ghq.sh
+++ b/home/dot_bashrc.d/executable_40-ghq.sh
@@ -1,13 +1,14 @@
 # ghq helpers.
 
-# ghqで管理されているリポジトリを選択して移動する関数
+# ghqで管理されているリポジトリ(roots 経由でモノレポ内のルートも含む)を選択して移動する関数
 gcd() {
   command -v ghq >/dev/null 2>&1 || { echo "ghq not found." >&2; return 1; }
+  command -v roots >/dev/null 2>&1 || { echo "roots not found." >&2; return 1; }
   command -v fzf >/dev/null 2>&1 || { echo "fzf not found." >&2; return 1; }
 
   local dir
-  # fzfを使ってリポジトリを選択
-  dir="$(ghq list -p | fzf)" || return 1
+  # ghq 管理下の各リポジトリを起点に roots でモノレポ内のルートディレクトリも列挙し、fzf で選択
+  dir="$(ghq list --full-path | roots | fzf)" || return 1
   # 選択されたディレクトリが存在すれば移動
   [[ -n "$dir" ]] && { cd "$dir" || return; }
 }

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@
 #     --skip-gh          gh CLI のインストールをスキップ
 #     --skip-ghq         ghq のインストールをスキップ
 #     --skip-mkwork      mkwork のインストールをスキップ
+#     --skip-roots       roots のインストールをスキップ
 #     --skip-interactive 対話的な確認をスキップ (CI 用、 /dev/tty が利用できない場合も自動的に非対話モードになります)
 #     --help             ヘルプを表示
 # ==============================================================================
@@ -31,6 +32,7 @@ SKIP_APT=0
 SKIP_GH=0
 SKIP_GHQ=0
 SKIP_MKWORK=0
+SKIP_ROOTS=0
 SKIP_INTERACTIVE=0
 
 # ヘルプメッセージを表示する関数
@@ -45,6 +47,7 @@ OPTIONS:
   --skip-gh          gh CLI のインストールをスキップ
   --skip-ghq         ghq のインストールをスキップ
   --skip-mkwork      mkwork のインストールをスキップ
+  --skip-roots       roots のインストールをスキップ
   --skip-interactive 対話的な確認をスキップ (CI 用、 /dev/tty が利用できない場合も自動的に非対話モードになります)
   --help             このヘルプを表示
 
@@ -81,6 +84,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-mkwork)
       SKIP_MKWORK=1
+      shift
+      ;;
+    --skip-roots)
+      SKIP_ROOTS=1
       shift
       ;;
     --skip-interactive)
@@ -555,6 +562,90 @@ install_ghq() {
   log_info "ghq が正常にインストールされました"
 }
 
+# roots のインストール
+install_roots() {
+  if [[ "$SKIP_ROOTS" == "1" ]]; then
+    log_info "roots のインストールをスキップします (--skip-roots)"
+    return 0
+  fi
+
+  log_info "roots をインストールしています..."
+
+  if command -v roots &> /dev/null; then
+    log_warn "roots は既にインストールされています"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log_info "[DRY RUN] roots の GitHub Release からのダウンロード・インストールをスキップします"
+    return 0
+  fi
+
+  log_info "GitHub Release から最新版を取得しています..."
+
+  local version
+  local api_response
+  api_response=$(curl -fsSL https://api.github.com/repos/k1LoW/roots/releases/latest)
+
+  if command -v jq &> /dev/null; then
+    version=$(printf '%s\n' "$api_response" | jq -r '.tag_name')
+  else
+    log_warn "jq is not installed. Falling back to grep/sed for version parsing"
+    version=$(printf '%s\n' "$api_response" | grep '"tag_name":' | sed -E 's/.*"(v[^"]+)".*/\1/')
+  fi
+
+  if [[ -z "$version" || "$version" == "null" ]]; then
+    log_error "Failed to parse latest version from GitHub API"
+    return 1
+  fi
+
+  log_info "最新バージョン: $version"
+
+  local download_url="https://github.com/k1LoW/roots/releases/download/${version}/roots_${version}_linux_${ARCH}.tar.gz"
+
+  log_info "ダウンロード URL: $download_url"
+
+  local temp_dir
+  temp_dir=$(mktemp -d)
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  if [[ ! -d "$temp_dir" ]]; then
+    log_error "Failed to create temporary directory"
+    return 1
+  fi
+
+  cd "$temp_dir" || { log_error "Failed to change directory to temporary directory"; return 1; }
+
+  if ! curl -fsSL -o roots.tar.gz "$download_url"; then
+    log_error "Failed to download roots archive"
+    cd - > /dev/null || true
+    return 1
+  fi
+
+  if ! tar -xzf roots.tar.gz; then
+    log_error "Failed to extract roots archive"
+    cd - > /dev/null || true
+    return 1
+  fi
+
+  local roots_binary
+  roots_binary=$(find . -maxdepth 1 -type f -name roots -print -quit)
+
+  if [[ -z "$roots_binary" ]]; then
+    log_error "roots binary not found after extraction"
+    cd - > /dev/null || true
+    return 1
+  fi
+
+  mkdir -p "$HOME/.local/bin"
+  mv "$roots_binary" "$HOME/.local/bin/roots"
+  chmod +x "$HOME/.local/bin/roots"
+
+  cd - > /dev/null
+
+  log_info "roots が正常にインストールされました"
+}
+
 # mkwork のインストール
 install_mkwork() {
   if [[ "$SKIP_MKWORK" == "1" ]]; then
@@ -829,6 +920,7 @@ main() {
   install_apt_packages
   install_gh_cli
   install_ghq
+  install_roots
   install_mkwork
   setup_gitconfig_local
   setup_env

--- a/tests/unit/test_install.sh
+++ b/tests/unit/test_install.sh
@@ -16,7 +16,7 @@ echo "✅ --help option test passed"
 # テスト 2: --dry-run オプション (環境チェックのみ)
 echo "Test 2: --dry-run option"
 # ANSI カラーコードを削除してから grep
-if ! bash install.sh --dry-run --skip-interactive --skip-apt --skip-gh --skip-ghq --skip-mkwork 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -q "DRY RUN"; then
+if ! bash install.sh --dry-run --skip-interactive --skip-apt --skip-gh --skip-ghq --skip-mkwork --skip-roots 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -q "DRY RUN"; then
   echo "❌ --dry-run option test failed"
   exit 1
 fi


### PR DESCRIPTION
## 概要

Issue #212 「rootsの導入」に対応し、[k1LoW/roots](https://github.com/k1LoW/roots) を dotfiles のインストール対象に追加する。`roots` はモノレポなど複数のルートディレクトリを探索する Go 製 CLI ツール。

## 変更内容

- `install.sh`: `install_roots` 関数を追加(GitHub Release からバイナリを取得し `~/.local/bin` に配置する、`install_mkwork` に近いシンプルな構成)。`--skip-roots` オプションとヘルプ表示も追加。
- `home/dot_bashrc.d/executable_40-ghq.sh`: `gcd` 関数を `ghq list --full-path | roots | fzf` に変更し、モノレポ内のルートディレクトリも選択対象にする。`roots` 未インストール時はエラーメッセージを出して終了する。
- `tests/unit/test_install.sh`: dry-run テストの引数に `--skip-roots` を追加。

## 検証

- `install.sh --help` / `--dry-run`(`--skip-roots` あり・なし両方)を確認
- `tests/unit/test_install.sh` / `tests/syntax/test_bash_syntax.sh` / `tests/syntax/test_shellcheck.sh`(変更ファイルは全て通過)/ `tests/integration/test_chezmoi_apply.sh` が通過
- 実際に `roots` バイナリをインストールし、`gcd` のパイプライン(`ghq list --full-path | roots | fzf`)が実ディレクトリを返すことをエンドツーエンドで確認
- `roots` 未インストール時に `gcd` がエラーメッセージを出して `return 1` することを確認
- `/deep-review` によるローカル diff レビュー(8観点)を実施、score 50 以上の指摘なし

## 関連ドキュメント

Closes #212

Spec: https://github.com/book000/dotfiles/issues/212#issuecomment-4950072945
Plan: https://github.com/book000/dotfiles/issues/212#issuecomment-4950082787