### PR TITLE
fix: サブエージェントの完了報告と Post-PR checklist の自動連鎖を強化する

### DIFF
--- a/home/dot_claude/rules/workflow-sub-agents.md
+++ b/home/dot_claude/rules/workflow-sub-agents.md
@@ -87,14 +87,7 @@ This applies whenever a background-mode sub-agent (the `Agent` tool's default, o
 
 **Follow-up procedure:**
 
-1. On receiving an idle notification, immediately send that sub-agent one
-   `SendMessage` nudge that explicitly names `SendMessage` as the
-   required mechanism for reporting — e.g. "You must call `SendMessage`
-   to report your result or current status; plain text output alone is
-   not visible to the caller." A generic "please continue or report
-   status" nudge that does not name `SendMessage` is insufficient — it
-   was tried in practice and did not resolve repeated idling (see the
-   incident behind this rule's "Proactive complement" section below).
+1. On receiving an idle notification, immediately send that sub-agent one `SendMessage` nudge that explicitly names `SendMessage` as the required mechanism for reporting — e.g. "You must call `SendMessage` to report your result or current status; plain text output alone is not visible to the caller." A generic "please continue or report status" nudge that does not name `SendMessage` is insufficient — it was tried in practice and did not resolve repeated idling (see the incident behind this rule's "Proactive complement" section below).
 2. If no `completed` notification arrives within a timeout (default 15
    minutes since the nudge; a calling skill may define its own threshold —
    that takes precedence over this default), set up a `CronCreate`
@@ -127,27 +120,7 @@ This applies whenever a background-mode sub-agent (the `Agent` tool's default, o
 
 **Proactive complement — instruct every background-mode sub-agent to report before going idle:**
 
-Named/teammate sub-agents (dispatched via the `Agent` tool with a `name`
-parameter, meant to be resumed later via `SendMessage`) have no automatic
-"completed" notification the way a *sync-mode* `Agent` call does — the
-only way the team-lead learns of their status is if the sub-agent itself
-calls `SendMessage` before going idle. The same gap applies to anonymous
-one-shot `Agent` calls dispatched in background mode (the `Agent` tool's
-default): in practice, background-mode reviewer sub-agents dispatched
-without a `name` (e.g. `deep-review`'s Step 5 parallel reviewers) have
-also repeatedly gone idle without calling `SendMessage`, instead of
-returning a result automatically, when their initial prompt did not
-explicitly require it. So whenever dispatching **any** background-mode
-sub-agent — named/teammate or anonymous one-shot alike — always append
-an explicit instruction to its prompt along these lines: "Before you stop
-taking actions for any reason (completion, being blocked, uncertainty, or
-anything else), you MUST call SendMessage to report your result or
-status to the parent session (use `to: \"team-lead\"` for named/teammate
-sub-agents, or the caller's default target for anonymous one-shot calls).
-Never go idle without reporting — plain text output alone is not visible
-to the caller." This does not apply to **sync-mode** (`run_in_background:
-false`) dispatches, since those already block the calling turn until the
-sub-agent returns its result directly.
+Named/teammate sub-agents (dispatched via the `Agent` tool with a `name` parameter, meant to be resumed later via `SendMessage`) have no automatic "completed" notification the way a *sync-mode* `Agent` call does — the only way the team-lead learns of their status is if the sub-agent itself calls `SendMessage` before going idle. The same gap applies to anonymous one-shot `Agent` calls dispatched in background mode (the `Agent` tool's default): in practice, background-mode reviewer sub-agents dispatched without a `name` (e.g. `deep-review`'s Step 5 parallel reviewers) have also repeatedly gone idle without calling `SendMessage`, instead of returning a result automatically, when their initial prompt did not explicitly require it. So whenever dispatching **any** background-mode sub-agent — named/teammate or anonymous one-shot alike — always append an explicit instruction to its prompt along these lines: "Before you stop taking actions for any reason (completion, being blocked, uncertainty, or anything else), you MUST call SendMessage to report your result or status to the parent session (use `to: "team-lead"` for named/teammate sub-agents, or the caller's default target for anonymous one-shot calls). Never go idle without reporting — plain text output alone is not visible to the caller." This does not apply to **sync-mode** (`run_in_background: false`) dispatches, since those already block the calling turn until the sub-agent returns its result directly. It also does not apply to sub-agents whose completion is instead tracked via a shared state-tracking mechanism (a state file such as `STATE.md`, or the `Todo`/`Task` tools) that the parent session polls directly — mirroring the existing reactive-procedure carve-out noted above — since in that case the parent doesn't rely on the sub-agent's own `SendMessage` call to learn of completion.
 
 This is a preventive measure, not a replacement for the reactive follow-up
 procedure above: a sub-agent that stalls before it can even reason about

--- a/home/dot_claude/rules/workflow-sub-agents.md
+++ b/home/dot_claude/rules/workflow-sub-agents.md
@@ -88,7 +88,13 @@ This applies whenever a background-mode sub-agent (the `Agent` tool's default, o
 **Follow-up procedure:**
 
 1. On receiving an idle notification, immediately send that sub-agent one
-   `SendMessage` nudge asking it to continue or report its current status.
+   `SendMessage` nudge that explicitly names `SendMessage` as the
+   required mechanism for reporting — e.g. "You must call `SendMessage`
+   to report your result or current status; plain text output alone is
+   not visible to the caller." A generic "please continue or report
+   status" nudge that does not name `SendMessage` is insufficient — it
+   was tried in practice and did not resolve repeated idling (see the
+   incident behind this rule's "Proactive complement" section below).
 2. If no `completed` notification arrives within a timeout (default 15
    minutes since the nudge; a calling skill may define its own threshold —
    that takes precedence over this default), set up a `CronCreate`
@@ -119,19 +125,29 @@ This applies whenever a background-mode sub-agent (the `Agent` tool's default, o
   sub-agent progress (a state file like `STATE.md`, or the `Todo`/`Task`
   tools) may reuse that instead of inventing a new one.
 
-**Proactive complement — instruct named/teammate sub-agents to report before going idle:**
+**Proactive complement — instruct every background-mode sub-agent to report before going idle:**
 
 Named/teammate sub-agents (dispatched via the `Agent` tool with a `name`
 parameter, meant to be resumed later via `SendMessage`) have no automatic
-"completed" notification the way anonymous one-shot `Agent` calls do — the
+"completed" notification the way a *sync-mode* `Agent` call does — the
 only way the team-lead learns of their status is if the sub-agent itself
-calls `SendMessage` before going idle. So whenever dispatching a
-named/teammate sub-agent, always append an explicit instruction to its
-prompt along these lines: "Before you stop taking actions for any reason
-(completion, being blocked, uncertainty, or anything else), you MUST call
-SendMessage to report your status to team-lead. Never go idle without
-reporting." This does not apply to anonymous one-shot `Agent` calls without
-a `name` — those already return a result automatically when they stop.
+calls `SendMessage` before going idle. The same gap applies to anonymous
+one-shot `Agent` calls dispatched in background mode (the `Agent` tool's
+default): in practice, background-mode reviewer sub-agents dispatched
+without a `name` (e.g. `deep-review`'s Step 5 parallel reviewers) have
+also repeatedly gone idle without calling `SendMessage`, instead of
+returning a result automatically, when their initial prompt did not
+explicitly require it. So whenever dispatching **any** background-mode
+sub-agent — named/teammate or anonymous one-shot alike — always append
+an explicit instruction to its prompt along these lines: "Before you stop
+taking actions for any reason (completion, being blocked, uncertainty, or
+anything else), you MUST call SendMessage to report your result or
+status to the parent session (use `to: \"team-lead\"` for named/teammate
+sub-agents, or the caller's default target for anonymous one-shot calls).
+Never go idle without reporting — plain text output alone is not visible
+to the caller." This does not apply to **sync-mode** (`run_in_background:
+false`) dispatches, since those already block the calling turn until the
+sub-agent returns its result directly.
 
 This is a preventive measure, not a replacement for the reactive follow-up
 procedure above: a sub-agent that stalls before it can even reason about

--- a/home/dot_claude/rules/workflow.md
+++ b/home/dot_claude/rules/workflow.md
@@ -51,6 +51,8 @@ Rules and checklists for the full development workflow.
 
 ## Post-PR checklist
 
+**Once `gh pr create` (or any other PR-creating operation) succeeds, continue directly into this checklist before reporting completion to the user — do not treat PR creation itself as the end of the task.**
+
 Run `/pr-health-monitor <PR number>` to automate, or manually:
 
 1. Verify no merge conflicts.

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -108,16 +108,7 @@ Then, using the exploration results and the diff information, use a Haiku sub-ag
      commands, not diff text): pass only the list of changed file paths
      (from the Step 3 change summary), not the full diff.
 
-   Every reviewer sub-agent is dispatched in background mode without a
-   `name`. Its initial prompt MUST also include this explicit reporting
-   instruction, verbatim: "Before you stop taking actions for any reason
-   (completion, being blocked, uncertainty, or anything else), you MUST
-   call SendMessage to report your findings to the parent session. Never
-   go idle without reporting — plain text output alone is not visible to
-   the caller." Without this, the sub-agent may write its findings as
-   plain text and stop without calling `SendMessage`, producing a
-   repeated idle notification instead of a completed result (see
-   `rules/workflow-sub-agents.md`'s "Proactive complement" section).
+   Every reviewer sub-agent is dispatched in background mode, whether given a `name` or left anonymous. Its initial prompt MUST also include this explicit reporting instruction, verbatim: "Before you stop taking actions for any reason (completion, being blocked, uncertainty, or anything else), you MUST call SendMessage to report your findings to the parent session. Never go idle without reporting — plain text output alone is not visible to the caller." Without this, the sub-agent may write its findings as plain text and stop without calling `SendMessage`, producing a repeated idle notification instead of a completed result (see `rules/workflow-sub-agents.md`'s "Proactive complement" section).
 
 Each agent returns findings as: *problem summary + evidence + file:line reference*.
 
@@ -136,7 +127,9 @@ Do NOT report the following:
 **Idle sub-agent follow-up:** these reviewer sub-agents run in the background per `rules/workflow-sub-agents.md`'s "Handling Idle Notifications from Background Sub-Agents" — apply that procedure here, made concrete for this step:
 
 - When dispatching the reviewers above, note which reviewer slug (e.g.
-  `f-security`) each sub-agent corresponds to.
+  `f-security`) each sub-agent corresponds to, along with its dispatch
+  identifier — its `name` if one was assigned, otherwise its `agentId` —
+  so it can actually be nudged via `SendMessage` later.
 - On any idle notification from one of these sub-agents, nudge it
   immediately via `SendMessage` — do not wait for the next check-in.
 - Right after dispatch, set up a `CronCreate` check-in every 15 minutes

--- a/home/dot_claude/skills/deep-review/SKILL.md
+++ b/home/dot_claude/skills/deep-review/SKILL.md
@@ -108,6 +108,17 @@ Then, using the exploration results and the diff information, use a Haiku sub-ag
      commands, not diff text): pass only the list of changed file paths
      (from the Step 3 change summary), not the full diff.
 
+   Every reviewer sub-agent is dispatched in background mode without a
+   `name`. Its initial prompt MUST also include this explicit reporting
+   instruction, verbatim: "Before you stop taking actions for any reason
+   (completion, being blocked, uncertainty, or anything else), you MUST
+   call SendMessage to report your findings to the parent session. Never
+   go idle without reporting — plain text output alone is not visible to
+   the caller." Without this, the sub-agent may write its findings as
+   plain text and stop without calling `SendMessage`, producing a
+   repeated idle notification instead of a completed result (see
+   `rules/workflow-sub-agents.md`'s "Proactive complement" section).
+
 Each agent returns findings as: *problem summary + evidence + file:line reference*.
 
 **Instructions passed to every agent (false-positive suppression):**


### PR DESCRIPTION
Closes #279
Closes #280

## 概要

background 起動サブエージェントの完了報告漏れ(#279)と、PR 作成後に Post-PR checklist へ自動的に継続しない問題(#280)を、既存のプロンプトファイル(rules/*.md、deep-review/SKILL.md)の文言強化で解決する。

## 変更内容

### Issue #279 対応
- `home/dot_claude/rules/workflow-sub-agents.md`
  - 「Proactive complement」節のスコープを、named/teammate サブエージェントのみ対象という誤った前提から、匿名の one-shot background 呼び出しも含む全 background-mode サブエージェントを対象とするよう訂正。
  - idle 通知後のナッジ文言を、`SendMessage` が報告手段として必須であることを明示する内容に更新。
  - `STATE.md` 等の状態ファイルで完了を追跡するサブエージェント(例: `check-container-status`)向けの例外を明記。
- `home/dot_claude/skills/deep-review/SKILL.md`
  - Step 5 の reviewer サブエージェント dispatch に、`SendMessage` での報告を必須とする定型指示を追加。
  - reviewer の dispatch 方式(`name` の有無)に関する記述矛盾を解消し、`SendMessage` でナッジする際に必要な識別子(`name` または `agentId`)を記録するよう追記。

### Issue #280 対応
- `home/dot_claude/rules/workflow.md`
  - Post-PR checklist の書き出しに、`gh pr create` 成功後は確認なしでそのままチェックリストへ継続する旨を明示する一文を追加。

## 検証

- `tests/unit/test_hooks.sh` / `tests/syntax/test_bash_syntax.sh` を実行し、いずれも exit 0 で成功。
- `/deep-review`(Local diff mode)を実行し、検出された score ≥ 50 の指摘(散文の途中改行、`check-container-status` との整合性、reviewer dispatch 記述の矛盾)をすべて修正済み。

## 関連ドキュメント

- Issue #279 — Spec: https://github.com/book000/dotfiles/issues/279#issuecomment-5150121687 / Plan: https://github.com/book000/dotfiles/issues/279#issuecomment-5150143991
- Issue #280 — Spec: https://github.com/book000/dotfiles/issues/280#issuecomment-5150121812 / Plan: https://github.com/book000/dotfiles/issues/280#issuecomment-5150144078
