### PR TITLE
fix: Codex の personality 設定を削除する

### DIFF
--- a/home/dot_codex/modify_config.toml
+++ b/home/dot_codex/modify_config.toml
@@ -7,7 +7,6 @@
 {{- $config = $config | setValueAtPath "model_reasoning_summary" "auto" -}}
 {{- $config = $config | setValueAtPath "project_doc_fallback_filenames" (list "AGENTS.local.md") -}}
 {{- $config = $config | setValueAtPath "notify" (list "codex-wakatime") -}}
-{{- $config = $config | setValueAtPath "personality" "pragmatic" -}}
 {{- $config = $config | setValueAtPath "sandbox_workspace_write.network_access" true -}}
 {{- $config = $config | setValueAtPath "features.hooks" true -}}
 {{- $_ := unset (index $config "features") "codex_hooks" -}}


### PR DESCRIPTION
## 概要

Issue #288 の要望に基づき、`home/dot_codex/modify_config.toml` から Codex の `personality = "pragmatic"` 設定を削除する。

## 変更内容

- `home/dot_codex/modify_config.toml` の `personality` 設定行を削除。設定を明示的に上書きしなくなり、Codex 側のデフォルト挙動にフォールバックする。
- リポジトリ内を `personality` で全文検索したが、他に参照している箇所は存在しないため追加の変更は不要。

## 検証

- `tests/syntax/test_bash_syntax.sh` / `test_shellcheck.sh` / `test_json_schema.sh`
- `tests/unit/test_install.sh` / `test_notifications.sh` / `test_hooks.sh`
- `tests/integration/test_chezmoi_apply.sh`

いずれも fresh 実行で全て成功(exit 0)。

Closes #288