### PR TITLE
fix: mise の ubi backend を github backend に変更する

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -6,7 +6,7 @@ python = "3.14"
 pnpm = "latest"
 ghq = "latest"
 gh = "latest"
-"ubi:k1LoW/roots" = "latest"
+"github:k1LoW/roots" = "latest"
 gitleaks = "latest"
 
 [settings]

--- a/install.sh
+++ b/install.sh
@@ -484,7 +484,7 @@ install_mise_tools() {
     log_info "roots のインストールをスキップします (--skip-roots)"
   else
     log_info "roots を mise 経由でインストールしています..."
-    run_command mise install ubi:k1LoW/roots
+    run_command mise install github:k1LoW/roots
   fi
 
   if [[ "$SKIP_GITLEAKS" == "1" ]]; then


### PR DESCRIPTION
## 概要

mise が `ubi` backend の非推奨警告を出力していたため、`github` backend に置き換える。

```
mise WARN  deprecated [ubi]: The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo). This will be removed in mise 2027.1.0.
```

## 変更内容

- `home/dot_config/mise/config.toml`: `"ubi:k1LoW/roots"` → `"github:k1LoW/roots"`
- `install.sh`: `mise install ubi:k1LoW/roots` → `mise install github:k1LoW/roots`

owner/repo (`k1LoW/roots`) は変更せず、バックエンド識別子のみを置き換えている。リポジトリ全体を検索し、他に `ubi:` を参照している箇所がないことを確認済み。`renovate.json` の `regexManagers` は mise ネイティブサポートで自動追跡されるため変更不要。

## 動作確認

- `tests/syntax/test_bash_syntax.sh` / `test_shellcheck.sh` / `test_json_schema.sh`: pass
- `tests/unit/test_install.sh`: pass
- `/lite-review`: no issues found

Closes #270
