### PR TITLE
docs: 文中改行を避けるルールをCLAUDE.mdに一般化する

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -15,6 +15,7 @@
 - Code comments: follow project CLAUDE.md; default English. Error messages: English.
 - Half-width space between Japanese and alphanumeric characters.
 - **All Markdown under `~/.claude/` must be written in English.**
+- **No mid-sentence line breaks**: within a single prose paragraph (chat responses, generated Markdown documents/articles, PR/commit/comment bodies, etc.), do not insert a manual line break (hard-wrapping, e.g. at a fixed column width) in the middle of a sentence. Write each sentence as one continuous line in the source text; let the renderer wrap it. This applies to prose paragraphs, not to intentionally structured content (bullet lists, code blocks, tables), where one item/line per line is expected.
 
 ## Git
 

--- a/home/dot_claude/rules/confluence.md
+++ b/home/dot_claude/rules/confluence.md
@@ -81,6 +81,4 @@ Git/GitHub artifacts — only to documents whose primary purpose is to be read b
 - If MCP resolution (cloudId, space, page) fails, report the error to the user and ask how
   to proceed rather than guessing.
 - Uploaded content is still subject to `rules/security.md` — never include secrets.
-- **No mid-sentence line breaks in body text**: within a single Markdown paragraph, do not insert a manual line break (hard-wrapping, e.g. at a fixed column width) in the middle of a sentence.
-  Write each sentence as one continuous line in the source Markdown; let the renderer wrap it.
-  This applies to prose paragraphs, not to intentionally structured content (bullet lists, code blocks, tables), where one item/line per line is expected.
+- No mid-sentence line breaks in body text — see the global "No mid-sentence line breaks" rule in `CLAUDE.md`'s Language section.


### PR DESCRIPTION
## 概要

Claude Codeが文章(Markdownなど)を書く際に、文中で意図せず改行を挿入してしまう問題への対処。

## 変更内容

- `CLAUDE.md` の Language セクションに、文中改行を避けるルールを新規追加(チャット応答・生成文書・PR/commit/コメント本文などプローズ全般に適用)。
- `rules/confluence.md` に既にあった Confluence 本文限定の同種ルールは重複を避けるため、`CLAUDE.md` の当該ルールへの参照に整理。

Closes #238