### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.env
+.gitconfig.local


### PR DESCRIPTION
## 概要

`.worktreeinclude` を新規作成し、`git worktree` 作成時に以下のパターンを含めるようにする。

- `.env`
- `.gitconfig.local`

## 背景

- `home/dot_env.example`: `~/.env` にコピーして使うテンプレートで、Discord webhook / Trilium トークンなどのプレースホルダを含み、「~/.env はGitに含めないでください（機密情報を含むため）」とコメントされている。
- `home/dot_gitconfig.local.example`: `~/.gitconfig.local` にコピーして使うテンプレートで、`[user]` の name/email と `[ghq]` root を設定する。
- `README.md`(36-58行目付近): セットアップ手順として `.gitconfig.local` / `.env` を `*.example` からコピーして手動編集する旨が明記されている。
- `install.sh`: `setup_gitconfig_local()` や `.env` 用のコピー関数(`copy_env_if_needed`)があり、`*.example` から `$HOME/.env` / `$HOME/.gitconfig.local` を生成し、`.env` は機密情報を含むため `chmod 600` している。
- `home/dot_claude/scripts/completion-notify/*.sh` や `home/dot_codex/scripts/completion-notify/*.sh` の多数のスクリプトが `.env` を `source` して `DISCORD_*_WEBHOOK` / `TRILIUM_ETAPI_TOKEN` を読み込む。
- `tests/integration/test_chezmoi_apply.sh`(232行目付近): `.env.example` は存在し `.env` は存在しないことを確認しており、`.env` が Git 管理外のローカルコピーであることを裏付けている。

これらのファイルはリポジトリの `.gitignore` 対象ではなく、`$HOME` 配下に chezmoi の `install.sh`/`chezmoi apply` によって生成されるものであり、リポジトリ自体には含まれない。そのため、新しい `git worktree` を作成した際には持ち込まれず、`install.sh`/`chezmoi apply` によって空/デフォルト値で再生成されてしまう。`.worktreeinclude` に登録することで、既存の worktree からこれらのファイルを引き継げるようにする。

## 参照

- https://github.com/book000/book000/issues/132
