### PR TITLE
fix: tmux の OSC 応答待機時間を延長する

### DIFF
--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -14,8 +14,7 @@ bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft=
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
 # デフォルトターミナルを設定（tmux 内部で使用される TERM 値）
-# tmux-256color を優先使用（screen-256color より terminfo が完全で、
-# プログラムが DA1/DA2 クエリで機能補完しようとする動作を抑制できる）
+# tmux-256color を優先使用（screen-256color より terminfo が完全）
 if-shell 'infocmp tmux-256color > /dev/null 2>&1' \
   'set -g default-terminal "tmux-256color"' \
   'set -g default-terminal "screen-256color"'
@@ -26,14 +25,8 @@ set -g focus-events off
 # true color (24-bit color) サポートを有効化
 # terminal-features を使用して RGB サポートを宣言型で設定する（tmux 3.2+）
 #
-# 【terminal-overrides Tc ではなく terminal-features RGB を使う理由】
-# terminal-overrides の Tc は tmux がアタッチ時に外部ターミナルへ
-# OSC 10/11（前景色・背景色問い合わせ）クエリを送信する原因となる。
-# 応答 (`\e]11;rgb:xxxx/xxxx/xxxx\a`) がタイミングによって
-# シェルの stdin に漏れ込み `^[]11;rgb:...^[` として表示されてしまう。
-#
-# terminal-features の RGB は宣言型（クエリなし）でサポートを有効化するため
-# アタッチ時の OSC 10/11 クエリを回避できる。
+# terminal-features で RGB サポートを宣言する。
+# tmux 自身の OSC 10/11 問い合わせを抑止する設定ではない。
 set -ga terminal-features ",*256col*:RGB"
 set -ga terminal-features ",xterm*:RGB"
 
@@ -41,8 +34,6 @@ set -ga terminal-features ",xterm*:RGB"
 set -g default-shell /bin/bash
 
 # クライアント側の PATH と COLORFGBG を tmux サーバに同期する
-# COLORFGBG を同期することで、再接続時も背景色設定が引き継がれ
-# 新規ペインで OSC 11 クエリが発生しにくくなる
 set -g update-environment "PATH COLORFGBG"
 
 # rキーで設定ファイルをリロードする
@@ -50,8 +41,10 @@ bind r source-file ~/.tmux.conf \; display-message "Reloaded tmux.conf"
 
 # コピーモードのキー操作をvi風にする
 setw -g mode-keys vi
-# エスケープキーの入力待ち時間を10ミリ秒にする（Vimなどでの操作性向上）
-set -sg escape-time 10
+# OSC 10/11 の応答が遅延・分割されても通常のキー入力として漏れにくくするため、
+# エスケープシーケンスを最大 1000 ミリ秒待機する。
+# ESC 単独入力の反応も最大 1000 ミリ秒遅くなる。
+set -sg escape-time 1000
 
 # powerline の設定を条件付きで読み込む
 # powerline が存在しない環境ではエラーを抑制


### PR DESCRIPTION
Closes #283

## 概要

tmux が遅延・分割された OSC 10/11 応答を通常入力として扱う可能性を低減する。

## 変更内容

- `escape-time` を 10 ms から 1000 ms に延長する。
- OSC 問い合わせの抑止を誤って説明していたコメントを、実際の設定動作に合わせて修正する。

## 検証

- `tmux -f home/dot_tmux.conf` で `escape-time 1000` を確認
- `bash tests/syntax/test_bash_syntax.sh`
- `bash tests/integration/test_chezmoi_apply.sh`

## 前提とトレードオフ

- これは応答の継続部分が 1000 ms 以内に届く場合の緩和策であり、すべての遅延パターンを保証するものではない。
- `Esc` 単独入力の反応は最大 1000 ms 遅くなる。