### PR TITLE
feat: mise を導入し gh・ghq・roots のインストールを mise 管理に切り替える

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@
 - トークン・Webhook URL・パスワード等を平文でコミットしていないか確認する。
 - `~/.env` や `~/.gitconfig.local` はリポジトリ管理外。`.env.example` / `.gitconfig.local.example` などサンプルのみを含める。
 - pre-commit フック(`home/dot_config/git/hooks/executable_pre-commit`)や `home/dot_gitleaks.toml` の allowlist を変更する場合、誤検知抑制が広すぎて実際のシークレット検知を無効化していないか確認する。
+- `gitleaks` コマンド自体は `install.sh` に直接インストールロジックを持たず、mise 経由でインストールされる(下記「mise 管理下のツール」参照)。
 
 ### テストの追随
 
@@ -29,7 +30,7 @@
 
 ### mise 管理下のツール
 
-- `gh`・`ghq`・`roots` などの CLI ツールは `home/dot_config/mise/config.toml` の宣言に基づき `mise` 経由でインストールする。`install.sh` に直接インストールロジックを追加していないか確認する。
+- `gh`・`ghq`・`roots`・`gitleaks` などの CLI ツールは `home/dot_config/mise/config.toml` の宣言に基づき `mise` 経由でインストールする。`install.sh` に直接インストールロジックを追加していないか確認する。
 - `install.sh` に固定記述された mise 本体のバージョン(`MISE_VERSION`)を変更する場合、`renovate.json` の対応する `regexManagers` エントリと矛盾していないか確認する。
 
 ## コーディング規約

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,6 +26,11 @@
 
 - `home/dot_codex/`、`home/dot_claude/scripts/` など通知・フック関連スクリプトを変更・削除した場合、`tests/unit/`、`tests/integration/`、`tests/syntax/` 配下の対応するテストが古い参照を残していないか確認する。
 
+### mise 管理下のツール
+
+- `gh`・`ghq`・`roots` などの CLI ツールは `home/dot_config/mise/config.toml` の宣言に基づき `mise` 経由でインストールする。`install.sh` に直接インストールロジックを追加していないか確認する。
+- `install.sh` に固定記述された mise 本体のバージョン(`MISE_VERSION`)を変更する場合、`renovate.json` の対応する `regexManagers` エントリと矛盾していないか確認する。
+
 ## コーディング規約
 
 - コミットメッセージは Conventional Commits に従い、`<description>` は日本語で記載する。
@@ -36,7 +41,7 @@
 ## 技術スタック
 
 - 言語: Bash
-- ツール: chezmoi, git, tmux, jq
+- ツール: chezmoi, git, tmux, jq, mise
 
 ## ドキュメント整合性
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ chezmoi はソース側のプレフィックスを解釈してデプロイする
 - `.env.example` と `.gitconfig.local.example` をサンプルとして提供。
 - wakatime は別途管理するため、dotfiles での暗号化管理は行わない。
 - PR 作成先は `upstream` remote があればそれを既定とし、`home/bin/executable_gh-pr-target-repo.sh`（デプロイ後 `~/bin/gh-pr-target-repo.sh`）で解決する。
-- 依存バージョンの更新は `renovate.json` の Renovate (GitHub App) で管理する。`home/dot_claude/private_settings.json` の `statusLine.command` に埋め込まれた `ccstatusline` の npm バージョンや、`install.sh` に固定記述された mise 本体のバージョンなど、通常の `package.json` では追跡できない箇所は `regexManagers` で個別に対象化する。`gh`/`ghq`/`roots` など mise 管理下のツールバージョンは `home/dot_config/mise/config.toml` への宣言により Renovate のネイティブな mise サポートで自動追跡される(`regexManagers` の追加設定は不要)。
+- 依存バージョンの更新は `renovate.json` の Renovate (GitHub App) で管理する。`home/dot_claude/private_settings.json` の `statusLine.command` に埋め込まれた `ccstatusline` の npm バージョンや、`install.sh` に固定記述された mise 本体のバージョンなど、通常の `package.json` では追跡できない箇所は `regexManagers` で個別に対象化する。`gh`/`ghq`/`roots`/`gitleaks` など mise 管理下のツールバージョンは `home/dot_config/mise/config.toml` への宣言により Renovate のネイティブな mise サポートで自動追跡される(`regexManagers` の追加設定は不要)。
 
 ## Claude Code フック / 通知機能
 
@@ -99,4 +99,4 @@ Claude Code のフックは `home/dot_claude/private_settings.json` で設定さ
 
 `home/dot_config/git/hooks/executable_pre-commit`(デプロイ後 `~/.config/git/hooks/pre-commit`)が `core.hooksPath` 経由でグローバル pre-commit フックとして登録され、`gitleaks` によるステージ済み差分のシークレットスキャンを行う。フォールバック設定は `home/dot_gitleaks.toml`(デプロイ後 `~/.gitleaks.toml`)。
 
-このフックや `install.sh` の `install_gitleaks` を変更した場合、`tests/unit/test_hooks.sh` / `tests/unit/test_install.sh` / `tests/integration/test_chezmoi_apply.sh` の参照が古くなっていないか確認する。
+このフックや `gitleaks` コマンド自体のインストール方法(`home/dot_config/mise/config.toml` 経由の mise 管理、`install.sh` の `install_mise_tools`)を変更した場合、`tests/unit/test_hooks.sh` / `tests/unit/test_install.sh` / `tests/integration/test_chezmoi_apply.sh` の参照が古くなっていないか確認する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ chezmoi はソース側のプレフィックスを解釈してデプロイする
 - `.env.example` と `.gitconfig.local.example` をサンプルとして提供。
 - wakatime は別途管理するため、dotfiles での暗号化管理は行わない。
 - PR 作成先は `upstream` remote があればそれを既定とし、`home/bin/executable_gh-pr-target-repo.sh`（デプロイ後 `~/bin/gh-pr-target-repo.sh`）で解決する。
-- 依存バージョンの更新は `renovate.json` の Renovate (GitHub App) で管理する。`home/dot_claude/private_settings.json` の `statusLine.command` に埋め込まれた `ccstatusline` の npm バージョンなど、通常の `package.json` では追跡できない箇所は `regexManagers` で個別に対象化する。
+- 依存バージョンの更新は `renovate.json` の Renovate (GitHub App) で管理する。`home/dot_claude/private_settings.json` の `statusLine.command` に埋め込まれた `ccstatusline` の npm バージョンや、`install.sh` に固定記述された mise 本体のバージョンなど、通常の `package.json` では追跡できない箇所は `regexManagers` で個別に対象化する。`gh`/`ghq`/`roots` など mise 管理下のツールバージョンは `home/dot_config/mise/config.toml` への宣言により Renovate のネイティブな mise サポートで自動追跡される(`regexManagers` の追加設定は不要)。
 
 ## Claude Code フック / 通知機能
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ macOS と Windows は現在サポートされていません。
 
 ## ツールバージョン管理
 
-`mise`（https://mise.jdx.dev/）を使用して、`gh`・`ghq`・`roots` などの CLI ツールおよび言語ランタイムのバージョンを管理しています。バージョンの宣言は `home/dot_config/mise/config.toml` で行い、Renovate が自動的に更新 PR を作成します。
+`mise`（https://mise.jdx.dev/）を使用して、`gh`・`ghq`・`roots`・`gitleaks` などの CLI ツールおよび言語ランタイムのバージョンを管理しています。バージョンの宣言は `home/dot_config/mise/config.toml` で行い、Renovate が自動的に更新 PR を作成します。
 
 ## セキュリティに関する注意事項
 
@@ -92,7 +92,7 @@ macOS と Windows は現在サポートされていません。
 **既知の制約:**
 
 - リポジトリ側で `core.hooksPath` がローカル設定として上書きされている場合、このグローバルフックは効きません(Git の標準仕様)。
-- `gitleaks` コマンドが見つからない場合は fail-open(警告を表示した上でコミットを続行)します。`install.sh` が `gitleaks` を自動インストールしますが、`--skip-gitleaks` でスキップした環境や、dotfiles 導入前の環境ではスキャンが行われません。
+- `gitleaks` コマンドが見つからない場合は fail-open(警告を表示した上でコミットを続行)します。`install.sh` が mise 経由で `gitleaks` を自動インストールしますが、`--skip-gitleaks` でスキップした環境や、dotfiles 導入前の環境ではスキャンが行われません。
 - 誤検知が発生した場合は、対象リポジトリに独自の `.gitleaks.toml` を配置するか、`git commit --no-verify` でバイパスしてください。
 
 ## Claude Code 通知機能

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ export PATH="$HOME/.local/bin:$PATH"
 
 macOS と Windows は現在サポートされていません。
 
+## ツールバージョン管理
+
+`mise`（https://mise.jdx.dev/）を使用して、`gh`・`ghq`・`roots` などの CLI ツールおよび言語ランタイムのバージョンを管理しています。バージョンの宣言は `home/dot_config/mise/config.toml` で行い、Renovate が自動的に更新 PR を作成します。
+
 ## セキュリティに関する注意事項
 
 `curl | bash` 方式には以下のリスクがあります:

--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -7,6 +7,7 @@ pnpm = "latest"
 ghq = "latest"
 gh = "latest"
 "ubi:k1LoW/roots" = "latest"
+gitleaks = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["node"]

--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -4,6 +4,9 @@ java = "25"
 node = "24"
 python = "3.14"
 pnpm = "latest"
+ghq = "latest"
+gh = "latest"
+"ubi:k1LoW/roots" = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["node"]

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@
 #     --skip-gh          gh CLI のインストールをスキップ
 #     --skip-ghq         ghq のインストールをスキップ
 #     --skip-mkwork      mkwork のインストールをスキップ
+#     --skip-mise        mise (ツールバージョン管理) のインストールをスキップ
 #     --skip-roots       roots のインストールをスキップ
 #     --skip-interactive 対話的な確認をスキップ (CI 用、 /dev/tty が利用できない場合も自動的に非対話モードになります)
 #     --help             ヘルプを表示
@@ -32,6 +33,7 @@ SKIP_APT=0
 SKIP_GH=0
 SKIP_GHQ=0
 SKIP_MKWORK=0
+SKIP_MISE=0
 SKIP_ROOTS=0
 SKIP_INTERACTIVE=0
 
@@ -47,6 +49,7 @@ OPTIONS:
   --skip-gh          gh CLI のインストールをスキップ
   --skip-ghq         ghq のインストールをスキップ
   --skip-mkwork      mkwork のインストールをスキップ
+  --skip-mise        mise (ツールバージョン管理) のインストールをスキップ
   --skip-roots       roots のインストールをスキップ
   --skip-interactive 対話的な確認をスキップ (CI 用、 /dev/tty が利用できない場合も自動的に非対話モードになります)
   --help             このヘルプを表示
@@ -84,6 +87,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-mkwork)
       SKIP_MKWORK=1
+      shift
+      ;;
+    --skip-mise)
+      SKIP_MISE=1
       shift
       ;;
     --skip-roots)
@@ -412,6 +419,34 @@ install_apt_packages() {
   # パッケージのインストール
   log_info "パッケージをインストールしています: ${packages[*]}"
   run_command sudo apt install -y "${packages[@]}"
+}
+
+# mise のバージョン (Renovate で追跡するため固定文字列として記述する)
+MISE_VERSION="v2026.7.6"
+
+# mise のインストール
+install_mise() {
+  if [[ "$SKIP_MISE" == "1" ]]; then
+    log_info "mise のインストールをスキップします (--skip-mise)"
+    return 0
+  fi
+
+  log_info "mise をインストールしています..."
+
+  if command -v mise &> /dev/null; then
+    log_warn "mise は既にインストールされています ($(mise --version))"
+    return 0
+  fi
+
+  # 公式インストーラはパイプを使うため run_command でラップできず、DRY_RUN を手動で分岐する
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log_info "[DRY RUN] curl -fsSL https://mise.run | MISE_VERSION=$MISE_VERSION sh"
+    return 0
+  fi
+
+  curl -fsSL https://mise.run | MISE_VERSION="$MISE_VERSION" sh
+
+  log_info "mise が正常にインストールされました ($("$HOME/.local/bin/mise" --version))"
 }
 
 # gh CLI のインストール

--- a/install.sh
+++ b/install.sh
@@ -486,115 +486,13 @@ install_mise_tools() {
     log_info "roots を mise 経由でインストールしています..."
     run_command mise install ubi:k1LoW/roots
   fi
-}
 
-# gitleaks のインストール
-install_gitleaks() {
   if [[ "$SKIP_GITLEAKS" == "1" ]]; then
     log_info "gitleaks のインストールをスキップします (--skip-gitleaks)"
-    return 0
-  fi
-
-  log_info "gitleaks をインストールしています..."
-
-  if command -v gitleaks &> /dev/null; then
-    log_warn "gitleaks は既にインストールされています"
-    return 0
-  fi
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    log_info "[DRY RUN] gitleaks の GitHub Release からのダウンロード・インストールをスキップします"
-    return 0
-  fi
-
-  log_info "GitHub Release から最新版を取得しています..."
-
-  local version
-  local api_response
-  api_response=$(curl -fsSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest)
-
-  if command -v jq &> /dev/null; then
-    version=$(printf '%s\n' "$api_response" | jq -r '.tag_name' | sed -E 's/^v//')
   else
-    log_warn "jq is not installed. Falling back to grep/sed for version parsing"
-    version=$(printf '%s\n' "$api_response" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    log_info "gitleaks を mise 経由でインストールしています..."
+    run_command mise install gitleaks
   fi
-
-  if [[ -z "$version" || "$version" == "null" ]]; then
-    log_error "Failed to parse latest version from GitHub API"
-    return 1
-  fi
-
-  log_info "最新バージョン: v$version"
-
-  # gitleaks のリリースアーカイブはアーキテクチャ名に amd64 ではなく x64 を使用する
-  local gitleaks_arch="$ARCH"
-  if [[ "$ARCH" == "amd64" ]]; then
-    gitleaks_arch="x64"
-  fi
-
-  local archive_filename="gitleaks_${version}_linux_${gitleaks_arch}.tar.gz"
-  local download_url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/${archive_filename}"
-
-  log_info "ダウンロード URL: $download_url"
-
-  local temp_dir
-  temp_dir=$(mktemp -d)
-  # ${temp_dir:-} は将来この関数がリファクタリングされ trap 登録より前で return するなど
-  # temp_dir 未定義のまま trap が発火し得る構成に変わっても set -u で落ちないようにする防御策
-  trap 'rm -rf "${temp_dir:-}"' RETURN
-
-  if [[ ! -d "$temp_dir" ]]; then
-    log_error "Failed to create temporary directory"
-    return 1
-  fi
-
-  cd "$temp_dir" || { log_error "Failed to change directory to temporary directory"; return 1; }
-
-  if ! curl -fsSL -o "$archive_filename" "$download_url"; then
-    log_error "Failed to download gitleaks archive"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  # 改ざん・アセット差し替えを検知するため、gitleaks が公開するチェックサムファイルと突合する
-  # (sha256sum -c はチェックサム行に記載されたファイル名で cwd を照合するため、
-  # ダウンロードしたアーカイブはリリースアセットと同じファイル名で保存する必要がある)
-  local checksums_url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_checksums.txt"
-  if ! curl -fsSL -o checksums.txt "$checksums_url"; then
-    log_error "Failed to download gitleaks checksums file"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  if ! grep -- "$archive_filename" checksums.txt | sha256sum -c - > /dev/null; then
-    log_error "gitleaks archive checksum verification failed"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  if ! tar -xzf "$archive_filename"; then
-    log_error "Failed to extract gitleaks archive"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  local gitleaks_binary
-  gitleaks_binary=$(find . -maxdepth 1 -type f -name gitleaks -print -quit)
-
-  if [[ -z "$gitleaks_binary" ]]; then
-    log_error "gitleaks binary not found after extraction"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  mkdir -p "$HOME/.local/bin"
-  mv "$gitleaks_binary" "$HOME/.local/bin/gitleaks"
-  chmod +x "$HOME/.local/bin/gitleaks"
-
-  cd - > /dev/null
-
-  log_info "gitleaks が正常にインストールされました"
 }
 
 # mkwork のインストール
@@ -871,7 +769,6 @@ main() {
   install_apt_packages
   install_mise
   install_mkwork
-  install_gitleaks
   setup_gitconfig_local
   setup_env
   copy_env_if_needed  # chezmoi apply 前に .env をコピー（テンプレート展開エラー回避）

--- a/install.sh
+++ b/install.sh
@@ -445,12 +445,20 @@ install_mise() {
 
   curl -fsSL https://mise.run | MISE_VERSION="$MISE_VERSION" sh
 
-  log_info "mise が正常にインストールされました ($("$HOME/.local/bin/mise" --version))"
+  # コマンド置換をログ引数に埋め込むと set -e 下で失敗が握りつぶされるため、変数に代入してから渡す
+  local installed_version
+  installed_version=$("$HOME/.local/bin/mise" --version)
+  log_info "mise が正常にインストールされました ($installed_version)"
 }
 
-# mise 経由でのツールインストール (gh, ghq, roots)
+# mise 経由でのツールインストール
 # home/dot_config/mise/config.toml の宣言に従い、chezmoi apply 後に実行する
 install_mise_tools() {
+  if [[ "$SKIP_MISE" == "1" ]]; then
+    log_info "mise 未インストールのため、mise 経由のツールインストールをスキップします (--skip-mise)"
+    return 0
+  fi
+
   if [[ "$SKIP_GH" == "1" ]]; then
     log_info "gh CLI のインストールをスキップします (--skip-gh)"
   else
@@ -751,7 +759,7 @@ main() {
   setup_env
   copy_env_if_needed  # chezmoi apply 前に .env をコピー（テンプレート展開エラー回避）
   apply_chezmoi
-  install_mise_tools  # config.toml 配置後に mise 経由で gh/ghq/roots をインストール
+  install_mise_tools  # config.toml 配置後に mise 経由で対象ツールをインストール
 
   log_info ""
   log_info "✅ インストールが正常に完了しました!"

--- a/install.sh
+++ b/install.sh
@@ -403,7 +403,6 @@ install_apt_packages() {
   local packages=(
     "curl"
     "git"
-    "unzip"
     "bash"
     "tmux"
     "vim"
@@ -449,240 +448,29 @@ install_mise() {
   log_info "mise が正常にインストールされました ($("$HOME/.local/bin/mise" --version))"
 }
 
-# gh CLI のインストール
-install_gh_cli() {
+# mise 経由でのツールインストール (gh, ghq, roots)
+# home/dot_config/mise/config.toml の宣言に従い、chezmoi apply 後に実行する
+install_mise_tools() {
   if [[ "$SKIP_GH" == "1" ]]; then
     log_info "gh CLI のインストールをスキップします (--skip-gh)"
-    return 0
-  fi
-
-  log_info "GitHub CLI (gh) をインストールしています..."
-
-  if command -v gh &> /dev/null; then
-    log_warn "gh は既にインストールされています ($(gh --version | head -n1))"
-    return 0
-  fi
-
-  # GitHub CLI 公式リポジトリの追加
-  if ! command -v curl &> /dev/null; then
-    run_command sudo apt update
-    run_command sudo apt install curl -y
-  fi
-
-  run_command curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg
-  run_command sudo dd if=/tmp/githubcli-archive-keyring.gpg of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-  run_command sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    log_info "[DRY RUN] echo \"deb [arch=\$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\" | sudo tee /etc/apt/sources.list.d/github-cli.list"
   else
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    log_info "gh CLI を mise 経由でインストールしています..."
+    run_command mise install gh
   fi
 
-  run_command sudo apt update
-  run_command sudo apt install gh -y
-
-  if [[ "$DRY_RUN" != "1" ]]; then
-    log_info "gh が正常にインストールされました ($(gh --version | head -n1))"
-  fi
-}
-
-# ghq のインストール
-install_ghq() {
   if [[ "$SKIP_GHQ" == "1" ]]; then
     log_info "ghq のインストールをスキップします (--skip-ghq)"
-    return 0
-  fi
-
-  log_info "ghq をインストールしています..."
-
-  if command -v ghq &> /dev/null; then
-    log_warn "ghq は既にインストールされています"
-    return 0
-  fi
-
-  # パッケージマネージャで試行
-  if command -v apt &> /dev/null; then
-    log_info "apt で ghq をインストールしています..."
-    if [[ "$DRY_RUN" == "1" ]]; then
-      log_info "[DRY RUN] apt で ghq のインストールをスキップし、GitHub Release からのインストールに進みます"
-    else
-      if run_command sudo apt install -y ghq 2>/dev/null; then
-        log_info "ghq が apt からインストールされました"
-        return 0
-      else
-        log_warn "apt で ghq が見つかりませんでした。GitHub Release からダウンロードします"
-      fi
-    fi
-  fi
-
-  # GitHub Release から最新版を取得
-  log_info "GitHub Release から最新版を取得しています..."
-
-  local version
-  local api_response
-  api_response=$(curl -fsSL https://api.github.com/repos/x-motemen/ghq/releases/latest)
-
-  # jq が利用可能なら JSON を安全にパースする
-  if command -v jq &> /dev/null; then
-    version=$(printf '%s\n' "$api_response" | jq -r '.tag_name' | sed -E 's/^v//')
   else
-    # jq が利用できない場合は従来の grep / sed にフォールバックする
-    log_warn "jq is not installed. Falling back to grep/sed for version parsing"
-    version=$(printf '%s\n' "$api_response" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    log_info "ghq を mise 経由でインストールしています..."
+    run_command mise install ghq
   fi
 
-  if [[ -z "$version" || "$version" == "null" ]]; then
-    log_error "Failed to parse latest version from GitHub API"
-    return 1
-  fi
-
-  log_info "最新バージョン: v$version"
-
-  # ダウンロード URL
-  local os
-  os=$(uname -s | tr '[:upper:]' '[:lower:]')
-  local download_url="https://github.com/x-motemen/ghq/releases/download/v${version}/ghq_${os}_${ARCH}.zip"
-
-  log_info "ダウンロード URL: $download_url"
-
-  # 一時ディレクトリでダウンロード
-  local temp_dir
-  temp_dir=$(mktemp -d)
-
-  # 一時ディレクトリのクリーンアップを設定
-  # ${temp_dir:-} は将来この関数がリファクタリングされ trap 登録より前で return するなど
-  # temp_dir 未定義のまま trap が発火し得る構成に変わっても set -u で落ちないようにする防御策
-  trap 'rm -rf "${temp_dir:-}"' RETURN
-
-  if [[ ! -d "$temp_dir" ]]; then
-    log_error "Failed to create temporary directory"
-    return 1
-  fi
-
-  cd "$temp_dir" || {
-    log_error "Failed to change directory to temporary directory"
-    return 1
-  }
-
-  # ghq のアーカイブをダウンロード
-  if ! curl -L -o ghq.zip "$download_url"; then
-    log_error "Failed to download ghq archive"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  # ダウンロードしたアーカイブを展開
-  if ! unzip -q ghq.zip; then
-    log_error "Failed to unzip ghq archive"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  # 展開後の ghq バイナリを特定
-  local ghq_binary
-  ghq_binary=$(find . -maxdepth 2 -type f -name ghq -print -quit)
-
-  if [[ -z "$ghq_binary" ]]; then
-    log_error "ghq binary not found after extraction"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  # ~/.local/bin にインストール
-  mkdir -p "$HOME/.local/bin"
-  mv "$ghq_binary" "$HOME/.local/bin/ghq"
-  chmod +x "$HOME/.local/bin/ghq"
-
-  cd - > /dev/null
-
-  log_info "ghq が正常にインストールされました"
-}
-
-# roots のインストール
-install_roots() {
   if [[ "$SKIP_ROOTS" == "1" ]]; then
     log_info "roots のインストールをスキップします (--skip-roots)"
-    return 0
-  fi
-
-  log_info "roots をインストールしています..."
-
-  if command -v roots &> /dev/null; then
-    log_warn "roots は既にインストールされています"
-    return 0
-  fi
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    log_info "[DRY RUN] roots の GitHub Release からのダウンロード・インストールをスキップします"
-    return 0
-  fi
-
-  log_info "GitHub Release から最新版を取得しています..."
-
-  local version
-  local api_response
-  api_response=$(curl -fsSL https://api.github.com/repos/k1LoW/roots/releases/latest)
-
-  if command -v jq &> /dev/null; then
-    version=$(printf '%s\n' "$api_response" | jq -r '.tag_name')
   else
-    log_warn "jq is not installed. Falling back to grep/sed for version parsing"
-    version=$(printf '%s\n' "$api_response" | grep '"tag_name":' | sed -E 's/.*"(v[^"]+)".*/\1/')
+    log_info "roots を mise 経由でインストールしています..."
+    run_command mise install ubi:k1LoW/roots
   fi
-
-  if [[ -z "$version" || "$version" == "null" ]]; then
-    log_error "Failed to parse latest version from GitHub API"
-    return 1
-  fi
-
-  log_info "最新バージョン: $version"
-
-  local download_url="https://github.com/k1LoW/roots/releases/download/${version}/roots_${version}_linux_${ARCH}.tar.gz"
-
-  log_info "ダウンロード URL: $download_url"
-
-  local temp_dir
-  temp_dir=$(mktemp -d)
-  # ${temp_dir:-} は将来この関数がリファクタリングされ trap 登録より前で return するなど
-  # temp_dir 未定義のまま trap が発火し得る構成に変わっても set -u で落ちないようにする防御策
-  trap 'rm -rf "${temp_dir:-}"' RETURN
-
-  if [[ ! -d "$temp_dir" ]]; then
-    log_error "Failed to create temporary directory"
-    return 1
-  fi
-
-  cd "$temp_dir" || { log_error "Failed to change directory to temporary directory"; return 1; }
-
-  if ! curl -fsSL -o roots.tar.gz "$download_url"; then
-    log_error "Failed to download roots archive"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  if ! tar -xzf roots.tar.gz; then
-    log_error "Failed to extract roots archive"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  local roots_binary
-  roots_binary=$(find . -maxdepth 1 -type f -name roots -print -quit)
-
-  if [[ -z "$roots_binary" ]]; then
-    log_error "roots binary not found after extraction"
-    cd - > /dev/null || true
-    return 1
-  fi
-
-  mkdir -p "$HOME/.local/bin"
-  mv "$roots_binary" "$HOME/.local/bin/roots"
-  chmod +x "$HOME/.local/bin/roots"
-
-  cd - > /dev/null
-
-  log_info "roots が正常にインストールされました"
 }
 
 # mkwork のインストール
@@ -957,14 +745,13 @@ main() {
   backup_ssh_config
   install_chezmoi
   install_apt_packages
-  install_gh_cli
-  install_ghq
-  install_roots
+  install_mise
   install_mkwork
   setup_gitconfig_local
   setup_env
   copy_env_if_needed  # chezmoi apply 前に .env をコピー（テンプレート展開エラー回避）
   apply_chezmoi
+  install_mise_tools  # config.toml 配置後に mise 経由で gh/ghq/roots をインストール
 
   log_info ""
   log_info "✅ インストールが正常に完了しました!"

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,12 @@
       "matchStrings": ["ccstatusline@(?<currentValue>[0-9.]+)"],
       "depNameTemplate": "ccstatusline",
       "datasourceTemplate": "npm"
+    },
+    {
+      "fileMatch": ["^install\\.sh$"],
+      "matchStrings": ["MISE_VERSION=\"v(?<currentValue>[0-9.]+)\""],
+      "depNameTemplate": "jdx/mise",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     },
     {
       "fileMatch": ["^install\\.sh$"],
-      "matchStrings": ["MISE_VERSION=\"v(?<currentValue>[0-9.]+)\""],
+      "matchStrings": ["MISE_VERSION=\"(?<currentValue>v[0-9.]+)\""],
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases"
     }

--- a/tests/unit/test_install.sh
+++ b/tests/unit/test_install.sh
@@ -16,7 +16,7 @@ echo "✅ --help option test passed"
 # テスト 2: --dry-run オプション (環境チェックのみ)
 echo "Test 2: --dry-run option"
 # ANSI カラーコードを削除してから grep
-if ! bash install.sh --dry-run --skip-interactive --skip-apt --skip-gh --skip-ghq --skip-mkwork --skip-roots 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -q "DRY RUN"; then
+if ! bash install.sh --dry-run --skip-interactive --skip-apt --skip-gh --skip-ghq --skip-mkwork --skip-roots --skip-mise 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -q "DRY RUN"; then
   echo "❌ --dry-run option test failed"
   exit 1
 fi


### PR DESCRIPTION
## 概要

Issue #210「miseの導入」に対応し、[mise](https://mise.jdx.dev/) をツールバージョン管理として導入します。

## 変更内容

- `install.sh` に公式インストーラ経由での mise インストール処理を追加(`--skip-mise` オプション付き、バージョン固定)
- `gh`・`ghq`・`roots`・`gitleaks` のインストールを、apt/GitHub Release 直接ダウンロードから mise 経由(`home/dot_config/mise/config.toml` 宣言 + `mise install`)に切り替え
  - `gitleaks` は `upstream/master` の #255(gitleaks 導入)とのマージで一旦 GitHub Release 直接ダウンロード方式が混入したため、同じ移行方針に合わせて mise 管理下へ変更
- `mkwork` は sourced シェル関数ライブラリで mise のシム/PATH モデルと相性が悪いため、移行対象から除外し現行の `install.sh` ロジックのまま維持
- `renovate.json` に mise 本体バージョン用の `regexManagers` を追加(`gh`/`ghq`/`roots`/`gitleaks` 側は mise のネイティブサポートにより追加設定不要)
- `README.md` / `CLAUDE.md` / `.github/copilot-instructions.md` を実態に合わせて更新

## 動作確認

- `bash -n install.sh` / shellcheck / JSON・TOML 構文チェック: 問題なし
- `tests/unit/`(`test_install.sh`・`test_hooks.sh` 含む)、`tests/syntax/` ほか既存の単体/構文テスト: 全て pass
- Docker 上で `chezmoi apply` による実インストールフローの統合テスト(`tests/integration/test_chezmoi_apply.sh`)を実行し pass
- ローカル diff モードでの Deep Review を実施し、指摘事項(`--skip-mise` 単体指定時の異常終了、Renovate バージョン抽出の不整合等)をすべて修正済み
- `upstream/master`(gitleaks 導入 #255 を含む)をマージし、コンフリクトを解消済み

Closes #210

Spec: https://github.com/book000/dotfiles/issues/210#issuecomment-4980034476
Plan: https://github.com/book000/dotfiles/issues/210#issuecomment-4980138311
