### PR TITLE
fix: エージェント idle フォローと PR クローズ監視の堅牢性を改善する

### DIFF
--- a/home/dot_claude/rules/workflow-sub-agents.md
+++ b/home/dot_claude/rules/workflow-sub-agents.md
@@ -78,3 +78,45 @@ For features spanning 5+ files or with security-critical paths:
 | Implementation worker | Sonnet | Write, Edit, Bash |
 | Verification worker | Opus | Read, Grep, Bash |
 | Discovery worker | Haiku | Read, Grep |
+
+## Handling Idle Notifications from Background Sub-Agents
+
+The `Agent` tool runs sub-agents in the background by default and notifies
+the parent session when one completes. If a sub-agent stops taking actions
+without calling `SendMessage` to report completion, the harness may deliver
+an **idle** notification instead of a **completed** one. Treat these as
+distinct: an idle notification means the sub-agent went quiet without
+finishing, not that it's done.
+
+This applies whenever a background-mode sub-agent (the `Agent` tool's
+default, or explicit `run_in_background: true`) sends an idle notification.
+It does not apply to sync-mode (`run_in_background: false`) dispatches,
+since those block the calling turn until the sub-agent returns.
+
+**Follow-up procedure:**
+
+1. On receiving an idle notification, immediately send that sub-agent one
+   `SendMessage` nudge asking it to continue or report its current status.
+2. If no `completed` notification arrives within a timeout (default 15
+   minutes since the nudge; a calling skill may define its own threshold —
+   that takes precedence over this default), set up a `CronCreate`
+   check-in (default: every 15 minutes) if one isn't already running, to
+   track outstanding sub-agents.
+3. At each check-in, any sub-agent still not completed after its own
+   timeout (default 30 minutes since the nudge) is stopped (e.g. via
+   `TaskStop`) and re-dispatched once, with the same input.
+4. If the re-dispatch also times out, mark that sub-agent's task as
+   **unresolved** in the calling skill's final report — do not silently
+   drop it — and move on with the rest of the work instead of waiting
+   further.
+5. Once every sub-agent is either completed or marked unresolved, delete
+   the `CronCreate` check-in with `CronDelete`.
+
+**Notes:**
+
+- `CronCreate` jobs are session-scoped and auto-expire after 7 days (same
+  constraint as `check-container-status`'s use of `CronCreate`).
+- This rule sets the default cadence and retry count; it does not mandate
+  a specific state-tracking mechanism. A calling skill that already tracks
+  sub-agent progress (a state file like `STATE.md`, or the `Todo`/`Task`
+  tools) may reuse that instead of inventing a new one.

--- a/home/dot_claude/rules/workflow-sub-agents.md
+++ b/home/dot_claude/rules/workflow-sub-agents.md
@@ -81,17 +81,9 @@ For features spanning 5+ files or with security-critical paths:
 
 ## Handling Idle Notifications from Background Sub-Agents
 
-The `Agent` tool runs sub-agents in the background by default and notifies
-the parent session when one completes. If a sub-agent stops taking actions
-without calling `SendMessage` to report completion, the harness may deliver
-an **idle** notification instead of a **completed** one. Treat these as
-distinct: an idle notification means the sub-agent went quiet without
-finishing, not that it's done.
+The `Agent` tool runs sub-agents in the background by default and notifies the parent session when one completes. If a sub-agent stops taking actions without calling `SendMessage` to report completion, the harness may deliver an **idle** notification instead of a **completed** one. Treat these as distinct: an idle notification means the sub-agent went quiet without finishing, not that it's done.
 
-This applies whenever a background-mode sub-agent (the `Agent` tool's
-default, or explicit `run_in_background: true`) sends an idle notification.
-It does not apply to sync-mode (`run_in_background: false`) dispatches,
-since those block the calling turn until the sub-agent returns.
+This applies whenever a background-mode sub-agent (the `Agent` tool's default, or explicit `run_in_background: true`) sends an idle notification. It does not apply to sync-mode (`run_in_background: false`) dispatches, since those block the calling turn until the sub-agent returns.
 
 **Follow-up procedure:**
 

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -122,6 +122,28 @@ Do NOT report the following:
 
 **Fixed reviewers:** see `~/.claude/skills/deep-review/reviewers/*.md` for the full list and scope of each (`a-claude-md-compliance`, `b-bugs-correctness`, `c-history-context`, `e-code-comment-quality`, `f-security`, `g-performance`, `h-error-handling`, `i-type-design-tests`).
 
+**Idle sub-agent follow-up:** these reviewer sub-agents run in the background per `rules/workflow-sub-agents.md`'s "Handling Idle Notifications from Background Sub-Agents" — apply that procedure here, made concrete for this step:
+
+- When dispatching the reviewers above, note which reviewer slug (e.g.
+  `f-security`) each sub-agent corresponds to.
+- On any idle notification from one of these sub-agents, nudge it
+  immediately via `SendMessage` — do not wait for the next check-in.
+- Right after dispatch, set up a `CronCreate` check-in every 15 minutes
+  with this prompt: "For any of the deep-review reviewer sub-agents from
+  Step 5 that are not yet completed: send a `SendMessage` nudge to any
+  that have gone idle and haven't been nudged yet, and re-dispatch (once,
+  same reviewer definition) any that are still not completed 30 minutes
+  after their nudge." This check-in exists both to catch any real-time
+  nudge that was missed and to perform the timeout/re-dispatch step.
+- If a reviewer still hasn't completed after its one re-dispatch, record
+  its findings as **unavailable** ("reviewer sub-agent did not respond;
+  its scope was not checked in this run") instead of silently omitting it
+  — carry that note through to Step 13's final report. Step 6 onward
+  proceeds with whichever reviewers did complete, so one unresponsive
+  reviewer never blocks the rest of the pipeline.
+- Once every reviewer is either completed or marked unavailable,
+  `CronDelete` the check-in created above.
+
 ### Step 6: Confidence scoring (batched)
 
 Launch a **single** Haiku sub-agent to score **all** findings returned by

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -277,6 +277,8 @@ When no issues were found:
 No issues found. Checked for bugs, CLAUDE.md compliance, security (incl. AI-PR risks), performance, error handling, silent failures, type design, and test coverage.
 ```
 
+If any reviewer sub-agent from Step 5 was marked unavailable (see Step 5's idle sub-agent follow-up), note it explicitly in the report so the reader knows that perspective was not checked in this run, e.g. add a line such as `⚠️ Reviewer unavailable: <slug> (did not respond; its scope was not checked in this run)` alongside the findings.
+
 #### Formatting rules
 
 - GitHub code links must use the full SHA + `#L<line>` format. Do not embed `$(git rev-parse HEAD)` — it will not expand in Markdown.

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -277,7 +277,7 @@ When no issues were found:
 No issues found. Checked for bugs, CLAUDE.md compliance, security (incl. AI-PR risks), performance, error handling, silent failures, type design, and test coverage.
 ```
 
-If any reviewer sub-agent from Step 5 was marked unavailable (see Step 5's idle sub-agent follow-up), note it explicitly in the report so the reader knows that perspective was not checked in this run, e.g. add a line such as `⚠️ Reviewer unavailable: <slug> (did not respond; its scope was not checked in this run)` alongside the findings.
+If any reviewer sub-agent from Step 5 was marked unavailable (see Step 5's idle sub-agent follow-up), note it explicitly in the report so the reader knows that perspective was not checked in this run, e.g. add a line such as `Reviewer unavailable: <slug> (did not respond; its scope was not checked in this run)` alongside the findings.
 
 #### Formatting rules
 

--- a/home/dot_claude/skills/issue-pr-deep/SKILL.md
+++ b/home/dot_claude/skills/issue-pr-deep/SKILL.md
@@ -313,6 +313,8 @@ SKILL.md) — there is no separate background process or log file to verify.
 Report the monitor as running; `/handle-pr-reviews` is called directly in
 this conversation when the monitor detects a review.
 
+If requesting or obtaining a Copilot review fails or looks unlikely to ever arrive (e.g. `request-review-copilot` missing, a permissions error, Copilot not enabled on the target repository), do not pause here to ask the user whether to keep waiting or give up. The Copilot review `Monitor` keeps running independently regardless, so move on to Phase 17 unconditionally and immediately.
+
 ## Phase 17: Start the PR Close Monitor
 
 Immediately after Phase 16, start the merge/close monitor so cleanup

--- a/home/dot_claude/skills/issue-pr-lite/SKILL.md
+++ b/home/dot_claude/skills/issue-pr-lite/SKILL.md
@@ -108,6 +108,8 @@ chmod 600 ~/.claude/data/session-state.json
 Same as `issue-pr-deep`'s Phase 16: run `/pr-health-monitor <PR number>`
 immediately, without asking the user whether to run it.
 
+Same as `issue-pr-deep`'s Phase 16→17 transition: if requesting or obtaining a Copilot review fails or looks unlikely to ever arrive, do not pause to ask the user whether to keep waiting or give up — move on to Phase 10 unconditionally and immediately.
+
 ## Phase 10: Start the PR Close Monitor
 
 Same as `issue-pr-deep`'s Phase 17:

--- a/home/dot_claude/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_claude/skills/pr-health-monitor/SKILL.md
@@ -151,6 +151,8 @@ gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus --jq '{mergeable,merge
 
 If there are conflicts, merge the base branch to resolve them.
 
+This is a one-shot snapshot at PR-creation time, not continuous monitoring. When `pr-health-monitor` is invoked as part of `issue-pr-deep` or `issue-pr-lite`, those flows start `wait-for-pr-close`'s `Monitor` loop immediately afterward, and that loop continuously detects conflicts for as long as the session stays alive (see `wait-for-pr-close`'s SKILL.md). When `pr-health-monitor` is invoked standalone — for example in a later session, after the original `wait-for-pr-close` Monitor ended with the session or hit its 7-day `CronCreate` limit — this one-shot check is the only conflict detection available, so it is kept rather than removed.
+
 ### Task D: Update PR Body
 
 Following CLAUDE.md rules, write the PR body with the current final state of the branch only — no history. Language: follow the project CLAUDE.md if it specifies one; otherwise Japanese.
@@ -176,7 +178,7 @@ Report the result of each task in the following format:
 
 ```
 ✅ CI: all checks passed
-✅ Conflicts: none
+✅ Conflicts: none (one-shot check; if this run continues into wait-for-pr-close, that Monitor keeps checking continuously)
 ✅ PR body: updated
 ⏳ Copilot review: Monitor running in this session
    → /handle-pr-reviews will be called directly in this conversation on detection

--- a/home/dot_claude/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_claude/skills/pr-health-monitor/SKILL.md
@@ -151,7 +151,7 @@ gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus --jq '{mergeable,merge
 
 If there are conflicts, merge the base branch to resolve them.
 
-This is a one-shot snapshot at PR-creation time, not continuous monitoring. When `pr-health-monitor` is invoked as part of `issue-pr-deep` or `issue-pr-lite`, those flows start `wait-for-pr-close`'s `Monitor` loop immediately afterward, and that loop continuously detects conflicts for as long as the session stays alive (see `wait-for-pr-close`'s SKILL.md). When `pr-health-monitor` is invoked standalone — for example in a later session, after the original `wait-for-pr-close` Monitor ended with the session or hit its 7-day `CronCreate` limit — this one-shot check is the only conflict detection available, so it is kept rather than removed.
+This is a one-shot snapshot at PR-creation time, not continuous monitoring. When `pr-health-monitor` is invoked as part of `issue-pr-deep` or `issue-pr-lite`, those flows start `wait-for-pr-close`'s `Monitor` loop immediately afterward, and that loop continuously detects conflicts for as long as the session stays alive (see `wait-for-pr-close`'s SKILL.md). When `pr-health-monitor` is invoked standalone — for example in a later session, after the original `wait-for-pr-close` Monitor ended along with its session (that Monitor does not persist across sessions) — this one-shot check is the only conflict detection available, so it is kept rather than removed.
 
 ### Task D: Update PR Body
 

--- a/home/dot_claude/skills/wait-for-copilot-review/SKILL.md
+++ b/home/dot_claude/skills/wait-for-copilot-review/SKILL.md
@@ -175,3 +175,10 @@ event arrives in this conversation and this conversation acts on it.
 - No lock file / flock is used — Step 0's one-time existence check replaces
   it, since a `Monitor` loop only needs to run once per PR within a given
   session.
+- If requesting a Copilot review fails or Copilot code review isn't
+  available for the target repository (`request-review-copilot` missing,
+  a permissions error, Copilot not enabled on the repo, etc.), it is fine
+  to leave this `Monitor` running anyway. The caller must not wait for the
+  Copilot review to succeed before moving on to later phases (e.g.
+  starting the PR-close monitor) — there is no need to ask the user
+  whether to keep waiting or stop.

--- a/home/dot_claude/skills/wait-for-pr-close/SKILL.md
+++ b/home/dot_claude/skills/wait-for-pr-close/SKILL.md
@@ -71,24 +71,41 @@ literally before calling `Monitor`, the same way `<PR_NUMBER>` in
 Monitor({
   command: "
     fail_count=0
+    prev_mergeable=\"\"
     while true; do
       sleep 30
-      state=$(gh pr view \"$PR_NUMBER\" --repo \"$OWNER/$REPO\" --json state -q .state 2>/tmp/wait-pr-close-err.$$)
+      json=$(gh pr view \"$PR_NUMBER\" --repo \"$OWNER/$REPO\" --json state,mergeable,mergeStateStatus 2>/tmp/wait-pr-close-err.$$)
       rc=$?
-      if [[ $rc -ne 0 || -z \"$state\" ]]; then
+      if [[ $rc -ne 0 || -z \"$json\" ]]; then
         err_msg=$(tail -c 200 /tmp/wait-pr-close-err.$$ 2>/dev/null)
         fail_count=$((fail_count + 1))
         if [[ \"$fail_count\" -ge 5 ]]; then
           echo \"WARNING: gh pr view failed 5 times in a row - last error: ${err_msg:-unknown}\"
           fail_count=0
         fi
-      else
-        fail_count=0
+        rm -f /tmp/wait-pr-close-err.$$
+        continue
       fi
+      fail_count=0
       rm -f /tmp/wait-pr-close-err.$$
+      state=$(jq -r '.state' <<<\"$json\")
+      mergeable=$(jq -r '.mergeable' <<<\"$json\")
+      mergeStateStatus=$(jq -r '.mergeStateStatus' <<<\"$json\")
+      if [[ \"$mergeable\" == \"CONFLICTING\" && \"$mergeable\" != \"$prev_mergeable\" ]]; then
+        echo \"pr_conflict_detected mergeable=$mergeable mergeStateStatus=$mergeStateStatus\"
+        SCRIPT_DIR=\"$HOME/.claude/scripts/completion-notify\"
+        if [[ -x \"$SCRIPT_DIR/send-discord-notification.sh\" ]]; then
+          payload=$(jq -n \\
+            --arg title \"PR Conflict Detected\" \\
+            --arg desc \"PR #${PR_NUMBER} now has merge conflicts (mergeStateStatus: ${mergeStateStatus}).\" \\
+            --arg url \"https://github.com/${OWNER}/${REPO}/pull/${PR_NUMBER}\" \\
+            '{embeds: [{title: $title, description: $desc, url: $url, color: 15158332}]}')
+          printf '%s\\n' \"$payload\" | \"$SCRIPT_DIR/send-discord-notification.sh\"
+        fi
+      fi
+      prev_mergeable=\"$mergeable\"
       if [[ \"$state\" == \"MERGED\" || \"$state\" == \"CLOSED\" ]]; then
         echo \"pr_closed state=$state\"
-        # Send a Discord notification, same as the old script did
         SCRIPT_DIR=\"$HOME/.claude/scripts/completion-notify\"
         if [[ -x \"$SCRIPT_DIR/send-discord-notification.sh\" ]]; then
           payload=$(jq -n \\
@@ -102,7 +119,7 @@ Monitor({
       fi
     done
   ",
-  description: "PR #<PR_NUMBER> merge/close",
+  description: "PR #<PR_NUMBER> merge/close/conflict",
   persistent: true,
 })
 ```
@@ -117,12 +134,15 @@ Monitor({
   including the last captured error — to the Monitor's stdout, so a
   failure streak is never silent, then resets the counter and keeps
   polling.
+- Each poll now fetches `mergeable`/`mergeStateStatus` alongside `state` in the same `gh pr view` call. A transition into `mergeable == "CONFLICTING"` emits a `pr_conflict_detected` event and a Discord notification, but does **not** `break` the loop — conflict detection runs alongside close detection, not instead of it. Re-notification is suppressed by comparing against the previous poll's `mergeable` value, the same de-duplication pattern `pr-health-monitor`'s CI-check Monitor uses for its `prev`/`cur` comparison.
 
 ### Step 2: On Detection
 
 When the monitor emits a `pr_closed` event (or Step 0 already found the PR
 closed), call `/pr-cleanup https://github.com/$OWNER/$REPO/pull/$PR_NUMBER`
 directly in the same conversation.
+
+When the monitor emits a `pr_conflict_detected` event, the caller (the session that started `pr-health-monitor`/this monitor) should resolve the conflict (e.g. merge the base branch into the PR branch). The monitor itself keeps running afterward — it only stops on `pr_closed`.
 
 ## Notes
 


### PR DESCRIPTION
## 概要

Issue #272(サブエージェントが idle 状態になったまま無限待機する問題)と Issue #273(Copilot レビューが得られなくても PR クローズ待ちができるようにする、コンフリクト検知も追加してほしい)を、1 つの PR でまとめて対応します。

## 変更内容

1. `rules/workflow-sub-agents.md`: バックグラウンドサブエージェントが idle 通知を送った際のフォロー手順(即時 nudge → `CronCreate` による 15 分チェックイン → 30 分タイムアウトで再ディスパッチ → 解消しなければ unresolved と明記 → `CronDelete` によるクリーンアップ)を汎用ルールとして追加。
2. `skills/deep-review/SKILL.md`: Step 5(並列パースペクティブレビュー)のレビュアーサブエージェントが idle になった場合のフォロー手順を追加。Step 13(結果報告)にも、応答しなかったレビュアーがいる場合はレポートに明記する旨を追加。
3. `skills/wait-for-pr-close/SKILL.md`: Monitor のポーリングで `mergeable`/`mergeStateStatus` も取得し、`CONFLICTING` への変化を `pr_conflict_detected` イベントと Discord 通知で検知するようにした(PR クローズ検知とは独立して動作し続ける)。
4. `skills/pr-health-monitor/SKILL.md`: Task C(一回限りのコンフリクト確認)が `wait-for-pr-close` の継続監視と並存するフォールバックであることを明記。
5. `skills/wait-for-copilot-review/SKILL.md`: Copilot レビューの取得自体が失敗・利用不可でも、Monitor を止めずに後続フェーズへ進んでよい旨を追記。
6. `skills/issue-pr-deep/SKILL.md` / `skills/issue-pr-lite/SKILL.md`: 上記 5 の方針を Phase 遷移(Phase 16→17 / Phase 9→10)に反映。

## 検証

- `tests/integration/test_chezmoi_apply.sh` 実行済み(全項目パス)。
- `/deep-review`(ローカル diff モード)実行済み。1 件(pr-health-monitor の `CronCreate` に関する誤記述)を修正済み(コミット `d12b8bf`)。

Closes #272
Closes #273

Spec: https://github.com/book000/dotfiles/issues/272#issuecomment-5083968698
Plan: https://github.com/book000/dotfiles/issues/272#issuecomment-5084015150
