### PR TITLE
fix: issue-pr の Phase 2.5 で AskUserQuestion を抑止する指示を強化する

### DIFF
--- a/home/dot_claude/skills/issue-pr/SKILL.md
+++ b/home/dot_claude/skills/issue-pr/SKILL.md
@@ -176,10 +176,23 @@ Judge "small-scale" only if **all** of the following hold:
 When unsure, do **not** judge it small-scale — default to the safe
 (`issue-pr-deep`) side.
 
-Make the call yourself — do not stop to confirm this judgment with the
-user via AskUserQuestion. Briefly state which path was chosen and why
-(one or two sentences) before invoking it, so the decision is visible, but
-do not turn that statement into a question.
+**Make the call yourself. Do not confirm this judgment with the user via
+AskUserQuestion, under any circumstance** — there is no exception for "the
+judgment feels uncertain" or "the user might want a say." Briefly state
+which path was chosen and why (one or two sentences) before invoking it,
+so the decision is visible, but do not turn that statement into a
+question.
+
+If you find yourself drafting an AskUserQuestion call with options
+resembling "issue-pr-lite で進める" / "issue-pr-deep で進める" (or any
+English equivalent, e.g. "Proceed with issue-pr-lite" / "Proceed with
+issue-pr-deep"), stop — that is exactly the anti-pattern this rule
+forbids, not a legitimate checkpoint.
+
+This judgment is not the kind of "clarifying question" the global
+CLAUDE.md's "Use AskUserQuestion for all clarifying questions directed at
+the user" rule refers to — that rule governs genuine ambiguity in what
+the user wants, not this dispatcher's own internal scale assessment.
 
 Based on the judgment, invoke the chosen skill via the Skill tool
 (`issue-pr-deep` or `issue-pr-lite`). The worktree, `ISSUE_OWNER`,


### PR DESCRIPTION
## Summary

`issue-pr` の Phase 2.5(スケール判定)で「AskUserQuestion で確認しない」という指示が、PR #264(Issue #263)の修正後も再現するという Issue #266 の報告を受けた修正。

PR #264 は指示テキストを追加しただけで、同ファイル内の他のハードルール(`**Do not call ExitPlanMode to work around this.**` など)と比べて視覚的な強調・具体的なアンチパターン例を欠いていた。今回はこの箇所を、同ファイル内で既に実績のある強調パターン(太字の独立段落 + 具体的アンチパターン例 + グローバル指示との関係の明示)に置き換えた。

## Changes

- `home/dot_claude/skills/issue-pr/SKILL.md` の Phase 2.5 のみを修正(判定ロジック自体は変更なし)。

## Closes

Closes #266

## Docs

- Spec: https://github.com/book000/dotfiles/issues/266#issuecomment-5021086763
- Plan: https://github.com/book000/dotfiles/issues/266#issuecomment-5021458631
