### PR TITLE
fix: git config の書き込み系操作を PreToolUse hook でブロックする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,6 @@ chezmoi はソース側のプレフィックスを解釈してデプロイする
 Claude Code のフックは `home/dot_claude/private_settings.json` で設定され、`Stop` / `PreToolUse` / `PostToolUse` / `PermissionRequest` / `Notification` / `UserPromptSubmit` を使う。役割は大きく 2 系統:
 
 - **Discord 通知**: `home/dot_claude/scripts/completion-notify/` 配下のスクリプト(セッション完了、権限リクエスト、AskUserQuestion、Notification 等)。`~/.env` の `DISCORD_CLAUDE_WEBHOOK` と `DISCORD_CLAUDE_MENTION_USER_ID` を使用する。
-- **レビュー強制など**: `home/dot_claude/hooks/` 配下のスクリプト(deep-review、レビュースレッド未解決チェック、rtk 書き換え等)。
+- **レビュー強制など**: `home/dot_claude/hooks/` 配下のスクリプト(deep-review、レビュースレッド未解決チェック、rtk 書き換え、git config ガード等)。
 
 フックのコマンドや対象スクリプトを変更したときは、`tests/unit/test_hooks.sh` / `test_notifications.sh` の参照が古くなっていないか確認する。

--- a/home/dot_claude/hooks/executable_git-config-guard.sh
+++ b/home/dot_claude/hooks/executable_git-config-guard.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
 # git config の書き込み系操作をブロックする PreToolUse フック。
-# permission mode (通常 / skip-permissions) に関わらず必ず実行されるため、
-# これを「git config 書き込みを防ぐ唯一の確実な強制手段」として扱う。
+# permission mode に関わらず必ず実行されるため、書き込みを防ぐ唯一の確実な強制手段として扱う。
 #
-# 判定ルール:
-#   - コマンドに "git config" を含まない → 対象外、常に許可
-#   - 読み取り系 (--get/--get-all/--get-regexp/--get-urlmatch/--list/-l、
-#     または値引数を伴わない参照呼び出し) → 常に許可
-#   - それ以外(書き込み・削除。--unset/--unset-all/--remove-section/
-#     --rename-section/--edit/-e を含む) → デフォルト拒否
+# コマンド文字列は &&/||/;/| で区切ったセグメントごとに判定する。全体を単一の
+# 文字列として正規表現照合すると、連結された別コマンド側の読み取りオプションや
+# 別の "git config" 文字列に引きずられて、実際の書き込みセグメントを見逃すため。
+#
+# 位置引数(オプションを除く実引数)が2個以上ならフラグの内容に関わらず拒否する。
+# --get 等の読み取り系オプションを個別に判定すると、値の末尾に付与して分類を
+# 偽装する回避策(例: git config user.name attacker --get x)を許してしまうため。
 #
 # 既知の制限: 素直な "git config ..." 形式のみ検出する。
-# "git -C <dir> config" や "git --git-dir=... config" のような
-# 変則的な前置形式、alias・変数展開経由の呼び出しは対象外。
+# "git -C <dir> config" や "git --git-dir=... config" などの変則的な前置形式、
+# alias・変数展開経由の呼び出しは対象外。
 
-# 将来の例外を許すための allow-list(現時点では空)。
-# 一致した場合は書き込み系であっても常に許可する。
+# 将来の例外を許す allow-list(現時点では空)。一致すれば書き込みでも常に許可する。
 ALLOWLIST=()
 
 if ! command -v jq &> /dev/null; then
@@ -24,42 +23,54 @@ if ! command -v jq &> /dev/null; then
 fi
 
 INPUT=$(cat)
+
+# jq 起動前に生の JSON 文字列上で足切りする(ホットパス最適化)。
+# command に "git config" を含まなければ JSON 文字列側にも含まれないため、
+# 後続の $CMD に対する判定を弱めることはない。
+if [[ "$INPUT" != *"git config"* ]]; then
+    exit 0
+fi
+
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-[ -n "$CMD" ] || exit 0
-
-# "git config" を含まないコマンドは対象外
-if [[ "$CMD" != *"git config"* ]]; then
+if [[ -z "$CMD" || "$CMD" != *"git config"* ]]; then
     exit 0
 fi
 
-# allow-list に一致すれば常に許可
-for pattern in "${ALLOWLIST[@]}"; do
-    if [[ "$CMD" == *"$pattern"* ]]; then
-        exit 0
+IFS=$'\n' read -rd '' -a SEGMENTS < <(printf '%s\n' "$CMD" | sed -E 's/(&&|\|\||;|\|)/\n/g') || true
+
+DENY=0
+for SEGMENT in "${SEGMENTS[@]}"; do
+    [[ "$SEGMENT" == *"git config"* ]] || continue
+
+    IS_ALLOWED=0
+    for pattern in "${ALLOWLIST[@]}"; do
+        if [[ "$SEGMENT" == *"$pattern"* ]]; then
+            IS_ALLOWED=1
+            break
+        fi
+    done
+    [ "$IS_ALLOWED" -eq 1 ] && continue
+
+    if [[ "$SEGMENT" =~ --unset-all|--unset|--remove-section|--rename-section|--edit|(^|[[:space:]])-e([[:space:]]|$) ]]; then
+        DENY=1
+        break
     fi
-done
 
-# 読み取り専用オプションが含まれていれば許可
-if [[ "$CMD" =~ --get-all|--get-regexp|--get-urlmatch|--get|--list|(^|[[:space:]])-l([[:space:]]|$) ]]; then
-    exit 0
-fi
-
-# 書き込み・削除系オプションが明示されていなければ、位置引数の個数で
-# 「値を指定しない参照呼び出し」かどうかを判定する。
-if [[ ! "$CMD" =~ --unset-all|--unset|--remove-section|--rename-section|--edit|(^|[[:space:]])-e([[:space:]]|$) ]]; then
-    AFTER_CONFIG=$(echo "$CMD" | sed -E 's/^.*git[[:space:]]+config[[:space:]]*//')
+    AFTER_CONFIG=$(echo "$SEGMENT" | sed -E 's/^.*git[[:space:]]+config[[:space:]]*//')
     read -ra ARGS <<< "$AFTER_CONFIG"
     POSITIONAL_COUNT=0
     for arg in "${ARGS[@]}"; do
         [[ "$arg" == -* ]] && continue
         POSITIONAL_COUNT=$((POSITIONAL_COUNT + 1))
     done
-    # 位置引数 (オプションを除いた実引数) が1個以下 → キー名のみの参照呼び出し
-    if [ "$POSITIONAL_COUNT" -le 1 ]; then
-        exit 0
+    if [ "$POSITIONAL_COUNT" -ge 2 ]; then
+        DENY=1
+        break
     fi
-fi
+done
+
+[ "$DENY" -eq 1 ] || exit 0
 
 jq -n \
     --arg reason "git config writes are blocked by policy; ask the user to run this manually" \

--- a/home/dot_claude/hooks/executable_git-config-guard.sh
+++ b/home/dot_claude/hooks/executable_git-config-guard.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# git config の書き込み系操作をブロックする PreToolUse フック。
+# permission mode (通常 / skip-permissions) に関わらず必ず実行されるため、
+# これを「git config 書き込みを防ぐ唯一の確実な強制手段」として扱う。
+#
+# 判定ルール:
+#   - コマンドに "git config" を含まない → 対象外、常に許可
+#   - 読み取り系 (--get/--get-all/--get-regexp/--get-urlmatch/--list/-l、
+#     または値引数を伴わない参照呼び出し) → 常に許可
+#   - それ以外(書き込み・削除。--unset/--unset-all/--remove-section/
+#     --rename-section/--edit/-e を含む) → デフォルト拒否
+#
+# 既知の制限: 素直な "git config ..." 形式のみ検出する。
+# "git -C <dir> config" や "git --git-dir=... config" のような
+# 変則的な前置形式、alias・変数展開経由の呼び出しは対象外。
+
+# 将来の例外を許すための allow-list(現時点では空)。
+# 一致した場合は書き込み系であっても常に許可する。
+ALLOWLIST=()
+
+if ! command -v jq &> /dev/null; then
+    echo "[git-config-guard] WARNING: jq is not installed. Hook cannot inspect commands, allowing." >&2
+    exit 0
+fi
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[ -n "$CMD" ] || exit 0
+
+# "git config" を含まないコマンドは対象外
+if [[ "$CMD" != *"git config"* ]]; then
+    exit 0
+fi
+
+# allow-list に一致すれば常に許可
+for pattern in "${ALLOWLIST[@]}"; do
+    if [[ "$CMD" == *"$pattern"* ]]; then
+        exit 0
+    fi
+done
+
+# 読み取り専用オプションが含まれていれば許可
+if [[ "$CMD" =~ --get-all|--get-regexp|--get-urlmatch|--get|--list|(^|[[:space:]])-l([[:space:]]|$) ]]; then
+    exit 0
+fi
+
+# 書き込み・削除系オプションが明示されていなければ、位置引数の個数で
+# 「値を指定しない参照呼び出し」かどうかを判定する。
+if [[ ! "$CMD" =~ --unset-all|--unset|--remove-section|--rename-section|--edit|(^|[[:space:]])-e([[:space:]]|$) ]]; then
+    AFTER_CONFIG=$(echo "$CMD" | sed -E 's/^.*git[[:space:]]+config[[:space:]]*//')
+    read -ra ARGS <<< "$AFTER_CONFIG"
+    POSITIONAL_COUNT=0
+    for arg in "${ARGS[@]}"; do
+        [[ "$arg" == -* ]] && continue
+        POSITIONAL_COUNT=$((POSITIONAL_COUNT + 1))
+    done
+    # 位置引数 (オプションを除いた実引数) が1個以下 → キー名のみの参照呼び出し
+    if [ "$POSITIONAL_COUNT" -le 1 ]; then
+        exit 0
+    fi
+fi
+
+jq -n \
+    --arg reason "git config writes are blocked by policy; ask the user to run this manually" \
+    '{
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": $reason
+        }
+    }'

--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -11,6 +11,14 @@
     "IS_DEMO": "1"
   },
   "model": "opusplan",
+  "permissions": {
+    "deny": [
+      "Bash(git config user.name:*)",
+      "Bash(git config user.email:*)",
+      "Bash(git config --global user.name:*)",
+      "Bash(git config --global user.email:*)"
+    ]
+  },
   "hooks": {
     "Stop": [
       {
@@ -52,6 +60,11 @@
             "type": "command",
             "command": "~/.claude/hooks/rtk-rewrite.sh",
             "onFailure": "ignore"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/git-config-guard.sh",
+            "onFailure": "fail"
           }
         ]
       }

--- a/tests/unit/test_hooks.sh
+++ b/tests/unit/test_hooks.sh
@@ -194,10 +194,15 @@ for cmd in \
 done
 
 # 書き込み系: permissionDecision: deny が出力される
+# (回避策として、読み取りコマンドとの連結や、書き込みコマンドへの
+# 読み取り系オプション付与によるすり抜けを試みるケースも含む)
 for cmd in \
   'git config user.name "Foo"' \
   'git config --global user.email foo@example.com' \
-  'git config --unset user.name'; do
+  'git config --unset user.name' \
+  'git config --list && git config user.name attacker' \
+  'git config user.name attacker --get x' \
+  'git config user.name attacker && echo git config'; do
   OUTPUT=$(run_git_config_guard "$cmd")
   DECISION=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
   if [[ "$DECISION" != "deny" ]]; then

--- a/tests/unit/test_hooks.sh
+++ b/tests/unit/test_hooks.sh
@@ -12,6 +12,7 @@ HOOKS=(
   "home/dot_claude/hooks/executable_code-review-immediate-fix.sh"
   "home/dot_claude/hooks/executable_require-code-review-fixes.sh"
   "home/dot_claude/hooks/executable_require-review-thread-fixes.sh"
+  "home/dot_claude/hooks/executable_git-config-guard.sh"
 )
 
 # 各フックの構文チェック
@@ -168,6 +169,44 @@ else
   fi
 fi
 rm -rf "$TEST_HOME" "$TEST_BIN_DIR" "$TEST_CAPTURE_DIR"
+
+echo "Testing git-config-guard hook behavior..."
+GIT_CONFIG_GUARD="home/dot_claude/hooks/executable_git-config-guard.sh"
+
+run_git_config_guard() {
+  local cmd="$1"
+  jq -n --arg cmd "$cmd" '{"tool_input": {"command": $cmd}}' | bash "$GIT_CONFIG_GUARD"
+}
+
+# 読み取り系: 常に許可される(標準出力なし)
+for cmd in \
+  'git config --get user.name' \
+  'git config --list' \
+  'git config user.name' \
+  'git status'; do
+  OUTPUT=$(run_git_config_guard "$cmd")
+  if [[ -n "$OUTPUT" ]]; then
+    echo "❌ git-config-guard denied a command that should be allowed: $cmd"
+    FAILED=1
+  else
+    echo "✅ git-config-guard allowed: $cmd"
+  fi
+done
+
+# 書き込み系: permissionDecision: deny が出力される
+for cmd in \
+  'git config user.name "Foo"' \
+  'git config --global user.email foo@example.com' \
+  'git config --unset user.name'; do
+  OUTPUT=$(run_git_config_guard "$cmd")
+  DECISION=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  if [[ "$DECISION" != "deny" ]]; then
+    echo "❌ git-config-guard did not deny a write command: $cmd"
+    FAILED=1
+  else
+    echo "✅ git-config-guard denied: $cmd"
+  fi
+done
 
 if [ $FAILED -eq 0 ]; then
   echo "✅ All hook tests passed"


### PR DESCRIPTION
## 概要

`git config` の書き込み系操作(`user.name`/`user.email` の変更、`--unset` 等の削除操作)を Claude Code の PreToolUse hook でブロックする。`CLAUDE.md` に禁止事項として記載するだけでは強制力がなく、実際に書き換えが行われることがあったため、permission mode に関わらず必ず実行される hook で機械的に強制する。

## 変更内容

1. `home/dot_claude/hooks/executable_git-config-guard.sh`(新規)
   - PreToolUse (matcher: `Bash`) hook。`git config` を含むコマンドをセグメント単位(`&&`/`||`/`;`/`|` 区切り)で判定し、読み取り系(`--get`/`--list` 等、または値なしの参照呼び出し)は許可、書き込み・削除系(位置引数2個以上、`--unset` 等)は拒否する。
   - 既知の制限: `git -C <dir> config` 等の変則的な前置形式、alias・変数展開経由の呼び出しは対象外。
2. `home/dot_claude/private_settings.json`
   - hook を `hooks.PreToolUse`(matcher `Bash`, `onFailure: fail`)に登録。
   - `permissions.deny` に `git config user.name`/`user.email`(`--global` 含む)のエントリを追加(通常 permission mode での追加防御線)。
3. `tests/unit/test_hooks.sh`
   - hook の構文チェック対象に追加。
   - 読み取り4ケース(許可)・書き込み6ケース(拒否、コマンド連結や偽装フラグによる回避策を含む)の振る舞いテストを追加。
4. `CLAUDE.md`
   - 既存のフック一覧の記載に「git config ガード」を追記。

## 検証

- `tests/unit/test_hooks.sh` / `tests/syntax/test_bash_syntax.sh` / `tests/syntax/test_json_schema.sh`: 全て pass。
- `tests/syntax/test_shellcheck.sh`: 既存の無関係な問題(`wait-for-copilot-review.sh` の SC2329、本 PR 以前から存在)のみで exit 1。本 PR による regression なし。
- `/deep-review` (local diff mode) で検出したコマンド連結・偽装によるすり抜け2件と、jq 起動のホットパス最適化1件を修正済み。

Closes #250

Spec: https://github.com/book000/dotfiles/issues/250#issuecomment-4968935516
Plan: https://github.com/book000/dotfiles/issues/250#issuecomment-4970318191