### PR TITLE
fix: issue-pr の lite/deep 判定でユーザー確認を省略する

### DIFF
--- a/home/dot_claude/skills/issue-pr-lite/SKILL.md
+++ b/home/dot_claude/skills/issue-pr-lite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-pr-lite
-description: Lightweight path for small-scale Issues. Invoked by the `issue-pr` dispatcher after Phase 2.5 judges the change small-scale and the user confirms. Skips spec/plan; implements directly.
+description: Lightweight path for small-scale Issues. Invoked by the `issue-pr` dispatcher after Phase 2.5 judges the change small-scale. Skips spec/plan; implements directly.
 disable-model-invocation: false
 ---
 

--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -12,9 +12,13 @@ judges the change's scale, and hands off to either `issue-pr-deep` (full
 spec/plan approval flow) or `issue-pr-lite` (direct implementation, no
 spec/plan) — see Phase 2.5. It has no Phase 3-onward logic of its own.
 
-Approval here is done via **AskUserQuestion**, not Claude Code's native Plan
-Mode — Plan Mode only allows a single read-only-until-ExitPlanMode gate, and
-blocks the Write/Bash/MCP calls this skill needs starting at Phase 1.
+Where approval is needed further down this flow (e.g. `issue-pr-deep`'s
+spec/plan sign-off), it is done via **AskUserQuestion**, not Claude Code's
+native Plan Mode — Plan Mode only allows a single
+read-only-until-ExitPlanMode gate, and blocks the Write/Bash/MCP calls this
+skill needs starting at Phase 1. This dispatcher's own Phase 2.5 scale
+judgment is not one of those approval points — it is made automatically,
+without asking the user (see Phase 2.5 below).
 
 **Do not call ExitPlanMode to work around this.** It exists to get sign-off
 on a concrete plan, not to escape Plan Mode. If Plan Mode is active when this
@@ -163,13 +167,12 @@ Judge "small-scale" only if **all** of the following hold:
 When unsure, do **not** judge it small-scale — default to the safe
 (`issue-pr-deep`) side.
 
-Confirm the judgment with the user via **AskUserQuestion** — never invoke
-`issue-pr-lite` on your own judgment alone:
+Make the call yourself — do not stop to confirm this judgment with the
+user via AskUserQuestion. Briefly state which path was chosen and why
+(one or two sentences) before invoking it, so the decision is visible, but
+do not turn that statement into a question.
 
-- If judged small-scale, options: "issue-pr-lite で進める(spec/planを省略し、直接実装)" (recommended) / "issue-pr-deep で進める(通常のspec/planフル承認フロー)"
-- If not judged small-scale, options: "issue-pr-deep で進める(推奨)" / "issue-pr-lite で進める"
-
-Based on the user's choice, invoke the chosen skill via the Skill tool
+Based on the judgment, invoke the chosen skill via the Skill tool
 (`issue-pr-deep` or `issue-pr-lite`). The worktree, `ISSUE_OWNER`,
 `ISSUE_REPO`, and the Issue body are already in this conversation's
 context — the invoked skill starts at its own Phase 3 without redoing


### PR DESCRIPTION
## 概要

`issue-pr` ディスパッチャーの Phase 2.5(スケール判定)で、判定後に `AskUserQuestion` によりユーザーへ確認を求めていたステップを削除しました。判定ロジック自体(単一ファイル限定・設計判断不要・曖昧さなしの基準、迷ったら deep 側にデフォルトする方針)は変更していません。

## 変更内容

- `home/dot_claude/skills/issue-pr/SKILL.md`
  - Phase 2.5: 判定結果をユーザーに確認せず、そのまま `issue-pr-deep`/`issue-pr-lite` を呼び出すように変更。判断内容を一言アナウンスするのみとした。
  - 冒頭の approval に関する説明を、この変更に合わせて明確化(Phase 2.5 自体は承認ポイントではないことを明記)。
- `home/dot_claude/skills/issue-pr-lite/SKILL.md`
  - description からユーザー確認を前提とした記述を削除。

Closes #263