### PR TITLE
fix: gh repo view の曖昧な解決による fork 判定バグを修正する

### DIFF
--- a/home/bin/executable_gh-pr-target-repo.sh
+++ b/home/bin/executable_gh-pr-target-repo.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: gh-pr-target-repo.sh [--remote]
+Usage: gh-pr-target-repo.sh [--remote|--origin]
 
 Resolve the preferred GitHub repository for pull request creation.
 - If `upstream` exists and points to GitHub, prefer it
@@ -13,6 +13,11 @@ Resolve the preferred GitHub repository for pull request creation.
 
 Options:
   --remote  Print the preferred remote name instead of owner/repo
+  --origin  Resolve `origin` specifically, bypassing the upstream
+            preference above. Use this when a caller needs the local
+            checkout's own remote (e.g. fork-detection comparisons,
+            cleanup steps scoped to the local checkout) rather than the
+            PR's target repository.
 EOF
 }
 
@@ -26,6 +31,9 @@ if [[ $# -eq 1 ]]; then
   case "$1" in
     --remote)
       OUTPUT_MODE="remote"
+      ;;
+    --origin)
+      OUTPUT_MODE="origin"
       ;;
     -h|--help)
       usage
@@ -70,6 +78,18 @@ remote_to_repo() {
 
   printf '%s\n' "$remote_url"
 }
+
+if [[ "$OUTPUT_MODE" == "origin" ]]; then
+  # Bypass the upstream-preference loop below entirely — a caller asking
+  # for `origin` specifically needs the local checkout's own remote, not
+  # whichever remote this script would otherwise prefer.
+  if ! ORIGIN_REPO=$(remote_to_repo origin); then
+    echo "Error: Could not resolve GitHub repository from the 'origin' remote" >&2
+    exit 1
+  fi
+  printf '%s\n' "$ORIGIN_REPO"
+  exit 0
+fi
 
 PREFERRED_REMOTE=""
 PREFERRED_REPO=""

--- a/home/dot_claude/skills/handle-pr-reviews/SKILL.md
+++ b/home/dot_claude/skills/handle-pr-reviews/SKILL.md
@@ -23,14 +23,14 @@ if echo "$PR_ARG" | grep -q 'github\.com'; then
   REPO=$(echo "$PR_ARG" | grep -oP 'github\.com/[^/]+/\K[^/]+(?=/pull)')
   PR_NUMBER=$(echo "$PR_ARG" | grep -oP '/pull/\K\d+')
 else
-  # Number only: get from current repository. Resolve directly from the
-  # `origin` remote's URL, not via unqualified `gh repo view` — when both
-  # `origin` and `upstream` remotes exist (the fork scenario), `gh repo
-  # view` with no repository argument resolves ambiguously and can
+  # Number only: get from current repository. Resolve via the shared
+  # gh-pr-target-repo.sh script, not via unqualified `gh repo view` — when
+  # both `origin` and `upstream` remotes exist (the fork scenario), `gh
+  # repo view` with no repository argument resolves ambiguously and can
   # silently return `upstream`'s owner/repo instead of `origin`'s.
-  ORIGIN_URL=$(git remote get-url origin)
-  OWNER=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f1)
-  REPO=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f2)
+  REPO_FULL=$(gh-pr-target-repo.sh)
+  OWNER=${REPO_FULL%%/*}
+  REPO=${REPO_FULL#*/}
   PR_NUMBER="$PR_ARG"
 fi
 

--- a/home/dot_claude/skills/handle-pr-reviews/SKILL.md
+++ b/home/dot_claude/skills/handle-pr-reviews/SKILL.md
@@ -23,9 +23,14 @@ if echo "$PR_ARG" | grep -q 'github\.com'; then
   REPO=$(echo "$PR_ARG" | grep -oP 'github\.com/[^/]+/\K[^/]+(?=/pull)')
   PR_NUMBER=$(echo "$PR_ARG" | grep -oP '/pull/\K\d+')
 else
-  # Number only: get from current repository
-  OWNER=$(gh repo view --json owner --jq '.owner.login')
-  REPO=$(gh repo view --json name --jq '.name')
+  # Number only: get from current repository. Resolve directly from the
+  # `origin` remote's URL, not via unqualified `gh repo view` — when both
+  # `origin` and `upstream` remotes exist (the fork scenario), `gh repo
+  # view` with no repository argument resolves ambiguously and can
+  # silently return `upstream`'s owner/repo instead of `origin`'s.
+  ORIGIN_URL=$(git remote get-url origin)
+  OWNER=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f1)
+  REPO=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f2)
   PR_NUMBER="$PR_ARG"
 fi
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -119,15 +119,17 @@ onto the correct base immediately, before any spec/plan/implementation work
 begins:
 
 ```bash
-# Resolve directly from the `origin` remote's URL, not via unqualified
-# `gh repo view` — when both `origin` and `upstream` remotes exist (this
-# fork scenario itself), `gh repo view` with no repository argument
-# resolves ambiguously and can silently return `upstream`'s owner/repo
-# instead of `origin`'s, which would make the comparison below wrongly
-# conclude there's no fork mismatch and skip the rebase entirely.
-ORIGIN_URL=$(git remote get-url origin)
-ORIGIN_OWNER=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f1)
-ORIGIN_REPO=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f2)
+# Resolve via the shared gh-pr-target-repo.sh script's `--origin` mode,
+# not via unqualified `gh repo view` — when both `origin` and `upstream`
+# remotes exist (this fork scenario itself), `gh repo view` with no
+# repository argument resolves ambiguously and can silently return
+# `upstream`'s owner/repo instead of `origin`'s, which would make the
+# comparison below wrongly conclude there's no fork mismatch and skip the
+# rebase entirely. `--origin` always targets `origin` specifically,
+# bypassing the script's default upstream-preferring resolution.
+ORIGIN_REPO_FULL=$(gh-pr-target-repo.sh --origin)
+ORIGIN_OWNER=${ORIGIN_REPO_FULL%%/*}
+ORIGIN_REPO=${ORIGIN_REPO_FULL#*/}
 if [ "$ISSUE_OWNER/$ISSUE_REPO" != "$ORIGIN_OWNER/$ORIGIN_REPO" ]; then
   # Reuse an existing remote pointing at ISSUE_OWNER/ISSUE_REPO, or add one.
   REMOTE_NAME=$(git remote -v | grep -F "github.com/$ISSUE_OWNER/$ISSUE_REPO" | head -1 | cut -f1)

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -119,8 +119,15 @@ onto the correct base immediately, before any spec/plan/implementation work
 begins:
 
 ```bash
-ORIGIN_OWNER=$(gh repo view --json owner -q .owner.login)
-ORIGIN_REPO=$(gh repo view --json name -q .name)
+# Resolve directly from the `origin` remote's URL, not via unqualified
+# `gh repo view` — when both `origin` and `upstream` remotes exist (this
+# fork scenario itself), `gh repo view` with no repository argument
+# resolves ambiguously and can silently return `upstream`'s owner/repo
+# instead of `origin`'s, which would make the comparison below wrongly
+# conclude there's no fork mismatch and skip the rebase entirely.
+ORIGIN_URL=$(git remote get-url origin)
+ORIGIN_OWNER=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f1)
+ORIGIN_REPO=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f2)
 if [ "$ISSUE_OWNER/$ISSUE_REPO" != "$ORIGIN_OWNER/$ORIGIN_REPO" ]; then
   # Reuse an existing remote pointing at ISSUE_OWNER/ISSUE_REPO, or add one.
   REMOTE_NAME=$(git remote -v | grep -F "github.com/$ISSUE_OWNER/$ISSUE_REPO" | head -1 | cut -f1)

--- a/home/dot_claude/skills/pr-cleanup/SKILL.md
+++ b/home/dot_claude/skills/pr-cleanup/SKILL.md
@@ -29,16 +29,19 @@ can be invoked manually for any PR, or automatically by `wait-for-pr-close`.
 # grep -oP (PCRE) doesn't work on macOS's BSD grep, so use sed -E for a portable form
 PR_ARG="$ARGUMENTS"
 
-# Always resolve the local `origin` remote's owner/repo directly from its
-# URL, not via unqualified `gh repo view`. When both `origin` and `upstream`
-# remotes exist (the fork scenario), `gh repo view` with no repository
-# argument resolves ambiguously and can silently return `upstream`'s
-# owner/repo instead of `origin`'s — this previously broke the Step 4 fork
-# check (it read `upstream`'s own `parent`, which is `null`, and concluded
-# `origin` wasn't a fork when it actually was).
-ORIGIN_URL=$(git remote get-url origin)
-ORIGIN_OWNER=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f1)
-ORIGIN_REPO=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f2)
+# Always resolve the local `origin` remote's owner/repo via the shared
+# gh-pr-target-repo.sh script's `--origin` mode, not via unqualified
+# `gh repo view`. When both `origin` and `upstream` remotes exist (the
+# fork scenario), `gh repo view` with no repository argument resolves
+# ambiguously and can silently return `upstream`'s owner/repo instead of
+# `origin`'s — this previously broke the Step 4 fork check (it read
+# `upstream`'s own `parent`, which is `null`, and concluded `origin` wasn't
+# a fork when it actually was). `--origin` bypasses the script's default
+# upstream-preferring resolution and always targets `origin` specifically,
+# which is what this skill's fork-detection genuinely needs.
+ORIGIN_REPO_FULL=$(gh-pr-target-repo.sh --origin)
+ORIGIN_OWNER=${ORIGIN_REPO_FULL%%/*}
+ORIGIN_REPO=${ORIGIN_REPO_FULL#*/}
 
 if echo "$PR_ARG" | grep -q 'github\.com'; then
   OWNER=$(echo "$PR_ARG" | sed -E 's#.*github\.com/([^/]+)/.*#\1#')

--- a/home/dot_claude/skills/pr-cleanup/SKILL.md
+++ b/home/dot_claude/skills/pr-cleanup/SKILL.md
@@ -28,13 +28,25 @@ can be invoked manually for any PR, or automatically by `wait-for-pr-close`.
 ```bash
 # grep -oP (PCRE) doesn't work on macOS's BSD grep, so use sed -E for a portable form
 PR_ARG="$ARGUMENTS"
+
+# Always resolve the local `origin` remote's owner/repo directly from its
+# URL, not via unqualified `gh repo view`. When both `origin` and `upstream`
+# remotes exist (the fork scenario), `gh repo view` with no repository
+# argument resolves ambiguously and can silently return `upstream`'s
+# owner/repo instead of `origin`'s — this previously broke the Step 4 fork
+# check (it read `upstream`'s own `parent`, which is `null`, and concluded
+# `origin` wasn't a fork when it actually was).
+ORIGIN_URL=$(git remote get-url origin)
+ORIGIN_OWNER=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f1)
+ORIGIN_REPO=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f2)
+
 if echo "$PR_ARG" | grep -q 'github\.com'; then
   OWNER=$(echo "$PR_ARG" | sed -E 's#.*github\.com/([^/]+)/.*#\1#')
   REPO=$(echo "$PR_ARG" | sed -E 's#.*github\.com/[^/]+/([^/]+)/pull/.*#\1#')
   PR_NUMBER=$(echo "$PR_ARG" | sed -E 's#.*/pull/([0-9]+).*#\1#')
 else
-  OWNER=$(gh repo view --json owner --jq '.owner.login')
-  REPO=$(gh repo view --json name --jq '.name')
+  OWNER="$ORIGIN_OWNER"
+  REPO="$ORIGIN_REPO"
   PR_NUMBER="$PR_ARG"
 fi
 ```
@@ -101,7 +113,7 @@ git branch -D "$HEAD_REF"
 ## Step 3: Update the Local Default Branch
 
 ```bash
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+DEFAULT_BRANCH=$(gh repo view "$ORIGIN_OWNER/$ORIGIN_REPO" --json defaultBranchRef -q .defaultBranchRef.name)
 git checkout "$DEFAULT_BRANCH"
 git pull
 ```
@@ -119,13 +131,16 @@ the local checkout, which is always `origin`.
 ## Step 4: Sync the Fork (if applicable)
 
 ```bash
-if gh repo view --json parent -q .parent 2>/dev/null | grep -qv '^null$'; then
-  gh repo sync
+if gh repo view "$ORIGIN_OWNER/$ORIGIN_REPO" --json parent -q .parent 2>/dev/null | grep -qv '^null$'; then
+  gh repo sync "$ORIGIN_OWNER/$ORIGIN_REPO"
 fi
 ```
 
-`gh repo view --json parent` returns `null` for non-fork repositories;
-`gh repo sync` is only run when a parent exists (i.e. `origin` is a fork).
+`gh repo view "$ORIGIN_OWNER/$ORIGIN_REPO" --json parent` returns `null` for
+non-fork repositories; `gh repo sync` is only run when a parent exists
+(i.e. `origin` is a fork). Both calls explicitly target `$ORIGIN_OWNER/$ORIGIN_REPO`
+(resolved in Step 0) rather than relying on `gh`'s ambiguous no-argument
+resolution — see the comment in Step 0 for why.
 
 ## Step 5: Report Completion
 

--- a/home/dot_claude/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_claude/skills/pr-health-monitor/SKILL.md
@@ -33,14 +33,14 @@ if echo "$PR_ARG" | grep -q 'github\.com'; then
   REPO=$(echo "$PR_ARG" | grep -oP 'github\.com/[^/]+/\K[^/]+(?=/pull)')
   PR_NUMBER=$(echo "$PR_ARG" | grep -oP '/pull/\K\d+')
 else
-  # Number only (get from current repository). Resolve directly from the
-  # `origin` remote's URL, not via unqualified `gh repo view` — when both
-  # `origin` and `upstream` remotes exist (the fork scenario), `gh repo
-  # view` with no repository argument resolves ambiguously and can
+  # Number only (get from current repository). Resolve via the shared
+  # gh-pr-target-repo.sh script, not via unqualified `gh repo view` — when
+  # both `origin` and `upstream` remotes exist (the fork scenario), `gh
+  # repo view` with no repository argument resolves ambiguously and can
   # silently return `upstream`'s owner/repo instead of `origin`'s.
-  ORIGIN_URL=$(git remote get-url origin)
-  OWNER=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f1)
-  REPO=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f2)
+  REPO_FULL=$(gh-pr-target-repo.sh)
+  OWNER=${REPO_FULL%%/*}
+  REPO=${REPO_FULL#*/}
   PR_NUMBER="$PR_ARG"
 fi
 ```

--- a/home/dot_claude/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_claude/skills/pr-health-monitor/SKILL.md
@@ -33,9 +33,14 @@ if echo "$PR_ARG" | grep -q 'github\.com'; then
   REPO=$(echo "$PR_ARG" | grep -oP 'github\.com/[^/]+/\K[^/]+(?=/pull)')
   PR_NUMBER=$(echo "$PR_ARG" | grep -oP '/pull/\K\d+')
 else
-  # Number only (get from current repository)
-  OWNER=$(gh repo view --json owner --jq '.owner.login')
-  REPO=$(gh repo view --json name --jq '.name')
+  # Number only (get from current repository). Resolve directly from the
+  # `origin` remote's URL, not via unqualified `gh repo view` — when both
+  # `origin` and `upstream` remotes exist (the fork scenario), `gh repo
+  # view` with no repository argument resolves ambiguously and can
+  # silently return `upstream`'s owner/repo instead of `origin`'s.
+  ORIGIN_URL=$(git remote get-url origin)
+  OWNER=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f1)
+  REPO=$(echo "$ORIGIN_URL" | sed -E 's#^(git@[^:]+:|https://[^/]+/)##; s#\.git$##' | cut -d/ -f2)
   PR_NUMBER="$PR_ARG"
 fi
 ```

--- a/tests/unit/test_hooks.sh
+++ b/tests/unit/test_hooks.sh
@@ -59,6 +59,25 @@ else
 fi
 rm -rf "$TEST_REPO_DIR"
 
+echo "Testing gh-pr-target-repo helper --origin behavior..."
+TEST_REPO_DIR=$(mktemp -d)
+if ! (
+  cd "$TEST_REPO_DIR" || exit 1
+  git init -q
+  git remote add upstream git@github.com:book000/dotfiles.git
+  git remote add origin git@github.com:akubiusa/dotfiles.git
+  HELPER_OUTPUT=$(bash "$OLDPWD/home/bin/executable_gh-pr-target-repo.sh" --origin)
+  if [[ "$HELPER_OUTPUT" != "akubiusa/dotfiles" ]]; then
+    echo "❌ gh-pr-target-repo helper --origin did not resolve origin specifically"
+    exit 1
+  fi
+) ; then
+  FAILED=1
+else
+  echo "✅ gh-pr-target-repo helper --origin resolved origin regardless of upstream"
+fi
+rm -rf "$TEST_REPO_DIR"
+
 echo "Testing gh-pr-target-repo helper fallback behavior..."
 TEST_REPO_DIR=$(mktemp -d)
 TEST_BIN_DIR=$(mktemp -d)


### PR DESCRIPTION
## 概要

`origin`/`upstream` 双方のリモートが存在する fork シナリオで、引数なしの
`gh repo view` がどちらのリポジトリを指すか曖昧に解決され、
`upstream`(非 fork)のデータを返すことがある。これにより `pr-cleanup` の
fork 判定が「fork ではない」と誤判定し、`gh repo sync` をスキップしていた。

## 変更内容

- `pr-cleanup`/`issue-pr`/`handle-pr-reviews`/`pr-health-monitor` の各
  SKILL.md で、引数なし `gh repo view` に依存していたリポジトリ解決を
  共有スクリプト `gh-pr-target-repo.sh` の呼び出しに置き換えた。
- `gh-pr-target-repo.sh` に `--origin` オプションを追加し、
  upstream 優先の解決ロジックをバイパスして `origin` 自体を明示的に
  解決できるようにした(`pr-cleanup`/`issue-pr` は PR 作成先ではなく
  `origin` 自体の owner/repo を必要とするため)。
- `handle-pr-reviews`/`pr-health-monitor` は同スクリプトのデフォルト
  モード(upstream 優先)をそのまま呼び出す形に変更した
  (`home/dot_agents/skills` 配下の同名スキルと同じ規約に合わせた)。
- `tests/unit/test_hooks.sh` に `--origin` モードのテストケースを追加した。

## テスト

- `bash tests/unit/test_hooks.sh` — 全項目成功
- `bash tests/syntax/test_bash_syntax.sh` — 全項目成功