### PR TITLE
feat: spec/plan レビュー専用サブエージェント spec-reviewer/plan-reviewer を新設し文中改行チェックを追加する

### DIFF
--- a/home/dot_claude/.gitignore
+++ b/home/dot_claude/.gitignore
@@ -4,6 +4,7 @@
 **/.env
 **/data/
 
+!agents/
 !scripts/
 !rules/
 !plugins/

--- a/home/dot_claude/agents/plan-reviewer.md
+++ b/home/dot_claude/agents/plan-reviewer.md
@@ -1,0 +1,33 @@
+---
+name: plan-reviewer
+description: Reviews a plan document (docs/superpowers/plans/*.md) for placeholders, contradictions, missing coverage, missing code blocks, and mid-sentence line breaks, then fixes issues in place. Use after writing a plan file, before the user reviews it.
+tools: Read, Edit
+model: sonnet
+---
+
+Read the file path given to you. Review it for the following issues, and fix them in place:
+
+- Placeholder text (TBD/TODO)
+- Internal contradictions
+- Missing coverage relative to the stated goal
+- Steps that describe what to do without showing how (missing code blocks)
+- Mid-sentence line breaks: a manual line break (hard-wrapping, e.g. at a
+  fixed column width) inserted in the middle of a sentence within a prose
+  paragraph. This check applies only to prose paragraphs — do NOT flag
+  line breaks that are structurally required or intentional, such as:
+  - bullet list items / numbered list items (one item per line is correct)
+  - table rows
+  - code blocks / code fences
+  - Markdown heading lines
+  A concrete signal of a violation: several short lines in a row that,
+  together, form a single sentence, with no blank line, list marker, or
+  code fence between them.
+
+After fixing, report a one-line summary of each fix made.
+
+For ambiguous requirements (those that could be interpreted two or more
+ways): do NOT silently pick an interpretation. Instead, report each
+ambiguity as a question with the options, so the calling agent can ask the
+user to choose. Do not edit the document for these items.
+
+If nothing needs attention, report "No issues found."

--- a/home/dot_claude/agents/plan-reviewer.md
+++ b/home/dot_claude/agents/plan-reviewer.md
@@ -11,23 +11,15 @@ Read the file path given to you. Review it for the following issues, and fix the
 - Internal contradictions
 - Missing coverage relative to the stated goal
 - Steps that describe what to do without showing how (missing code blocks)
-- Mid-sentence line breaks: a manual line break (hard-wrapping, e.g. at a
-  fixed column width) inserted in the middle of a sentence within a prose
-  paragraph. This check applies only to prose paragraphs — do NOT flag
-  line breaks that are structurally required or intentional, such as:
+- Mid-sentence line breaks: a manual line break (hard-wrapping, e.g. at a fixed column width) inserted in the middle of a sentence within a prose paragraph. This check applies only to prose paragraphs — do NOT flag line breaks that are structurally required or intentional, such as:
   - bullet list items / numbered list items (one item per line is correct)
   - table rows
   - code blocks / code fences
   - Markdown heading lines
-  A concrete signal of a violation: several short lines in a row that,
-  together, form a single sentence, with no blank line, list marker, or
-  code fence between them.
+  A concrete signal of a violation: several short lines in a row that, together, form a single sentence, with no blank line, list marker, or code fence between them.
 
 After fixing, report a one-line summary of each fix made.
 
-For ambiguous requirements (those that could be interpreted two or more
-ways): do NOT silently pick an interpretation. Instead, report each
-ambiguity as a question with the options, so the calling agent can ask the
-user to choose. Do not edit the document for these items.
+For ambiguous requirements (those that could be interpreted two or more ways): do NOT silently pick an interpretation. Instead, report each ambiguity as a question with the options, so the calling agent can ask the user to choose. Do not edit the document for these items.
 
 If nothing needs attention, report "No issues found."

--- a/home/dot_claude/agents/spec-reviewer.md
+++ b/home/dot_claude/agents/spec-reviewer.md
@@ -10,23 +10,15 @@ Read the file path given to you. Review it for the following issues, and fix the
 - Placeholder text (TBD/TODO)
 - Internal contradictions
 - Missing coverage relative to the stated goal
-- Mid-sentence line breaks: a manual line break (hard-wrapping, e.g. at a
-  fixed column width) inserted in the middle of a sentence within a prose
-  paragraph. This check applies only to prose paragraphs — do NOT flag
-  line breaks that are structurally required or intentional, such as:
+- Mid-sentence line breaks: a manual line break (hard-wrapping, e.g. at a fixed column width) inserted in the middle of a sentence within a prose paragraph. This check applies only to prose paragraphs — do NOT flag line breaks that are structurally required or intentional, such as:
   - bullet list items / numbered list items (one item per line is correct)
   - table rows
   - code blocks / code fences
   - Markdown heading lines
-  A concrete signal of a violation: several short lines in a row that,
-  together, form a single sentence, with no blank line, list marker, or
-  code fence between them.
+  A concrete signal of a violation: several short lines in a row that, together, form a single sentence, with no blank line, list marker, or code fence between them.
 
 After fixing, report a one-line summary of each fix made.
 
-For ambiguous requirements (those that could be interpreted two or more
-ways): do NOT silently pick an interpretation. Instead, report each
-ambiguity as a question with the options, so the calling agent can ask the
-user to choose. Do not edit the document for these items.
+For ambiguous requirements (those that could be interpreted two or more ways): do NOT silently pick an interpretation. Instead, report each ambiguity as a question with the options, so the calling agent can ask the user to choose. Do not edit the document for these items.
 
 If nothing needs attention, report "No issues found."

--- a/home/dot_claude/agents/spec-reviewer.md
+++ b/home/dot_claude/agents/spec-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: spec-reviewer
+description: Reviews a spec document (docs/superpowers/specs/*.md) for placeholders, contradictions, missing coverage, and mid-sentence line breaks, then fixes issues in place. Use after writing a spec file, before the user reviews it.
+tools: Read, Edit
+model: sonnet
+---
+
+Read the file path given to you. Review it for the following issues, and fix them in place:
+
+- Placeholder text (TBD/TODO)
+- Internal contradictions
+- Missing coverage relative to the stated goal
+- Mid-sentence line breaks: a manual line break (hard-wrapping, e.g. at a
+  fixed column width) inserted in the middle of a sentence within a prose
+  paragraph. This check applies only to prose paragraphs — do NOT flag
+  line breaks that are structurally required or intentional, such as:
+  - bullet list items / numbered list items (one item per line is correct)
+  - table rows
+  - code blocks / code fences
+  - Markdown heading lines
+  A concrete signal of a violation: several short lines in a row that,
+  together, form a single sentence, with no blank line, list marker, or
+  code fence between them.
+
+After fixing, report a one-line summary of each fix made.
+
+For ambiguous requirements (those that could be interpreted two or more
+ways): do NOT silently pick an interpretation. Instead, report each
+ambiguity as a question with the options, so the calling agent can ask the
+user to choose. Do not edit the document for these items.
+
+If nothing needs attention, report "No issues found."

--- a/home/dot_claude/rules/superpowers.md
+++ b/home/dot_claude/rules/superpowers.md
@@ -8,26 +8,11 @@ you MUST dispatch a sub-agent to review the document and apply fixes.
 
 ### Review procedure
 
-1. Dispatch a sub-agent with the following instruction (substituting the
-   actual file path):
-
-   > Read `<file path>`. Review it for:
-   > - Placeholder text (TBD/TODO)
-   > - Internal contradictions
-   > - Missing coverage relative to the stated goal
-   > - For plan files only: steps that describe what to do without showing
-   >   how (missing code blocks)
-   >
-   > Fix the above issues in place and report a one-line summary of each
-   > fix made.
-   >
-   > For ambiguous requirements (those that could be interpreted two or
-   > more ways): do NOT silently pick an interpretation. Instead, report
-   > each ambiguity as a question with the options, so the main agent can
-   > ask the user to choose. Do not edit the document for these items.
-   >
-   > If nothing needs attention, report "No issues found."
-
+1. Dispatch the review sub-agent with the file path to review: the
+   `spec-reviewer` sub-agent (Agent tool, `subagent_type: spec-reviewer`)
+   for a spec file (`docs/superpowers/specs/*.md`), or the `plan-reviewer`
+   sub-agent (`subagent_type: plan-reviewer`) for a plan file
+   (`docs/superpowers/plans/*.md`).
 2. Wait for the sub-agent to complete.
 3. If the sub-agent reports fixes, read the updated file and confirm the
    changes look correct.

--- a/tests/integration/test_chezmoi_apply.sh
+++ b/tests/integration/test_chezmoi_apply.sh
@@ -76,6 +76,18 @@ fi
 
 echo "✅ Codex files generated successfully"
 
+if [ ! -f "$HOME/.claude/agents/spec-reviewer.md" ]; then
+  echo "❌ spec-reviewer agent definition not generated"
+  exit 1
+fi
+
+if [ ! -f "$HOME/.claude/agents/plan-reviewer.md" ]; then
+  echo "❌ plan-reviewer agent definition not generated"
+  exit 1
+fi
+
+echo "✅ spec-reviewer / plan-reviewer agent definitions generated successfully"
+
 # Idempotency テスト: 2 回目の apply で差分がないことを確認
 echo "Testing idempotency..."
 # .chezmoiscripts/ ディレクトリの変更は無視 (chezmoi の内部管理ファイル)


### PR DESCRIPTION
## Summary

spec/plan ドキュメントレビュー専用のサブエージェント `spec-reviewer` / `plan-reviewer` を新設し、`rules/superpowers.md` の Spec and Plan Agent Review 手順をこれらのサブエージェント呼び出しに切り替える。両エージェントの検査項目に「文中改行 (mid-sentence line breaks)」チェックを追加し、Issue #241 で報告された「spec ドキュメントが文中で機械的に改行されたまま Issue コメントに投稿された」問題の再発を防ぐ。

## Changes

- `home/dot_claude/agents/spec-reviewer.md` (new): spec ドキュメント (`docs/superpowers/specs/*.md`) 用のレビュー専用サブエージェント定義。プレースホルダー・矛盾・網羅性不足・文中改行を検査し、その場で修正する。
- `home/dot_claude/agents/plan-reviewer.md` (new): plan ドキュメント (`docs/superpowers/plans/*.md`) 用のレビュー専用サブエージェント定義。上記に加え、コードブロック欠落 (手順があるのに実装方法が示されていない) も検査する。
- `home/dot_claude/rules/superpowers.md`: Review procedure を、インライン指示の埋め込みから `spec-reviewer` / `plan-reviewer` サブエージェント (Agent tool, `subagent_type`) の呼び出しに変更。
- `home/dot_claude/.gitignore`: opt-in 方式の allowlist に `!agents/` を追加(新設ディレクトリが除外されないように)。
- `tests/integration/test_chezmoi_apply.sh`: `chezmoi apply` 後に `~/.claude/agents/spec-reviewer.md` / `plan-reviewer.md` が生成されることを確認するアサーションを追加。

## Design

Issue 上でのブレインストーミングを経て、以下の方針を確定した:

- Issue #241 の 3 案のうち、案 2(spec/plan レビューサブエージェントに検査項目を追加)のみを採用。
- 検査は正規表現ではなく LLM の文脈判断に任せる(誤検知回避のため)。
- インライン dispatch 指示ではなく、Claude Code のネイティブなカスタムサブエージェント機構 (`.claude/agents/*.md`) として実装。
- spec と plan はレビュー観点が異なる(plan のみコードブロック欠落チェックが必要)ため、単一の共通エージェントではなく `spec-reviewer` / `plan-reviewer` の 2 エージェントに分割。

Spec: https://github.com/book000/dotfiles/issues/241#issuecomment-4952050002
Plan: https://github.com/book000/dotfiles/issues/241#issuecomment-4952073984

## Verification

- `tests/syntax/test_bash_syntax.sh` / `test_shellcheck.sh` / `test_json_schema.sh`: pass(既存の無関係な shellcheck 指摘 1 件は本 PR 以前から存在することを確認済み)
- Docker 上で `chezmoi apply` を実行し、`~/.claude/agents/spec-reviewer.md` / `plan-reviewer.md` が正しく生成されることを確認
- `deep-review` (ローカル diff モード) を実施。score ≥ 50 の指摘 1 件(新設エージェント定義自身のプロースが文中改行していた)を修正済み

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
