### PR TITLE
fix: statusLine の ccstatusline npx 実行を --offline 優先 + フォールバックに変更する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ chezmoi はソース側のプレフィックスを解釈してデプロイする
 - `.env.example` と `.gitconfig.local.example` をサンプルとして提供。
 - wakatime は別途管理するため、dotfiles での暗号化管理は行わない。
 - PR 作成先は `upstream` remote があればそれを既定とし、`home/bin/executable_gh-pr-target-repo.sh`（デプロイ後 `~/bin/gh-pr-target-repo.sh`）で解決する。
+- 依存バージョンの更新は `renovate.json` の Renovate (GitHub App) で管理する。`home/dot_claude/private_settings.json` の `statusLine.command` に埋め込まれた `ccstatusline` の npm バージョンなど、通常の `package.json` では追跡できない箇所は `regexManagers` で個別に対象化する。
 
 ## Claude Code フック / 通知機能
 

--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -126,7 +126,7 @@
   "enableWorkflows": false,
   "statusLine": {
     "type": "command",
-    "command": "npx -y ccstatusline@latest"
+    "command": "npx -y --offline ccstatusline@2.2.23 || npx -y ccstatusline@2.2.23"
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>book000/templates//renovate/base-public"],
+  "regexManagers": [
+    {
+      "fileMatch": ["^home/dot_claude/private_settings\\.json$"],
+      "matchStrings": ["ccstatusline@(?<currentValue>[0-9.]+)"],
+      "depNameTemplate": "ccstatusline",
+      "datasourceTemplate": "npm"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

`home/dot_claude/private_settings.json` の `statusLine.command` が `npx -y ccstatusline@latest` になっており、ステータスライン更新のたびに npm レジストリへの問い合わせが発生し、負荷の高いホスト上での OOM kill の一因になっていた。

## 変更内容

- `statusLine.command` を `npx -y --offline ccstatusline@2.2.23 || npx -y ccstatusline@2.2.23` に変更し、ローカルキャッシュがあればネットワークアクセスを完全にスキップする。キャッシュがない新規マシン(`chezmoi apply` 直後等)では自動的にオンライン解決にフォールバックする。
- `ccstatusline` のバージョンを Renovate で自動追跡・更新できるよう `renovate.json` を新規追加した(`regexManagers` で `private_settings.json` 内の埋め込みバージョン文字列を npm データソースとして監視、book000/templates の共通設定を extends)。
- `CLAUDE.md` に Renovate によるバージョン管理方針を追記した。

## テスト

- `tests/syntax/test_json_schema.sh`: pass
- `tests/syntax/test_bash_syntax.sh`: pass
- `tests/syntax/test_shellcheck.sh`: pass(既存の無関係な SC2329 警告のみ、master でも同様)
- `/lite-review` 実施済み、指摘 1 件(ドキュメント更新漏れ)を修正済み

Closes #240