### PR TITLE
feat: GitHub Actions のステップ並列実行機能を試験導入する

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run shellcheck with action
+        id: run-shellcheck-with-action
+        background: true
         uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -29,9 +31,16 @@ jobs:
           shellcheck_flags: '-s bash'
 
       - name: Run custom shellcheck tests
+        id: run-custom-shellcheck-tests
+        background: true
         run: |
           sudo apt-get update && sudo apt-get install -y shellcheck
           bash tests/syntax/test_shellcheck.sh
+
+      - name: Wait for shellcheck steps
+        wait:
+          - run-shellcheck-with-action
+          - run-custom-shellcheck-tests
 
   syntax:
     name: Bash Syntax Check

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,10 +17,22 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run install.sh unit test
+        id: run-install-sh-unit-test
+        background: true
         run: bash tests/unit/test_install.sh
 
       - name: Run notification unit test
+        id: run-notification-unit-test
+        background: true
         run: bash tests/unit/test_notifications.sh
 
       - name: Run hooks unit test
+        id: run-hooks-unit-test
+        background: true
         run: bash tests/unit/test_hooks.sh
+
+      - name: Wait for unit tests
+        wait:
+          - run-install-sh-unit-test
+          - run-notification-unit-test
+          - run-hooks-unit-test


### PR DESCRIPTION
## 概要

GitHub Actions の新機能「ステップの並列実行」(`background:` / `wait`)を試験導入し、以下 2 job のステップを並列化した。

- `.github/workflows/unit-test.yml` の `unit-test` job: 3 つの `run:` ステップ(`test_install.sh` / `test_notifications.sh` / `test_hooks.sh`)
- `.github/workflows/pr-checks.yml` の `shellcheck` job: `reviewdog/action-shellcheck@v1`(`uses:` ステップ)と自前の shellcheck テスト(`run:` ステップ)

各ステップに `id:` と `background: true` を付与し、ジョブ末尾に `wait:` で全ステップ ID を待機する形とした。`uses:` ステップへの `background: true` 付与も、消費側としては制限に抵触しないことを事前調査で確認済みのため、`pr-checks.yml` 側もフォールバックなしで両ステップとも並列化対象にできた。

## 事前調査

- 本機能は 2026-06-25 付で GA 済み(beta ではない)。
- `wait` / `wait-all` / `background` / `cancel` の正確な型定義は、GitHub 公式 Workflow syntax ドキュメントが調査時点で未反映だったため、GitHub Actions ワークフロー用の公式 JSON Schema(`schemastore.org/github-workflow.json`)を直接検証して確定した。`wait` は文字列または文字列配列(`array of strings`)を受け付け、実装で使用した `wait: [id1, id2, ...]` の形式と一致する。

## 受け入れ基準との対応

- CI 実行時間の比較: 本 PR の Actions 実行ログで変更前後を確認可能。
- 各並列ステップのログが Actions UI で個別確認できること: `id:` を全ステップに付与し、既存のステップ名は変更していないため個別ログとして表示される。
- 既存テスト結果(成功/失敗判定)が変更前後で同一であること: シェルスクリプトの呼び出し方法のみ変更し、スクリプト自体は無変更。

Closes #260

Spec: [https://github.com/book000/dotfiles/issues/260#issuecomment-4989444278](https://github.com/book000/dotfiles/issues/260#issuecomment-4989444278)
Plan: [https://github.com/book000/dotfiles/issues/260#issuecomment-4989492689](https://github.com/book000/dotfiles/issues/260#issuecomment-4989492689)