### PR TITLE
feat: ツールコールマークアップ漏洩を検出するフックを追加する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,10 @@ chezmoi はソース側のプレフィックスを解釈してデプロイする
 
 ## Claude Code フック / 通知機能
 
-Claude Code のフックは `home/dot_claude/private_settings.json` で設定され、`Stop` / `PreToolUse` / `PostToolUse` / `PermissionRequest` / `Notification` / `UserPromptSubmit` を使う。役割は大きく 2 系統:
+Claude Code のフックは `home/dot_claude/private_settings.json` で設定され、`Stop` / `SubagentStop` / `PreToolUse` / `PostToolUse` / `PermissionRequest` / `Notification` / `UserPromptSubmit` を使う。役割は大きく 2 系統:
 
 - **Discord 通知**: `home/dot_claude/scripts/completion-notify/` 配下のスクリプト(セッション完了、権限リクエスト、AskUserQuestion、Notification 等)。`~/.env` の `DISCORD_CLAUDE_WEBHOOK` と `DISCORD_CLAUDE_MENTION_USER_ID` を使用する。
-- **レビュー強制など**: `home/dot_claude/hooks/` 配下のスクリプト(deep-review、レビュースレッド未解決チェック、rtk 書き換え、git config ガード等)。
+- **レビュー強制など**: `home/dot_claude/hooks/` 配下のスクリプト(deep-review、レビュースレッド未解決チェック、rtk 書き換え、git config ガード等)。加えて `executable_detect-leaked-toolcall.sh` は、レビュー強制とは別の関心事として、アシスタントメッセージへのツールコール XML マークアップの漏洩を `Stop` / `SubagentStop` の両方で検出する。
 
 フックのコマンドや対象スクリプトを変更したときは、`tests/unit/test_hooks.sh` / `test_notifications.sh` の参照が古くなっていないか確認する。
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ applies_to: all        # all | pr-only（省略時は all）
 `~/.claude/hooks/deep-review-require-fixes.sh`（Stop）が設定されており、
 スコア 50 以上の指摘が未対応の場合は Claude の処理を一時ブロックして対応を促す。
 
+また、`~/.claude/hooks/detect-leaked-toolcall.sh`（Stop / SubagentStop）は、Claude Code の既知の不具合によりツールコールの XML マークアップがプレーンテキストとして最終アシスタントメッセージに漏れ出していないかを検出し、検出時は自己模倣による再発を防ぐよう促すメッセージでブロックする。
+
 これらのフックは公式フック契約（stdin JSON + `decision/reason` 出力）に準拠している。
 
 ## `/claude-md-maintainer` スキル

--- a/home/dot_claude/hooks/executable_detect-leaked-toolcall.sh
+++ b/home/dot_claude/hooks/executable_detect-leaked-toolcall.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
-# Stop hook: トランスクリプトの最終アシスタントメッセージに、ツールコールの
-# XML マークアップ（<invoke>/<function_calls>/<parameter> 等）がプレーン
-# テキストとして漏れ出していないか検出する。
+# Stop / SubagentStop hook: トランスクリプトの最終アシスタントメッセージに、
+# ツールコールの XML マークアップ（<invoke>/<function_calls>/<parameter> 等）が
+# プレーンテキストとして漏れ出していないか検出する。
 # 検出時は、漏れたマークアップを引用・言い換えて再試行しない（自己模倣による
 # 汚染を招く）よう指示し、意図をプロースで手短に述べたうえで、構造化された
 # ツールコールを 1 回だけ発行するようブロックメッセージで促す。
 
 DATA_DIR="$HOME/.claude/data"
 LOG_FILE="$DATA_DIR/leaked-toolcall-triggers.log"
+
+# 引用されたマークアップや、このスキル自体を話題にしたメッセージ等の
+# 誤検知が同一セッション内で繰り返しブロックし続けセッションが行き詰まる
+# 事態を避けるため、セッションあたりの発火回数に上限を設ける
+MAX_TRIGGERS_PER_SESSION=3
 
 # stdin から JSON を読み込む（公式フック契約: stdin JSON）
 INPUT=$(cat)
@@ -21,24 +26,32 @@ if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
     exit 0
 fi
 
-# Extract the concatenated text of the transcript's last assistant message.
-# Arguments: $1 = transcript JSONL file path.
-# Content shape varies (plain string in .message.content/.content, or an
-# array of blocks where type == "text" blocks carry a .text field); both are
-# normalized to a single newline-joined string. Prints nothing on failure.
+# トランスクリプトの最終アシスタントメッセージのテキストを連結して取り出す。
+# 引数: $1 = トランスクリプト JSONL ファイルのパス。
+# トランスクリプトは数十 MB に達することがあり、全体を jq -s でスラープすると
+# 遅い上、途中に壊れた行が 1 行でもあると全体の解析が失敗し検出漏れになる。
+# そのため末尾のみを対象にし（末尾に近いほど「最終アシスタントメッセージ」に
+# 該当する可能性が高い）、壊れた行は try/catch で読み飛ばしてから最後の
+# assistant メッセージだけを採用する。content は文字列、またはブロック配列
+# （type == "text" のブロックのみ採用）のどちらの形もあり、両方を改行区切りの
+# 単一文字列に正規化する。失敗時は何も出力しない。
 extract_last_assistant_text() {
     local transcript_path="$1"
-    jq -rs '
-        [ .[] | select(type == "object") | select(.type == "assistant") ] | last |
-        if . == null then ""
-        else
-            (.message.content // .content) as $c |
-            if ($c | type) == "string" then $c
-            elif ($c | type) == "array" then
-                [ $c[] | select(.type == "text") | .text ] | join("\n")
-            else "" end
-        end
-    ' "$transcript_path" 2>/dev/null
+    tail -n 300 "$transcript_path" | jq -Rrs '
+        split("\n")
+        | map(select(length > 0))
+        | map(try fromjson catch null)
+        | map(select(. != null and .type == "assistant"))
+        | last
+        | if . == null then ""
+          else
+              (.message.content // .content) as $c
+              | if ($c | type) == "string" then $c
+                elif ($c | type) == "array" then
+                    ([$c[] | select(.type == "text") | .text] | join("\n"))
+                else "" end
+          end
+    ' 2>/dev/null
 }
 
 LAST_MESSAGE=$(extract_last_assistant_text "$TRANSCRIPT_PATH")
@@ -48,27 +61,60 @@ if [[ -z "$LAST_MESSAGE" ]]; then
     exit 0
 fi
 
-# 漏れたツールコールマークアップの行頭パターン（大文字小文字を区別しない）
-LEAK_PATTERN='^[[:space:]]*<([A-Za-z][A-Za-z0-9_.-]*:)?(invoke[[:space:]]|function_calls|parameter[[:space:]])'
+# 漏れたツールコールマークアップのパターン（大文字小文字を区別しない）。
+# 閉じタグ（/? による任意のスラッシュ）や属性なしの短縮形（<invoke>,
+# </invoke> 等）も拾えるよう、invoke/parameter 直後の空白必須要件は
+# 課さず、タグ名の直後が空白・スラッシュ・`>`・行末のいずれかであることのみ
+# 要求する。行頭アンカーは意図的に外している（プロースの途中から漏れが
+# 始まるケースを拾うため）。そのぶん、ツールコール構文を引用・説明する
+# メッセージに対する誤検知がわずかに増えるが、下記のセッション単位の
+# 発火回数上限で影響を抑える。
+LEAK_PATTERN='<(/)?([A-Za-z][A-Za-z0-9_.-]*:)?(invoke|function_calls|parameter)([[:space:]/>]|$)'
 
-MATCHED_LINE=""
-while IFS= read -r line; do
-    if grep -Eiq "$LEAK_PATTERN" <<< "$line"; then
-        MATCHED_LINE="$line"
-        break
-    fi
-done <<< "$LAST_MESSAGE"
+MATCHED_LINE=$(grep -Eim1 "$LEAK_PATTERN" <<< "$LAST_MESSAGE")
 
 # マッチなし → 正常終了
 if [[ -z "$MATCHED_LINE" ]]; then
     exit 0
 fi
 
-# 検出ログを追記する（ディレクトリはオーナーのみアクセス可能 (700) で作成する）
-mkdir -p "$DATA_DIR" && chmod 700 "$DATA_DIR"
-printf '%s\t%s\t%s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$SESSION_ID" "$MATCHED_LINE" >> "$LOG_FILE" 2>/dev/null
+# ログにはマッチした行全体ではなく、マッチしたタグ断片のみを記録する。
+# 行全体には漏れたツールコールの引数（シークレットやファイル内容を含み
+# うる）が含まれる可能性があり、そのままログへ書き出すと
+# rules/security.md の「シークレット値をログへ残さない」に反するため。
+MATCHED_MARKER=$(grep -Eiom1 "$LEAK_PATTERN" <<< "$MATCHED_LINE")
 
-REASON="⚠️ 直前のアシスタントメッセージに、ツールコールの XML マークアップ(<invoke>/<function_calls>/<parameter> 等)がプレーンテキストとして漏れ出しています。
+# セッション ID が英数字・ハイフン・アンダースコアのみで構成されているか検証する
+# （deep-review-require-fixes.sh 等と同一の検証。不正な値をファイルパスへ
+# 直接展開すると意図しないディレクトリへの書き込みを招くため、一致しない
+# 場合は固定名ファイルにフォールバックする）
+if [[ "$SESSION_ID" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    COUNT_FILE="$DATA_DIR/leaked-toolcall-count-${SESSION_ID}"
+else
+    COUNT_FILE="$DATA_DIR/leaked-toolcall-count.txt"
+fi
+
+mkdir -p "$DATA_DIR" 2>/dev/null && chmod 700 "$DATA_DIR" 2>/dev/null
+
+# 検出ログを追記する（ログファイル自体もオーナーのみ読み書き可能にする）
+printf '%s\t%s\t%s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$SESSION_ID" "$MATCHED_MARKER" 2>/dev/null >> "$LOG_FILE"
+chmod 600 "$LOG_FILE" 2>/dev/null
+
+CURRENT_COUNT=0
+if [[ -f "$COUNT_FILE" ]]; then
+    CURRENT_COUNT=$(cat "$COUNT_FILE" 2>/dev/null)
+    [[ "$CURRENT_COUNT" =~ ^[0-9]+$ ]] || CURRENT_COUNT=0
+fi
+
+# 上限に達している場合はブロックしない（誤検知による無限ブロックループを回避）
+if [[ "$CURRENT_COUNT" -ge "$MAX_TRIGGERS_PER_SESSION" ]]; then
+    exit 0
+fi
+
+printf '%s\n' "$((CURRENT_COUNT + 1))" 2>/dev/null > "$COUNT_FILE"
+chmod 600 "$COUNT_FILE" 2>/dev/null
+
+REASON="⚠️ 直前のアシスタントメッセージに、ツールコールの XML マークアップ(<invoke>/<function_calls>/<parameter> 等、閉じタグ・属性なしの短縮形を含む)がプレーンテキストとして漏れ出しています。
 
 これは Claude Code の既知の不具合によるもので、実際にはツールは実行されていません。
 

--- a/home/dot_claude/hooks/executable_detect-leaked-toolcall.sh
+++ b/home/dot_claude/hooks/executable_detect-leaked-toolcall.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Stop hook: トランスクリプトの最終アシスタントメッセージに、ツールコールの
+# XML マークアップ（<invoke>/<function_calls>/<parameter> 等）がプレーン
+# テキストとして漏れ出していないか検出する。
+# 検出時は、漏れたマークアップを引用・言い換えて再試行しない（自己模倣による
+# 汚染を招く）よう指示し、意図をプロースで手短に述べたうえで、構造化された
+# ツールコールを 1 回だけ発行するようブロックメッセージで促す。
+
+DATA_DIR="$HOME/.claude/data"
+LOG_FILE="$DATA_DIR/leaked-toolcall-triggers.log"
+
+# stdin から JSON を読み込む（公式フック契約: stdin JSON）
+INPUT=$(cat)
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
+
+# transcript_path が取得できない、またはファイルが存在しない場合はブロックしない
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+    exit 0
+fi
+
+# Extract the concatenated text of the transcript's last assistant message.
+# Arguments: $1 = transcript JSONL file path.
+# Content shape varies (plain string in .message.content/.content, or an
+# array of blocks where type == "text" blocks carry a .text field); both are
+# normalized to a single newline-joined string. Prints nothing on failure.
+extract_last_assistant_text() {
+    local transcript_path="$1"
+    jq -rs '
+        [ .[] | select(type == "object") | select(.type == "assistant") ] | last |
+        if . == null then ""
+        else
+            (.message.content // .content) as $c |
+            if ($c | type) == "string" then $c
+            elif ($c | type) == "array" then
+                [ $c[] | select(.type == "text") | .text ] | join("\n")
+            else "" end
+        end
+    ' "$transcript_path" 2>/dev/null
+}
+
+LAST_MESSAGE=$(extract_last_assistant_text "$TRANSCRIPT_PATH")
+
+# メッセージが取得できない場合はブロックしない
+if [[ -z "$LAST_MESSAGE" ]]; then
+    exit 0
+fi
+
+# 漏れたツールコールマークアップの行頭パターン（大文字小文字を区別しない）
+LEAK_PATTERN='^[[:space:]]*<([A-Za-z][A-Za-z0-9_.-]*:)?(invoke[[:space:]]|function_calls|parameter[[:space:]])'
+
+MATCHED_LINE=""
+while IFS= read -r line; do
+    if grep -Eiq "$LEAK_PATTERN" <<< "$line"; then
+        MATCHED_LINE="$line"
+        break
+    fi
+done <<< "$LAST_MESSAGE"
+
+# マッチなし → 正常終了
+if [[ -z "$MATCHED_LINE" ]]; then
+    exit 0
+fi
+
+# 検出ログを追記する（ディレクトリはオーナーのみアクセス可能 (700) で作成する）
+mkdir -p "$DATA_DIR" && chmod 700 "$DATA_DIR"
+printf '%s\t%s\t%s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$SESSION_ID" "$MATCHED_LINE" >> "$LOG_FILE" 2>/dev/null
+
+REASON="⚠️ 直前のアシスタントメッセージに、ツールコールの XML マークアップ(<invoke>/<function_calls>/<parameter> 等)がプレーンテキストとして漏れ出しています。
+
+これは Claude Code の既知の不具合によるもので、実際にはツールは実行されていません。
+
+対応手順:
+1. 漏れたマークアップを引用・言い換えて再試行しないでください（自己模倣により同じ漏れを再発させる原因になります）。
+2. 直前に何をしようとしていたかを、プロース文で手短に述べ直してください。
+3. そのうえで、正しく構造化されたツールコールを 1 回だけ発行してください。"
+
+jq -n --arg reason "$REASON" '{"decision":"block","reason":$reason}'
+exit 0

--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -38,6 +38,23 @@
             "type": "command",
             "command": "bash ~/.claude/hooks/require-review-thread-fixes.sh",
             "onFailure": "fail"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/detect-leaked-toolcall.sh",
+            "onFailure": "ignore"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/detect-leaked-toolcall.sh",
+            "onFailure": "ignore"
           }
         ]
       }

--- a/tests/unit/test_hooks.sh
+++ b/tests/unit/test_hooks.sh
@@ -367,6 +367,58 @@ for cmd in \
   fi
 done
 
+echo "Testing detect-leaked-toolcall hook behavior..."
+DETECT_LEAKED_TOOLCALL="home/dot_claude/hooks/executable_detect-leaked-toolcall.sh"
+
+run_detect_leaked_toolcall() {
+  local transcript_path="$1"
+  local session_id="$2"
+  jq -n --arg sid "$session_id" --arg tp "$transcript_path" '{"session_id": $sid, "transcript_path": $tp}' \
+    | HOME="$TEST_HOOK_HOME" bash "$DETECT_LEAKED_TOOLCALL"
+}
+
+TEST_HOOK_HOME=$(mktemp -d)
+
+# シナリオ 1: 最終アシスタントメッセージにツールコールのマークアップが漏れている場合はブロックすること
+TEST_TRANSCRIPT=$(mktemp)
+cat > "$TEST_TRANSCRIPT" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"text","text":"続けます。<invoke name=\"Write\">"}]}}
+EOF
+OUTPUT=$(run_detect_leaked_toolcall "$TEST_TRANSCRIPT" "test-session-leak")
+DECISION=$(echo "$OUTPUT" | jq -r '.decision // empty' 2>/dev/null)
+if [[ "$DECISION" != "block" ]]; then
+  echo "❌ detect-leaked-toolcall did not block a message with leaked tool-call markup"
+  FAILED=1
+else
+  echo "✅ detect-leaked-toolcall blocked a message with leaked tool-call markup"
+fi
+rm -f "$TEST_TRANSCRIPT"
+
+# シナリオ 2: 最終アシスタントメッセージが通常のプロースの場合はブロックしないこと
+TEST_TRANSCRIPT=$(mktemp)
+cat > "$TEST_TRANSCRIPT" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"text","text":"ordinary prose without any tool-call markup."}]}}
+EOF
+OUTPUT=$(run_detect_leaked_toolcall "$TEST_TRANSCRIPT" "test-session-clean")
+if [[ -n "$OUTPUT" ]]; then
+  echo "❌ detect-leaked-toolcall produced output for an ordinary message: $OUTPUT"
+  FAILED=1
+else
+  echo "✅ detect-leaked-toolcall stayed silent for an ordinary message"
+fi
+rm -f "$TEST_TRANSCRIPT"
+
+# シナリオ 3: transcript_path が存在しない場合はブロックしないこと
+OUTPUT=$(run_detect_leaked_toolcall "/nonexistent/path/transcript.jsonl" "test-session-missing")
+if [[ -n "$OUTPUT" ]]; then
+  echo "❌ detect-leaked-toolcall produced output for a missing transcript_path: $OUTPUT"
+  FAILED=1
+else
+  echo "✅ detect-leaked-toolcall stayed silent for a missing transcript_path"
+fi
+
+rm -rf "$TEST_HOOK_HOME"
+
 if [ $FAILED -eq 0 ]; then
   echo "✅ All hook tests passed"
 else

--- a/tests/unit/test_hooks.sh
+++ b/tests/unit/test_hooks.sh
@@ -13,6 +13,7 @@ HOOKS=(
   "home/dot_claude/hooks/executable_require-code-review-fixes.sh"
   "home/dot_claude/hooks/executable_require-review-thread-fixes.sh"
   "home/dot_claude/hooks/executable_git-config-guard.sh"
+  "home/dot_claude/hooks/executable_detect-leaked-toolcall.sh"
 )
 
 # 各フックの構文チェック


### PR DESCRIPTION
## 概要

Claude Code の既知の不具合(ツールコールの XML マークアップが実行されずプレーンテキストとして会話に漏れ、エラー表示なくターンが終わる。[anthropics/claude-code#68615](https://github.com/anthropics/claude-code/issues/68615) 参照)への対策として、`Stop` / `SubagentStop` フックでこれを検出し、再発を防ぐようブロックする仕組みを追加する。

一度漏れたマークアップの例が会話履歴に残るとモデルが模倣して再発しやすいため、検出時は「引用・言い換えて再試行しない」ことを明示的に指示する。

## 変更内容

- `home/dot_claude/hooks/executable_detect-leaked-toolcall.sh`(新規)
  - トランスクリプトの最終アシスタントメッセージから漏洩したツールコールマークアップ(`<invoke>`/`<function_calls>`/`<parameter>` 等、閉じタグ・属性なし短縮形を含む)を検出
  - 検出時はセッション終了をブロックし、正しい構造化ツールコールの再発行を促す
  - 誤検知による無限ブロックループを避けるため、セッションあたりの発火回数に上限(3回)を設ける
  - ログにはマッチしたタグ断片のみを記録し、漏洩行の引数(シークレット等を含みうる)は記録しない
- `home/dot_claude/private_settings.json`: `Stop` / 新設 `SubagentStop` の両方に登録
- `tests/unit/test_hooks.sh`: 構文チェックに加え、ブロック判定の挙動テストを追加
- `README.md`, `CLAUDE.md`: フックの説明を追加

## レビュー

`/deep-review`(ローカル差分モード)を実施し、score ≥ 50 の指摘 13 件をすべて修正済み(性能・信頼性・セキュリティ・コメント品質・テスト不足など)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
