### PR TITLE
docs: idle 通知フォロー手順の再読込トリガーとタイムアウト条件を明確化する

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -47,6 +47,7 @@ Not auto-loaded. Read the relevant file only when the situation applies:
 |---|---|
 | Checklists / Jira rules needed | `rules/workflow.md` |
 | Deciding whether to delegate to a sub-agent (esp. any work touching Claude Code's own prompt files: `CLAUDE.md`/`AGENTS.md`, `rules/*.md`, `skills/*`, `agents/*.md`, hooks, `settings.json`) | `rules/workflow-sub-agents.md` |
+| An idle notification arrives from a background sub-agent | `rules/workflow-sub-agents.md` ("Handling Idle Notifications from Background Sub-Agents" section) |
 | Writing/reviewing code, comments, tests, commits | `rules/coding-common.md` |
 | Writing a spec or plan document | `rules/superpowers.md` |
 | Posting a spec/plan/investigation doc to a GitHub Issue | `rules/issue-comment-docs.md` |

--- a/home/dot_claude/rules/workflow-sub-agents.md
+++ b/home/dot_claude/rules/workflow-sub-agents.md
@@ -118,3 +118,23 @@ This applies whenever a background-mode sub-agent (the `Agent` tool's default, o
   a specific state-tracking mechanism. A calling skill that already tracks
   sub-agent progress (a state file like `STATE.md`, or the `Todo`/`Task`
   tools) may reuse that instead of inventing a new one.
+
+**Proactive complement — instruct named/teammate sub-agents to report before going idle:**
+
+Named/teammate sub-agents (dispatched via the `Agent` tool with a `name`
+parameter, meant to be resumed later via `SendMessage`) have no automatic
+"completed" notification the way anonymous one-shot `Agent` calls do — the
+only way the team-lead learns of their status is if the sub-agent itself
+calls `SendMessage` before going idle. So whenever dispatching a
+named/teammate sub-agent, always append an explicit instruction to its
+prompt along these lines: "Before you stop taking actions for any reason
+(completion, being blocked, uncertainty, or anything else), you MUST call
+SendMessage to report your status to team-lead. Never go idle without
+reporting." This does not apply to anonymous one-shot `Agent` calls without
+a `name` — those already return a result automatically when they stop.
+
+This is a preventive measure, not a replacement for the reactive follow-up
+procedure above: a sub-agent that stalls before it can even reason about
+stopping (e.g. blocked at a permission gate before its first tool call)
+can't act on an instruction in its own prompt either, so the nudge/timeout/
+re-dispatch path above remains the safety net for that case.

--- a/home/dot_claude/rules/workflow-sub-agents.md
+++ b/home/dot_claude/rules/workflow-sub-agents.md
@@ -93,10 +93,16 @@ This applies whenever a background-mode sub-agent (the `Agent` tool's default, o
    minutes since the nudge; a calling skill may define its own threshold —
    that takes precedence over this default), set up a `CronCreate`
    check-in (default: every 15 minutes) if one isn't already running, to
-   track outstanding sub-agents.
+   track outstanding sub-agents. This timeout is purely elapsed wall-clock
+   time since the nudge was sent — it applies identically whether the
+   sub-agent acknowledged the nudge, produced other output, or gave zero
+   response of any kind; do not wait for an acknowledgment before starting
+   or continuing this clock.
 3. At each check-in, any sub-agent still not completed after its own
    timeout (default 30 minutes since the nudge) is stopped (e.g. via
-   `TaskStop`) and re-dispatched once, with the same input.
+   `TaskStop`) and re-dispatched once, with the same input — again based
+   solely on elapsed time, regardless of whether the sub-agent ever
+   responded to the nudge.
 4. If the re-dispatch also times out, mark that sub-agent's task as
    **unresolved** in the calling skill's final report — do not silently
    drop it — and move on with the rest of the work instead of waiting


### PR DESCRIPTION
## 概要

バックグラウンドサブエージェントが idle 状態になった際、team-lead(親セッション)がいつまでも応答を待ち続けてしまう問題への対策として、既存の idle 対応ルール(`rules/workflow-sub-agents.md`)がより確実に適用されるよう、以下 2 点を修正する。

## 変更内容

- `CLAUDE.md` の Context loading テーブルに、バックグラウンドサブエージェントから idle 通知を受け取った際に `rules/workflow-sub-agents.md` を読み直すトリガー行を追加。従来は「委譲を判断する時点」のみが読込トリガーで、実際に idle 通知が届く(会話がかなり進んだ後になりがちな)タイミングでルールが参照されないギャップがあった。
- `rules/workflow-sub-agents.md` の idle 対応手順(タイムアウトによる再ディスパッチ)について、SendMessage nudge への応答有無に関わらず経過時間のみで発火することを明記。nudge しても一切応答が返らないサブエージェント stall のケース(`anthropics/claude-code` issue #61547 で報告されている既知の挙動)でも、タイムアウト経由の再ディスパッチが確実に機能するようにする。

## 調査背景

`anthropics/claude-code` の実際の GitHub issue を調査した結果、ハーネス側に idle を自動検知・自動対応する専用の仕組み(`SubagentIdle` 相当のフックや、`TaskOutput` でのポーリングによる idle 判定)は存在せず、関連する機能要望(#45781)も `NOT_PLANNED` で close 済みであることを確認した。そのため、プロンプト(CLAUDE.md/rules)側での対策強化が現状取りうる最善の手段と判断した。

## 検証

- `git diff origin/master..HEAD` で意図した 2 ファイルのみの差分であることを確認済み。
- deep-review(ローカル diff モード)を実行したが、レビュアーサブエージェント(`a-claude-md-compliance` / `c-history-context`)が応答せず、ユーザーの判断で待機を打ち切った。差分はドキュメントの追記・文言明確化のみで、コード変更を含まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)