### PR TITLE
fix: install.sh の temp_dir 削除 trap を set -u 下で未定義でも落ちないよう防御的にする

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -516,7 +516,8 @@ install_ghq() {
   temp_dir=$(mktemp -d)
 
   # 一時ディレクトリのクリーンアップを設定
-  trap 'rm -rf "$temp_dir"' RETURN
+  # ${temp_dir:-} は set -u 下で temp_dir が未定義の場合でも trap がエラーにならないようにする防御策
+  trap 'rm -rf "${temp_dir:-}"' RETURN
 
   if [[ ! -d "$temp_dir" ]]; then
     log_error "Failed to create temporary directory"

--- a/install.sh
+++ b/install.sh
@@ -608,7 +608,8 @@ install_roots() {
 
   local temp_dir
   temp_dir=$(mktemp -d)
-  trap 'rm -rf "$temp_dir"' RETURN
+  # ${temp_dir:-} は set -u 下で temp_dir が未定義の場合でも trap がエラーにならないようにする防御策
+  trap 'rm -rf "${temp_dir:-}"' RETURN
 
   if [[ ! -d "$temp_dir" ]]; then
     log_error "Failed to create temporary directory"

--- a/install.sh
+++ b/install.sh
@@ -516,7 +516,8 @@ install_ghq() {
   temp_dir=$(mktemp -d)
 
   # 一時ディレクトリのクリーンアップを設定
-  # ${temp_dir:-} は set -u 下で temp_dir が未定義の場合でも trap がエラーにならないようにする防御策
+  # ${temp_dir:-} は将来この関数がリファクタリングされ trap 登録より前で return するなど
+  # temp_dir 未定義のまま trap が発火し得る構成に変わっても set -u で落ちないようにする防御策
   trap 'rm -rf "${temp_dir:-}"' RETURN
 
   if [[ ! -d "$temp_dir" ]]; then
@@ -608,7 +609,8 @@ install_roots() {
 
   local temp_dir
   temp_dir=$(mktemp -d)
-  # ${temp_dir:-} は set -u 下で temp_dir が未定義の場合でも trap がエラーにならないようにする防御策
+  # ${temp_dir:-} は将来この関数がリファクタリングされ trap 登録より前で return するなど
+  # temp_dir 未定義のまま trap が発火し得る構成に変わっても set -u で落ちないようにする防御策
   trap 'rm -rf "${temp_dir:-}"' RETURN
 
   if [[ ! -d "$temp_dir" ]]; then


### PR DESCRIPTION
## 概要

`install.sh` の `install_ghq()` / `install_roots()` 内にある一時ディレクトリ削除用の `trap 'rm -rf "$temp_dir"' RETURN` を `trap 'rm -rf "${temp_dir:-}"' RETURN` に変更し、`set -u` 下で `temp_dir` が万一未定義の状態で trap が発火しても `unbound variable` エラーにならないよう防御的にハードニングしました。

## 背景

Issue #245 は「`install.sh: bash: line 913: temp_dir: unbound variable`」という報告でしたが、本文が空で再現手順・環境情報がありませんでした。調査の結果、現行 `master` の 913 行目は `main() {` であり、`temp_dir` の使用箇所とは一致しません。README.md が案内するインストール手順(`curl` で `/tmp` に保存後に実行)から、報告者が古いキャッシュ済みスクリプトを実行した可能性が高く、現行コードでの再現は確認できませんでした。

一方で、`temp_dir` は現状 `local temp_dir` の直後に代入されるため通常は未定義になりませんが、将来のリファクタリングで trap 登録の位置や制御フローが変わった場合に備え、防御的な変更として本 PR を作成しています。

## 変更内容

- `install.sh` の `install_ghq()` / `install_roots()` それぞれの trap 行を `${temp_dir:-}` を使う形に変更(計 2 箇所)
- 各箇所にコメントを追加し、防御の意図(将来のリファクタリングで trap 発火時に `temp_dir` が未定義になり得る構成に変わっても `set -u` で落ちないようにする)を明記

## 検証

- `bash -n install.sh`: 構文エラーなし
- `tests/syntax/test_bash_syntax.sh`: 全スクリプト成功
- `tests/syntax/test_shellcheck.sh`: `install.sh` は成功(無関係な既存失敗1件は `origin/master` でも再現する既存問題)
- 対照実験: 修正前パターン(`"$temp_dir"`)は `set -u` 下で実際に `unbound variable` エラーを再現し、修正後パターン(`"${temp_dir:-}"`)ではエラーが起きないことを確認済み
- deep-review 実施済み。指摘1件(追加コメントの文言が誤解を招く表現だった点)を修正済み

Closes #245

Spec: https://github.com/book000/dotfiles/issues/245#issuecomment-4968143823
Plan: https://github.com/book000/dotfiles/issues/245#issuecomment-4968174544