### PR TITLE
fix: trilium-upload.sh の create-note で attributes プロパティを分離

### DIFF
--- a/home/bin/executable_trilium-upload.sh
+++ b/home/bin/executable_trilium-upload.sh
@@ -80,17 +80,25 @@ if [ "$get_status" = "200" ]; then
 elif [ "$get_status" = "404" ]; then
   # 新規作成: "_share" の直下に、noteId を明示指定して作成する。
   # → "_share" の子孫に配置されたノートは自動的に共有(公開閲覧可能)になる。
-  # マーカーラベルも同時に付与し、次回更新時の所有権確認に使う。
+  # NOTE: ETAPI の create-note は "attributes" プロパティを受け付けない
+  # (PROPERTY_NOT_ALLOWED) ため、マーカーラベルはノート作成後に
+  # 別途 POST /etapi/attributes で付与する。
   payload=$(jq -n \
     --arg noteId "$note_id" \
     --arg title "$title" \
     --arg content "$(cat "$html_file")" \
-    --arg markerLabel "$marker_label" \
-    '{parentNoteId: "_share", noteId: $noteId, title: $title, type: "text", content: $content,
-      attributes: [{type: "label", name: $markerLabel, value: "1"}]}')
+    '{parentNoteId: "_share", noteId: $noteId, title: $title, type: "text", content: $content}')
   curl -sf -X POST -H "$auth_header" -H "Content-Type: application/json" \
     --data "$payload" \
     "$TRILIUM_HTTP_URL/etapi/create-note" >/dev/null
+
+  label_payload=$(jq -n \
+    --arg noteId "$note_id" \
+    --arg markerLabel "$marker_label" \
+    '{noteId: $noteId, type: "label", name: $markerLabel, value: "1"}')
+  curl -sf -X POST -H "$auth_header" -H "Content-Type: application/json" \
+    --data "$label_payload" \
+    "$TRILIUM_HTTP_URL/etapi/attributes" >/dev/null
 else
   echo "ERROR: unexpected status $get_status from Trilium existence check ($TRILIUM_HTTP_URL/etapi/notes/$note_id)" >&2
   exit 1

--- a/home/bin/executable_trilium-upload.sh
+++ b/home/bin/executable_trilium-upload.sh
@@ -56,15 +56,17 @@ auth_header="Authorization: $TRILIUM_ETAPI_TOKEN"
 marker_label="triliumUploadTool"
 
 # 既存ノートかどうかを確認する。
+note_json=$(curl -s -H "$auth_header" \
+  "$TRILIUM_HTTP_URL/etapi/notes/$note_id")
 get_status=$(curl -s -o /dev/null -w '%{http_code}' -H "$auth_header" \
   "$TRILIUM_HTTP_URL/etapi/notes/$note_id")
 
 if [ "$get_status" = "200" ]; then
   # 衝突防止: マーカーラベルを持たないノートは他用途のノートとみなし、上書きを拒否する。
-  attributes=$(curl -sf -H "$auth_header" \
-    "$TRILIUM_HTTP_URL/etapi/notes/$note_id/attributes")
-  if ! printf '%s' "$attributes" | jq -e --arg name "$marker_label" \
-      'any(.[]; .type == "label" and .name == $name)' >/dev/null; then
+  # NOTE: ETAPI に単独の GET /etapi/notes/{id}/attributes エンドポイントは存在しない
+  # (404 Router not found) ため、ノート本体のレスポンスに含まれる "attributes" フィールドを見る。
+  if ! printf '%s' "$note_json" | jq -e --arg name "$marker_label" \
+      '.attributes | any(.[]; .type == "label" and .name == $name)' >/dev/null; then
     echo "ERROR: note $note_id exists but lacks the $marker_label marker; refusing to overwrite a note this script did not create" >&2
     exit 1
   fi


### PR DESCRIPTION
Trilium ETAPI の POST /etapi/create-note は attributes プロパティを受け付けず 400 PROPERTY_NOT_ALLOWED を返していた。
create-note の ペイロードから attributes を削除し、ノート作成後に別途 POST /etapi/attributes でマーカーラベル(triliumUploadTool)を付与するように変更した。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018hGNYidggzn9bVLK9tQwNW