### PR TITLE
feat: コードコメント品質ガイドラインを許可/禁止条件形式に改良し lite-review に統合する

### DIFF
--- a/home/dot_claude/rules/coding-common.md
+++ b/home/dot_claude/rules/coding-common.md
@@ -32,7 +32,10 @@ Rules that apply regardless of language.
   - Use a single emoji that matches the content of the error message
 - Content layer — each artifact carries one distinct layer of information; do not duplicate a layer into another artifact:
   - **Code** expresses *how*: the implementation steps themselves. If a comment is needed to understand the code, make the code clearer first instead of adding narration.
-  - **Code comments** express *why not*: rejected alternatives, workarounds, non-obvious constraints. A comment that only restates what the next line already shows is a violation — delete it instead of writing it.
+  - **Code comments** express *why not*: do not add comments by default.
+    - Allowed only for: the reasoning behind the implementation choice (why this approach and not a rejected alternative), non-obvious constraints from the spec, security/performance/compatibility caveats, or assumptions likely to break in the future.
+    - Never add: comments that restate what the code already shows, comments that only repeat what a function/variable name already makes obvious, "what" comments (e.g. "initialize the value", "increment the counter"), or temporary progress-report comments.
+    - Before finishing a task, review the comments you added or changed and remove any that fall under "Never add" above.
   - **Test code** expresses *what*: test/spec names and assertions state the behavior being verified, not the internal implementation steps.
   - **Commit messages** express *why*: the description/body explains the motivation/reasoning for the change. The diff itself already shows *what* changed — do not restate it.
 - Never leave edit-history notes (e.g. "Deleted X") in code — history belongs in commit messages / PRs

--- a/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
+++ b/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
@@ -7,11 +7,17 @@ applies_to: all
 
 ## Scope
 
-Read code comments and docstrings in changed files. These checks are explicitly in scope for this agent, so the shared "general code quality concerns" suppression in SKILL.md does not apply to them. Flag:
+Read code comments and docstrings in changed files. These checks are explicitly in scope for this agent, so the shared "general code quality concerns" suppression in SKILL.md does not apply to them.
 
-- Cases where the implementation contradicts what a comment describes.
+Judge each comment against `~/.claude/rules/coding-common.md`'s Content layer "Code comments" allow/deny conditions — read that file rather than assuming its content. Flag any comment that does not satisfy an allow condition, or that matches a deny condition, for example:
+
 - Redundant comments that merely restate what the code already makes obvious (e.g. a comment saying "increment i by 1" directly above `i++`).
 - Obvious descriptions or comments that can be removed without issue.
+- "What" comments and temporary progress-report comments left in the diff.
+
+Also flag the following mechanical defects, independent of the allow/deny judgment above — these are about a comment's accuracy or formatting, not about whether it should exist:
+
+- Cases where the implementation contradicts what a comment describes.
 - Comments prone to becoming stale — descriptions of specific values, counts, enumerated lists, or implementation details duplicated from the code, which are likely to drift out of sync when the code changes.
 - Unnatural mid-sentence line breaks: a compound word, phrase, or clause split at a position that ignores its semantic boundary (e.g. breaking a Japanese compound word between its constituent characters rather than at a natural word boundary, or breaking immediately before the particle/predicate that a preceding phrase modifies).
   Flag these by default — only skip the flag when joining the lines would clearly produce a line dramatically longer than the other single-line comments already present in the same file (exact character counting is unreliable for mixed-script text, so judge by comparison to the file's own surrounding comment lines instead of a fixed number).

--- a/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
+++ b/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
@@ -9,7 +9,7 @@ applies_to: all
 
 Read code comments and docstrings in changed files. These checks are explicitly in scope for this agent, so the shared "general code quality concerns" suppression in SKILL.md does not apply to them.
 
-Judge each comment against `~/.claude/rules/coding-common.md`'s Content layer "Code comments" allow/deny conditions — read that file rather than assuming its content. Flag any comment that does not satisfy an allow condition, or that matches a deny condition, for example:
+Judge each comment against the Content layer "Code comments" allow/deny conditions in `~/.claude/rules/coding-common.md` — that file's content is already provided in your context, so apply those conditions as given rather than assuming what they say from memory. Flag any comment that does not satisfy an allow condition, or that matches a deny condition, for example:
 
 - Redundant comments that merely restate what the code already makes obvious (e.g. a comment saying "increment i by 1" directly above `i++`).
 - Obvious descriptions or comments that can be removed without issue.

--- a/home/dot_claude/skills/lite-review/SKILL.md
+++ b/home/dot_claude/skills/lite-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lite-review
-description: Lightweight code review of a GitHub PR or the local working diff. Runs a single sub-agent covering 3 fixed perspectives (CLAUDE.md compliance, bugs/correctness, security), scores findings 0-100, reports only score >= 50, and for the user's own PRs auto-fixes, commits, pushes, and updates the PR body.
+description: Lightweight code review of a GitHub PR or the local working diff. Runs a single sub-agent covering 4 fixed perspectives (CLAUDE.md compliance, bugs/correctness, code comment quality, security), scores findings 0-100, reports only score >= 50, and for the user's own PRs auto-fixes, commits, pushes, and updates the PR body.
 argument-hint: "[PR number or URL | omit to review the local working diff]"
 disable-model-invocation: false
 effort: medium
@@ -40,20 +40,20 @@ Same as `deep-review` Step 2.
 
 Same as `deep-review` Step 3.
 
-### Step 4: Single-agent perspective review (3 fixed perspectives)
+### Step 4: Single-agent perspective review (4 fixed perspectives)
 
 Unlike `deep-review`'s Step 5 (one sub-agent per reviewer file), launch a
-**single** general-purpose sub-agent covering all 3 perspectives below in
+**single** general-purpose sub-agent covering all 4 perspectives below in
 one call:
 
-1. Read `~/.claude/skills/deep-review/reviewers/a-claude-md-compliance.md`, `b-bugs-correctness.md`, and `f-security.md` directly (reuse their
+1. Read `~/.claude/skills/deep-review/reviewers/a-claude-md-compliance.md`, `b-bugs-correctness.md`, `e-code-comment-quality.md`, and `f-security.md` directly (reuse their
    `## Scope` bodies verbatim — do not duplicate the text into this file).
 2. Pass the sub-agent: the full diff, the change summary from Step 3, the
    CLAUDE.md/rules content from Step 2 (with the "already read, don't
    re-Read" instruction), the shared false-positive suppression
    instructions (identical text to `deep-review` SKILL.md's Step 5
-   suppression block), and all 3 reviewers' `## Scope` bodies together,
-   instructing it to check the diff against all 3 perspectives in a
+   suppression block), and all 4 reviewers' `## Scope` bodies together,
+   instructing it to check the diff against all 4 perspectives in a
    single pass and return findings tagged with which perspective(s) they
    belong to.
 
@@ -98,7 +98,7 @@ no-issues-found — not just one) and the "no issues found" line changed to:
 ```
 ### Lite Review
 
-No issues found. Checked for CLAUDE.md compliance, bugs/correctness, and security.
+No issues found. Checked for CLAUDE.md compliance, bugs/correctness, code comment quality, and security.
 ```
 
 Formatting rules are identical to `deep-review` Step 13 (full SHA +


### PR DESCRIPTION
## 概要

`deep-review`/`lite-review` のコードコメント品質チェックを、禁止事項の列挙から許可/禁止条件ベースの判定に改良する。

## 変更内容

- `home/dot_claude/rules/coding-common.md`: コメント方針を「原則追加しない、許可条件を満たす場合のみ追加可」という許可/禁止条件形式に書き換え、実装完了後にコメントを見直すセルフチェック項目を追加した。
- `home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md`: `## Scope` の判定基準を `coding-common.md` の許可/禁止条件を参照する構造に転換した(文言の二重管理を避ける)。既存の機械的チェック(実装との矛盾、陳腐化しやすい記述、不自然な文中改行、冗長な複数行パディング)は維持した。
- `home/dot_claude/skills/lite-review/SKILL.md`: 固定レビュー観点を 3 観点(CLAUDE.md compliance, bugs/correctness, security)から 4 観点(+ code comment quality)に拡張した。

## 背景

Issue に引用されている Microsoft Copilot (Think Deeper) のアドバイスに加え、Claude Code 公式ドキュメント([Best practices for Claude Code](https://code.claude.com/docs/en/best-practices))および AI コードレビュー生成に関する研究([Towards Practical Defect-Focused Automated Code Review](https://arxiv.org/pdf/2505.17928))を調査し、設計に反映した。詳細は Issue コメントの spec/plan を参照。

- Spec: https://github.com/book000/dotfiles/issues/258#issuecomment-4983335007
- Plan: https://github.com/book000/dotfiles/issues/258#issuecomment-4983411517

## テスト

- `tests/syntax/test_bash_syntax.sh`: 変更対象が Markdown のみのため影響なし、パス確認済み。
- `tests/syntax/test_shellcheck.sh`: 変更対象と無関係な既存の SC2329(info)警告が 1 件あるが、本 PR の変更前から存在するもので対象外。
- `home/dot_claude/skills/lite-review/SKILL.md` を変更したため、`tests/unit/test_hooks.sh` 等の参照に古いものがないか確認済み(該当なし)。
- `/deep-review`(ローカル diff モード)を実行し、指摘 1 件(スコア 75)を修正済み。

Closes #258
