### PR TITLE
feat: コミット時のシークレット漏洩チェックを dotfiles 全体に導入する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,7 @@
 
 - トークン・Webhook URL・パスワード等を平文でコミットしていないか確認する。
 - `~/.env` や `~/.gitconfig.local` はリポジトリ管理外。`.env.example` / `.gitconfig.local.example` などサンプルのみを含める。
+- pre-commit フック(`home/dot_config/git/hooks/executable_pre-commit`)や `home/dot_gitleaks.toml` の allowlist を変更する場合、誤検知抑制が広すぎて実際のシークレット検知を無効化していないか確認する。
 
 ### テストの追随
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,9 @@ Claude Code のフックは `home/dot_claude/private_settings.json` で設定さ
 - **レビュー強制など**: `home/dot_claude/hooks/` 配下のスクリプト(deep-review、レビュースレッド未解決チェック、rtk 書き換え等)。
 
 フックのコマンドや対象スクリプトを変更したときは、`tests/unit/test_hooks.sh` / `test_notifications.sh` の参照が古くなっていないか確認する。
+
+## Git フック(シークレットスキャン)
+
+`home/dot_config/git/hooks/executable_pre-commit`(デプロイ後 `~/.config/git/hooks/pre-commit`)が `core.hooksPath` 経由でグローバル pre-commit フックとして登録され、`gitleaks` によるステージ済み差分のシークレットスキャンを行う。フォールバック設定は `home/dot_gitleaks.toml`(デプロイ後 `~/.gitleaks.toml`)。
+
+このフックや `install.sh` の `install_gitleaks` を変更した場合、`tests/unit/test_hooks.sh` / `tests/unit/test_install.sh` / `tests/integration/test_chezmoi_apply.sh` の参照が古くなっていないか確認する。

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ macOS と Windows は現在サポートされていません。
 
 より安全にインストールするには、3 ステップインストール（ダウンロード、確認、実行）を推奨します。
 
+## コミット時のシークレットスキャン
+
+`git commit` 実行時に、ステージ済み差分内のシークレット(API キー、トークンなど)を [gitleaks](https://github.com/gitleaks/gitleaks) で検知し、検知した場合はコミットをブロックします。`git config --global core.hooksPath` を `~/.config/git/hooks` に設定することで、dotfiles を導入した全 Git リポジトリで有効になります。
+
+**既知の制約:**
+
+- リポジトリ側で `core.hooksPath` がローカル設定として上書きされている場合、このグローバルフックは効きません(Git の標準仕様)。
+- `gitleaks` コマンドが見つからない場合は fail-open(警告を表示した上でコミットを続行)します。`install.sh` が `gitleaks` を自動インストールしますが、`--skip-gitleaks` でスキップした環境や、dotfiles 導入前の環境ではスキャンが行われません。
+- 誤検知が発生した場合は、対象リポジトリに独自の `.gitleaks.toml` を配置するか、`git commit --no-verify` でバイパスしてください。
+
 ## Claude Code 通知機能
 
 Claude Code がユーザー操作を必要とする場合に、Discord Webhook を使用して通知する機能が実装されています。

--- a/home/dot_config/git/config
+++ b/home/dot_config/git/config
@@ -15,6 +15,9 @@
   # untracked files のステータス確認を高速化する
   # See https://git-scm.com/docs/git-update-index#_untracked_cache
   untrackedCache = true
+  # コミット時にステージ済み差分のシークレット漏洩を gitleaks で検知する pre-commit フックを
+  # dotfiles 導入マシン上の全 Git リポジトリに適用する (home/dot_config/git/hooks/executable_pre-commit)
+  hooksPath = ~/.config/git/hooks
 
 [init]
   defaultBranch = master

--- a/home/dot_config/git/hooks/executable_pre-commit
+++ b/home/dot_config/git/hooks/executable_pre-commit
@@ -14,8 +14,10 @@ if ! command -v gitleaks > /dev/null 2>&1; then
 fi
 
 # リポジトリ自身の .gitleaks.toml があればそちらを gitleaks の自動検出に任せ、
-# 無ければグローバルのフォールバック設定 (~/.gitleaks.toml) を明示的に指定する
-GIT_ROOT=$(git rev-parse --show-toplevel 2> /dev/null) || exit 0
+# 無ければグローバルのフォールバック設定 (~/.gitleaks.toml) を明示的に指定する。
+# pre-commit フックは git により作業ツリーのルートを cwd として起動されるため
+# (githooks(5))、追加の git rev-parse 呼び出しは不要
+GIT_ROOT="$PWD"
 CONFIG_ARGS=()
 if [[ ! -f "$GIT_ROOT/.gitleaks.toml" ]] && [[ -f "$HOME/.gitleaks.toml" ]]; then
     CONFIG_ARGS=(--config "$HOME/.gitleaks.toml")

--- a/home/dot_config/git/hooks/executable_pre-commit
+++ b/home/dot_config/git/hooks/executable_pre-commit
@@ -1,0 +1,24 @@
+#!/bin/bash
+# pre-commit フック: git commit 時にステージ済み差分内のシークレット漏洩を gitleaks で検知する
+# chezmoi 管理下の core.hooksPath (~/.config/git/hooks) に配置され、dotfiles 導入マシン上の
+# 全 Git リポジトリで有効になる (home/dot_config/git/config の [core] hooksPath 設定を参照)
+
+set -u
+
+# gitleaks が見つからない場合は fail-open とする
+# (dotfiles 未導入・導入途中のマシンでコミットが一律ブロックされる事態を避けるため)
+if ! command -v gitleaks > /dev/null 2>&1; then
+    echo "⚠️  gitleaks not found in PATH. Secret scan skipped." >&2
+    echo "⚠️  Install gitleaks to enable secret scanning: https://github.com/gitleaks/gitleaks#installing" >&2
+    exit 0
+fi
+
+# リポジトリ自身の .gitleaks.toml があればそちらを gitleaks の自動検出に任せ、
+# 無ければグローバルのフォールバック設定 (~/.gitleaks.toml) を明示的に指定する
+GIT_ROOT=$(git rev-parse --show-toplevel 2> /dev/null) || exit 0
+CONFIG_ARGS=()
+if [[ ! -f "$GIT_ROOT/.gitleaks.toml" ]] && [[ -f "$HOME/.gitleaks.toml" ]]; then
+    CONFIG_ARGS=(--config "$HOME/.gitleaks.toml")
+fi
+
+gitleaks protect --staged --redact -v "${CONFIG_ARGS[@]}"

--- a/home/dot_gitleaks.toml
+++ b/home/dot_gitleaks.toml
@@ -4,7 +4,12 @@ title = "dotfiles gitleaks config (global fallback)"
 useDefault = true
 
 [allowlist]
+# このファイルはリポジトリ自身の .gitleaks.toml を持たない全リポジトリで
+# グローバルフォールバック設定 (~/.gitleaks.toml) として使われるため、
+# パスは dotfiles 自身の具体的なファイル名に限定し、他リポジトリの
+# *.example ファイルまで誤って除外しないようにする
 description = "Exclude dotfiles' own example/placeholder files from false positives"
 paths = [
-  '''\.example$''',
+  '''(^|/)\.env\.example$''',
+  '''(^|/)\.gitconfig\.local\.example$''',
 ]

--- a/home/dot_gitleaks.toml
+++ b/home/dot_gitleaks.toml
@@ -1,0 +1,10 @@
+title = "dotfiles gitleaks config (global fallback)"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Exclude dotfiles' own example/placeholder files from false positives"
+paths = [
+  '''\.example$''',
+]

--- a/install.sh
+++ b/install.sh
@@ -702,7 +702,8 @@ install_gitleaks() {
     gitleaks_arch="x64"
   fi
 
-  local download_url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_${gitleaks_arch}.tar.gz"
+  local archive_filename="gitleaks_${version}_linux_${gitleaks_arch}.tar.gz"
+  local download_url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/${archive_filename}"
 
   log_info "ダウンロード URL: $download_url"
 
@@ -719,13 +720,29 @@ install_gitleaks() {
 
   cd "$temp_dir" || { log_error "Failed to change directory to temporary directory"; return 1; }
 
-  if ! curl -fsSL -o gitleaks.tar.gz "$download_url"; then
+  if ! curl -fsSL -o "$archive_filename" "$download_url"; then
     log_error "Failed to download gitleaks archive"
     cd - > /dev/null || true
     return 1
   fi
 
-  if ! tar -xzf gitleaks.tar.gz; then
+  # 改ざん・アセット差し替えを検知するため、gitleaks が公開するチェックサムファイルと突合する
+  # (sha256sum -c はチェックサム行に記載されたファイル名で cwd を照合するため、
+  # ダウンロードしたアーカイブはリリースアセットと同じファイル名で保存する必要がある)
+  local checksums_url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_checksums.txt"
+  if ! curl -fsSL -o checksums.txt "$checksums_url"; then
+    log_error "Failed to download gitleaks checksums file"
+    cd - > /dev/null || true
+    return 1
+  fi
+
+  if ! grep -- "$archive_filename" checksums.txt | sha256sum -c - > /dev/null; then
+    log_error "gitleaks archive checksum verification failed"
+    cd - > /dev/null || true
+    return 1
+  fi
+
+  if ! tar -xzf "$archive_filename"; then
     log_error "Failed to extract gitleaks archive"
     cd - > /dev/null || true
     return 1

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@
 #     --skip-ghq         ghq のインストールをスキップ
 #     --skip-mkwork      mkwork のインストールをスキップ
 #     --skip-roots       roots のインストールをスキップ
+#     --skip-gitleaks    gitleaks のインストールをスキップ
 #     --skip-interactive 対話的な確認をスキップ (CI 用、 /dev/tty が利用できない場合も自動的に非対話モードになります)
 #     --help             ヘルプを表示
 # ==============================================================================
@@ -33,6 +34,7 @@ SKIP_GH=0
 SKIP_GHQ=0
 SKIP_MKWORK=0
 SKIP_ROOTS=0
+SKIP_GITLEAKS=0
 SKIP_INTERACTIVE=0
 
 # ヘルプメッセージを表示する関数
@@ -48,6 +50,7 @@ OPTIONS:
   --skip-ghq         ghq のインストールをスキップ
   --skip-mkwork      mkwork のインストールをスキップ
   --skip-roots       roots のインストールをスキップ
+  --skip-gitleaks    gitleaks のインストールをスキップ
   --skip-interactive 対話的な確認をスキップ (CI 用、 /dev/tty が利用できない場合も自動的に非対話モードになります)
   --help             このヘルプを表示
 
@@ -88,6 +91,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-roots)
       SKIP_ROOTS=1
+      shift
+      ;;
+    --skip-gitleaks)
+      SKIP_GITLEAKS=1
       shift
       ;;
     --skip-interactive)
@@ -650,6 +657,98 @@ install_roots() {
   log_info "roots が正常にインストールされました"
 }
 
+# gitleaks のインストール
+install_gitleaks() {
+  if [[ "$SKIP_GITLEAKS" == "1" ]]; then
+    log_info "gitleaks のインストールをスキップします (--skip-gitleaks)"
+    return 0
+  fi
+
+  log_info "gitleaks をインストールしています..."
+
+  if command -v gitleaks &> /dev/null; then
+    log_warn "gitleaks は既にインストールされています"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log_info "[DRY RUN] gitleaks の GitHub Release からのダウンロード・インストールをスキップします"
+    return 0
+  fi
+
+  log_info "GitHub Release から最新版を取得しています..."
+
+  local version
+  local api_response
+  api_response=$(curl -fsSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest)
+
+  if command -v jq &> /dev/null; then
+    version=$(printf '%s\n' "$api_response" | jq -r '.tag_name' | sed -E 's/^v//')
+  else
+    log_warn "jq is not installed. Falling back to grep/sed for version parsing"
+    version=$(printf '%s\n' "$api_response" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+  fi
+
+  if [[ -z "$version" || "$version" == "null" ]]; then
+    log_error "Failed to parse latest version from GitHub API"
+    return 1
+  fi
+
+  log_info "最新バージョン: v$version"
+
+  # gitleaks のリリースアーカイブはアーキテクチャ名に amd64 ではなく x64 を使用する
+  local gitleaks_arch="$ARCH"
+  if [[ "$ARCH" == "amd64" ]]; then
+    gitleaks_arch="x64"
+  fi
+
+  local download_url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_${gitleaks_arch}.tar.gz"
+
+  log_info "ダウンロード URL: $download_url"
+
+  local temp_dir
+  temp_dir=$(mktemp -d)
+  # ${temp_dir:-} は将来この関数がリファクタリングされ trap 登録より前で return するなど
+  # temp_dir 未定義のまま trap が発火し得る構成に変わっても set -u で落ちないようにする防御策
+  trap 'rm -rf "${temp_dir:-}"' RETURN
+
+  if [[ ! -d "$temp_dir" ]]; then
+    log_error "Failed to create temporary directory"
+    return 1
+  fi
+
+  cd "$temp_dir" || { log_error "Failed to change directory to temporary directory"; return 1; }
+
+  if ! curl -fsSL -o gitleaks.tar.gz "$download_url"; then
+    log_error "Failed to download gitleaks archive"
+    cd - > /dev/null || true
+    return 1
+  fi
+
+  if ! tar -xzf gitleaks.tar.gz; then
+    log_error "Failed to extract gitleaks archive"
+    cd - > /dev/null || true
+    return 1
+  fi
+
+  local gitleaks_binary
+  gitleaks_binary=$(find . -maxdepth 1 -type f -name gitleaks -print -quit)
+
+  if [[ -z "$gitleaks_binary" ]]; then
+    log_error "gitleaks binary not found after extraction"
+    cd - > /dev/null || true
+    return 1
+  fi
+
+  mkdir -p "$HOME/.local/bin"
+  mv "$gitleaks_binary" "$HOME/.local/bin/gitleaks"
+  chmod +x "$HOME/.local/bin/gitleaks"
+
+  cd - > /dev/null
+
+  log_info "gitleaks が正常にインストールされました"
+}
+
 # mkwork のインストール
 install_mkwork() {
   if [[ "$SKIP_MKWORK" == "1" ]]; then
@@ -926,6 +1025,7 @@ main() {
   install_ghq
   install_roots
   install_mkwork
+  install_gitleaks
   setup_gitconfig_local
   setup_env
   copy_env_if_needed  # chezmoi apply 前に .env をコピー（テンプレート展開エラー回避）

--- a/tests/integration/test_chezmoi_apply.sh
+++ b/tests/integration/test_chezmoi_apply.sh
@@ -98,6 +98,45 @@ fi
 
 echo "✅ Secret scan pre-commit hook and hooksPath generated successfully"
 
+# エンドツーエンド検証: 実際の git commit が core.hooksPath 経由でこのフックを起動すること
+# (ユニットテストはフックスクリプトを bash 経由で直接呼び出すのみで、
+# core.hooksPath の名前解決・実行権限を含む git 自身の起動経路は検証していないため)
+HOOK_TEST_REPO=$(mktemp -d)
+HOOK_MOCK_BIN=$(mktemp -d)
+HOOK_INVOKED_MARKER=$(mktemp -u)
+cat > "$HOOK_MOCK_BIN/gitleaks" << EOF
+#!/bin/bash
+touch "$HOOK_INVOKED_MARKER"
+exit 0
+EOF
+chmod +x "$HOOK_MOCK_BIN/gitleaks"
+
+(
+  cd "$HOOK_TEST_REPO" || exit 1
+  git init -q
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  echo "content" > file.txt
+  git add file.txt
+  PATH="$HOOK_MOCK_BIN:$PATH" git commit -q -m "test commit"
+)
+HOOK_COMMIT_EXIT=$?
+
+if [ "$HOOK_COMMIT_EXIT" -ne 0 ]; then
+  echo "❌ git commit failed unexpectedly (exit $HOOK_COMMIT_EXIT)"
+  rm -rf "$HOOK_TEST_REPO" "$HOOK_MOCK_BIN"
+  exit 1
+fi
+
+if [ ! -f "$HOOK_INVOKED_MARKER" ]; then
+  echo "❌ pre-commit hook was not invoked by git via core.hooksPath"
+  rm -rf "$HOOK_TEST_REPO" "$HOOK_MOCK_BIN"
+  exit 1
+fi
+
+rm -rf "$HOOK_TEST_REPO" "$HOOK_MOCK_BIN" "$HOOK_INVOKED_MARKER"
+echo "✅ pre-commit hook invoked by git via core.hooksPath end-to-end"
+
 if [ ! -f "$HOME/.claude/agents/spec-reviewer.md" ]; then
   echo "❌ spec-reviewer agent definition not generated"
   exit 1

--- a/tests/integration/test_chezmoi_apply.sh
+++ b/tests/integration/test_chezmoi_apply.sh
@@ -76,6 +76,28 @@ fi
 
 echo "✅ Codex files generated successfully"
 
+# シークレットスキャン pre-commit フックの検証
+if [ ! -x "$HOME/.config/git/hooks/pre-commit" ]; then
+  echo "❌ pre-commit hook not generated or not executable"
+  exit 1
+fi
+
+if [ ! -f "$HOME/.gitleaks.toml" ]; then
+  echo "❌ .gitleaks.toml not generated"
+  exit 1
+fi
+
+# git config --get はストア済みの生文字列を返し、~ はここでは展開されない (git 内部で
+# フック解決時にのみ展開される) ため、リテラル文字列 "~/.config/git/hooks" と比較する
+HOOKS_PATH_VALUE=$(git config --file "$HOME/.config/git/config" --get core.hooksPath || true)
+# shellcheck disable=SC2088
+if [ "$HOOKS_PATH_VALUE" != "~/.config/git/hooks" ]; then
+  echo "❌ core.hooksPath not set to \$HOME/.config/git/hooks (got: $HOOKS_PATH_VALUE)"
+  exit 1
+fi
+
+echo "✅ Secret scan pre-commit hook and hooksPath generated successfully"
+
 if [ ! -f "$HOME/.claude/agents/spec-reviewer.md" ]; then
   echo "❌ spec-reviewer agent definition not generated"
   exit 1

--- a/tests/unit/test_hooks.sh
+++ b/tests/unit/test_hooks.sh
@@ -169,6 +169,120 @@ else
 fi
 rm -rf "$TEST_HOME" "$TEST_BIN_DIR" "$TEST_CAPTURE_DIR"
 
+echo "Testing pre-commit hook (gitleaks secret scan)..."
+PRECOMMIT_HOOK="home/dot_config/git/hooks/executable_pre-commit"
+
+if [ ! -f "$PRECOMMIT_HOOK" ]; then
+  echo "❌ pre-commit hook not found: $PRECOMMIT_HOOK"
+  FAILED=1
+else
+  if ! bash -n "$PRECOMMIT_HOOK"; then
+    echo "❌ Syntax error in pre-commit hook"
+    FAILED=1
+  else
+    echo "✅ Syntax OK: $PRECOMMIT_HOOK"
+  fi
+
+  # シナリオ 1: gitleaks が PATH に無い場合は fail-open (exit 0 かつ警告) となること
+  TEST_REPO_DIR=$(mktemp -d)
+  TEST_BIN_DIR=$(mktemp -d)
+  if ! (
+    cd "$TEST_REPO_DIR" || exit 1
+    git init -q
+    HOOK_OUTPUT=$(PATH="$TEST_BIN_DIR" "$(command -v bash)" "$OLDPWD/$PRECOMMIT_HOOK" 2>&1)
+    HOOK_EXIT=$?
+    if [[ $HOOK_EXIT -ne 0 ]]; then
+      echo "❌ pre-commit hook did not fail-open when gitleaks is missing (exit $HOOK_EXIT)"
+      exit 1
+    fi
+    if ! echo "$HOOK_OUTPUT" | grep -qi "gitleaks not found"; then
+      echo "❌ pre-commit hook did not warn about missing gitleaks"
+      exit 1
+    fi
+  ); then
+    FAILED=1
+  else
+    echo "✅ pre-commit hook fails open when gitleaks is missing"
+  fi
+  rm -rf "$TEST_REPO_DIR" "$TEST_BIN_DIR"
+
+  # シナリオ 2: gitleaks がシークレットを検知した場合は exit 1 でブロックすること
+  TEST_REPO_DIR=$(mktemp -d)
+  TEST_BIN_DIR=$(mktemp -d)
+  cat > "$TEST_BIN_DIR/gitleaks" << 'EOF'
+#!/bin/bash
+echo "leaks found" >&2
+exit 1
+EOF
+  chmod +x "$TEST_BIN_DIR/gitleaks"
+  if ! (
+    cd "$TEST_REPO_DIR" || exit 1
+    git init -q
+    if PATH="$TEST_BIN_DIR:$PATH" bash "$OLDPWD/$PRECOMMIT_HOOK" > /dev/null 2>&1; then
+      echo "❌ pre-commit hook did not block commit when gitleaks detected a secret"
+      exit 1
+    fi
+  ); then
+    FAILED=1
+  else
+    echo "✅ pre-commit hook blocks commit when gitleaks detects a secret"
+  fi
+  rm -rf "$TEST_REPO_DIR" "$TEST_BIN_DIR"
+
+  # シナリオ 3: リポジトリ側に .gitleaks.toml が無い場合はグローバル設定にフォールバックすること
+  TEST_REPO_DIR=$(mktemp -d)
+  TEST_BIN_DIR=$(mktemp -d)
+  TEST_HOME=$(mktemp -d)
+  TEST_ARGS_LOG=$(mktemp)
+  cat > "$TEST_BIN_DIR/gitleaks" << EOF
+#!/bin/bash
+echo "\$*" > "$TEST_ARGS_LOG"
+exit 0
+EOF
+  chmod +x "$TEST_BIN_DIR/gitleaks"
+  echo "title = \"test\"" > "$TEST_HOME/.gitleaks.toml"
+  if ! (
+    cd "$TEST_REPO_DIR" || exit 1
+    git init -q
+    HOME="$TEST_HOME" PATH="$TEST_BIN_DIR:$PATH" bash "$OLDPWD/$PRECOMMIT_HOOK" > /dev/null 2>&1
+    if ! grep -q -- "--config $TEST_HOME/.gitleaks.toml" "$TEST_ARGS_LOG"; then
+      echo "❌ pre-commit hook did not fall back to the global gitleaks config"
+      exit 1
+    fi
+  ); then
+    FAILED=1
+  else
+    echo "✅ pre-commit hook falls back to the global gitleaks config when the repo has none"
+  fi
+  rm -rf "$TEST_REPO_DIR" "$TEST_BIN_DIR" "$TEST_HOME" "$TEST_ARGS_LOG"
+
+  # シナリオ 4: リポジトリ側に .gitleaks.toml がある場合は --config を渡さず自動検出に任せること
+  TEST_REPO_DIR=$(mktemp -d)
+  TEST_BIN_DIR=$(mktemp -d)
+  TEST_ARGS_LOG=$(mktemp)
+  cat > "$TEST_BIN_DIR/gitleaks" << EOF
+#!/bin/bash
+echo "\$*" > "$TEST_ARGS_LOG"
+exit 0
+EOF
+  chmod +x "$TEST_BIN_DIR/gitleaks"
+  if ! (
+    cd "$TEST_REPO_DIR" || exit 1
+    git init -q
+    echo 'title = "repo-local"' > .gitleaks.toml
+    PATH="$TEST_BIN_DIR:$PATH" bash "$OLDPWD/$PRECOMMIT_HOOK" > /dev/null 2>&1
+    if grep -q -- "--config" "$TEST_ARGS_LOG"; then
+      echo "❌ pre-commit hook overrode the repo's own .gitleaks.toml"
+      exit 1
+    fi
+  ); then
+    FAILED=1
+  else
+    echo "✅ pre-commit hook defers to the repo's own .gitleaks.toml when present"
+  fi
+  rm -rf "$TEST_REPO_DIR" "$TEST_BIN_DIR" "$TEST_ARGS_LOG"
+fi
+
 if [ $FAILED -eq 0 ]; then
   echo "✅ All hook tests passed"
 else

--- a/tests/unit/test_hooks.sh
+++ b/tests/unit/test_hooks.sh
@@ -249,6 +249,10 @@ EOF
       echo "❌ pre-commit hook did not fall back to the global gitleaks config"
       exit 1
     fi
+    if ! grep -q -- "protect --staged --redact -v" "$TEST_ARGS_LOG"; then
+      echo "❌ pre-commit hook did not pass protect --staged --redact -v to gitleaks"
+      exit 1
+    fi
   ); then
     FAILED=1
   else
@@ -275,12 +279,28 @@ EOF
       echo "❌ pre-commit hook overrode the repo's own .gitleaks.toml"
       exit 1
     fi
+    if ! grep -q -- "protect --staged --redact -v" "$TEST_ARGS_LOG"; then
+      echo "❌ pre-commit hook did not pass protect --staged --redact -v to gitleaks"
+      exit 1
+    fi
   ); then
     FAILED=1
   else
     echo "✅ pre-commit hook defers to the repo's own .gitleaks.toml when present"
   fi
   rm -rf "$TEST_REPO_DIR" "$TEST_BIN_DIR" "$TEST_ARGS_LOG"
+
+  # シナリオ 5: グローバルフォールバック設定 (home/dot_gitleaks.toml) が構文的に有効な TOML であること
+  # (gitleaks は設定エラーとシークレット検知の両方で同じ終了コードを返すため、構文エラーが
+  # 混入すると全リポジトリでコミットが無差別にブロックされる。real gitleaks は使わずに TOML
+  # 構文のみを検証する)
+  GITLEAKS_CONFIG="home/dot_gitleaks.toml"
+  if ! python3 -c "import tomllib, sys; tomllib.load(open(sys.argv[1], 'rb'))" "$GITLEAKS_CONFIG"; then
+    echo "❌ $GITLEAKS_CONFIG is not valid TOML"
+    FAILED=1
+  else
+    echo "✅ $GITLEAKS_CONFIG is valid TOML"
+  fi
 fi
 
 if [ $FAILED -eq 0 ]; then

--- a/tests/unit/test_install.sh
+++ b/tests/unit/test_install.sh
@@ -16,11 +16,19 @@ echo "✅ --help option test passed"
 # テスト 2: --dry-run オプション (環境チェックのみ)
 echo "Test 2: --dry-run option"
 # ANSI カラーコードを削除してから grep
-if ! bash install.sh --dry-run --skip-interactive --skip-apt --skip-gh --skip-ghq --skip-mkwork --skip-roots 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -q "DRY RUN"; then
+if ! bash install.sh --dry-run --skip-interactive --skip-apt --skip-gh --skip-ghq --skip-mkwork --skip-roots --skip-gitleaks 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -q "DRY RUN"; then
   echo "❌ --dry-run option test failed"
   exit 1
 fi
 echo "✅ --dry-run option test passed"
+
+# テスト 2.5: --help が --skip-gitleaks を案内していること
+echo "Test 2.5: --help mentions --skip-gitleaks"
+if ! bash install.sh --help 2>&1 | grep -q -- "--skip-gitleaks"; then
+  echo "❌ --help does not mention --skip-gitleaks"
+  exit 1
+fi
+echo "✅ --help mentions --skip-gitleaks"
 
 # テスト 3: 無効なオプション
 echo "Test 3: invalid option"


### PR DESCRIPTION
## 概要

コミット時にステージ済み差分内のシークレット (API キー・トークン等) を決定論的に検知し、コミットをブロックする仕組みを dotfiles 全体に導入する。`core.hooksPath` をグローバル設定することで、dotfiles を導入した全マシン・全 Git リポジトリで有効になる。

## 変更内容

- `home/dot_config/git/hooks/executable_pre-commit`: gitleaks によるステージ済み差分のシークレットスキャンを行う pre-commit フック。gitleaks が未導入の環境では fail-open (警告のみでコミットを許可)。リポジトリ自身に `.gitleaks.toml` があればそちらを優先し、無ければグローバルのフォールバック設定を使う。
- `home/dot_gitleaks.toml`: グローバルフォールバック用の gitleaks 設定。dotfiles 自身の example ファイルのみを許可リストに追加。
- `home/dot_config/git/config`: `core.hooksPath` を `~/.config/git/hooks` に設定。
- `install.sh`: `install_gitleaks` 関数を追加。GitHub Releases から gitleaks をダウンロードし、公開されているチェックサムファイルで改ざん検知を行った上で `~/.local/bin` にインストールする。
- テスト: `tests/unit/test_hooks.sh` に pre-commit フックの単体テスト (フォールバック設定への切り替え、リポジトリ自身の設定の優先、gitleaks 未導入時の fail-open、gitleaks への呼び出し引数、グローバル設定の TOML 構文検証) を追加。`tests/integration/test_chezmoi_apply.sh` に `core.hooksPath` 経由で実際の `git commit` がフックを起動することを検証するエンドツーエンドテストを追加。`tests/unit/test_install.sh` に `install_gitleaks` のテストを追加。

## 関連ドキュメント

Spec: https://github.com/book000/dotfiles/issues/253#issuecomment-4977586976
Plan: https://github.com/book000/dotfiles/issues/253#issuecomment-4977847594

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)