### PR TITLE
fix: cron 起動の claude プロセスを子孫探索付きで検出する

### DIFF
--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -6,15 +6,51 @@
 # 表示内容が一時的に切り替わることで誤検出（フラッピング）が起きるため採用しない。
 # 代わりに、tmux セッションが起動している claude プロセスの pid から会話ログの
 # jsonl ファイルを一意に特定し、その内容でリミット状態を判定する。
+# 指定した pid とその子孫すべての pid を列挙する(自分自身を含む)。
+# cron ジョブが CLAUDE_BIN="$(command -v claude)" のように解決した絶対パスで
+# claude を起動する場合など、claude プロセスが pane の直接の子とは限らず
+# シェルのラッパー経由の孫プロセスになりうるため、再帰的にすべて集める。
+# _collect_descendant_pids_seen は訪問済み pid の重複防止用(グローバル)
+collect_descendant_pids() {
+    local root_pid="$1"
+    declare -A -g _collect_descendant_pids_seen=()
+    _collect_descendant_pids_impl "$root_pid"
+}
+
+_collect_descendant_pids_impl() {
+    local root_pid="$1" children child
+
+    [ -n "${_collect_descendant_pids_seen[$root_pid]:-}" ] && return 0
+    _collect_descendant_pids_seen[$root_pid]=1
+
+    echo "$root_pid"
+    children=$(pgrep -P "$root_pid" 2>/dev/null) || return 0
+    for child in $children; do
+        _collect_descendant_pids_impl "$child"
+    done
+}
+
 # tmux セッション名から、対応する claude プロセスの pid を特定する
 resolve_claude_pid() {
-    local session="$1" pane_pid
+    local session="$1" pane_pid pid comm
 
     # tmux はターゲットが "0" のような裸の数字だと、セッション名ではなく
     # 「未指定」とみなして現在アクティブなセッションへフォールバックしてしまう
     # ため、末尾に ":" を付けてセッション名指定であることを明示する
     pane_pid=$(tmux display-message -t "${session}:" -p '#{pane_pid}' 2>/dev/null) || return 1
-    pgrep -P "$pane_pid" -f "^claude" | head -1
+
+    # /proc/<pid>/comm はカーネルが実行ファイルのベース名から設定するプロセス名
+    # フィールドで、起動経路(絶対パス経由か否か)によらず常に "claude" になる。
+    # pgrep -f のような argv 全体への正規表現マッチと異なり、絶対パス起動で
+    # argv[0] がフルパスになっても影響を受けない
+    for pid in $(collect_descendant_pids "$pane_pid"); do
+        comm=$(cat "/proc/$pid/comm" 2>/dev/null) || continue
+        if [ "$comm" = "claude" ]; then
+            echo "$pid"
+            return 0
+        fi
+    done
+    return 1
 }
 
 # claude プロセスの pid から、実際に sessions/<pid>.json が存在する
@@ -176,7 +212,7 @@ check_limit_status() {
 
     [ -f "$jsonl" ] || { echo -e "0\t-\t-"; return; }
 
-    # jsonl は会話全体（数MB〜数十MBになりうる）だが直近の実メッセージが分かればよいため、
+    # jsonl は会話全体で大きくなりうるが直近の実メッセージが分かればよいため、
     # 末尾のみを走査対象にして cron の定期実行での毎回フルパースを避ける
     last_msg=$(tail -n 50 "$jsonl" | jq -c 'select(.type == "assistant" or .type == "user")' 2>/dev/null | tail -1)
     [ -n "$last_msg" ] || { echo -e "0\t-\t-"; return; }

--- a/home/dot_codex/scripts/limit-unlocked/dot_env
+++ b/home/dot_codex/scripts/limit-unlocked/dot_env
@@ -1,0 +1,18 @@
+# ~/.env から読み込む
+if [[ -f "$HOME/.env" ]]; then
+    source "$HOME/.env"
+else
+    echo "⚠️  Warning: $HOME/.env not found." >&2
+    echo "Some features may not work. Create $HOME/.env with required variables." >&2
+    echo "See ~/.env.example for reference." >&2
+fi
+
+# limit-unlocked スクリプト用の環境変数をエクスポート
+export DISCORD_WEBHOOK_URL="${DISCORD_CODEX_LIMIT_WEBHOOK:-}"
+export MENTION_USER_ID="${DISCORD_CODEX_LIMIT_MENTION_USER_ID:-}"
+
+# Webhook URL の存在チェック（空の場合は警告）
+if [[ -z "${DISCORD_WEBHOOK_URL}" ]]; then
+    echo "⚠️  Warning: DISCORD_WEBHOOK_URL is not set in $HOME/.env." >&2
+    echo "Notifications will not be sent." >&2
+fi

--- a/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh
@@ -1,0 +1,432 @@
+#!/bin/bash
+# Codex CLI のリミット到達・解除を、rollout ログ (jsonl) に記録される構造化イベントから
+# 検出し、Discord 通知とセッション再開を行う。
+#
+# Claude Code のリミット解除スクリプト (home/dot_claude/scripts/limit-unlocked) と
+# 同じ方式を採る: tmux ペインの画面表示テキストは Bash ツール実行中などに前面プロセスや
+# 表示内容が一時的に切り替わることで誤検出(フラッピング)が起きるため走査しない。
+# 代わりに、tmux セッションの pid 配下のプロセスが実際に開いている rollout jsonl の
+# ファイルパスを特定し、その内容でリミット状態を判定する。
+#
+# 想定 crontab (このリポジトリでは管理しない。ユーザーが別途登録する):
+#   1-59/5 * * * * ~/.codex/scripts/limit-unlocked/check-notify.sh
+
+# 指定した pid の子孫すべての pid を、pid→ppid の対応表を 1 回の ps 呼び出しで
+# 取得した上で awk 側でツリーを再構成して列挙する(自分自身を含む)。
+# codex の実体は tmux ペインの直接の子プロセスとは限らず(例:
+# bash -> codex --yolo -> codex-code-mode-host、あるいは
+# node /path/to/bin/codex --yolo のように node が親になる場合もある)、
+# どのプロセス名が実際の codex 本体かを仮定できないため、子孫を再帰的に
+# すべて集めた上で fd 走査を行う。祖先ごとに pgrep を再帰呼び出しする方式は
+# 子孫数に比例して fork コストが線形に積み上がるため避ける
+collect_descendant_pids() {
+    local root_pid="$1"
+    ps -eo pid,ppid --no-headers 2>/dev/null | awk -v root="$root_pid" '
+        { ppid[$1] = $2 }
+        END {
+            queue[1] = root
+            qlen = 1
+            print root
+            seen[root] = 1
+            for (i = 1; i <= qlen; i++) {
+                cur = queue[i]
+                for (p in ppid) {
+                    if (ppid[p] == cur && !(p in seen)) {
+                        print p
+                        seen[p] = 1
+                        qlen++
+                        queue[qlen] = p
+                    }
+                }
+            }
+        }
+    '
+}
+
+# tmux セッション名から、対応する codex プロセス群が書き込んでいる rollout jsonl の
+# パスを特定する。Codex には Claude Code の sessions/<pid>.json のような
+# pid→セッション対応表が存在しないため、pane の pid とその子孫すべての
+# オープン fd を走査し、rollout-*.jsonl を指しているものを集めた上で、
+# 最終更新時刻が最も新しいもの(実際に追記され続けている rollout)を選ぶ。
+# fd ごとに readlink -f を fork する方式は procfs 上のソケット・パイプ等の
+# 無関係な fd も含めて全数チェックしてしまい低速なため、find -lname による
+# シンボリックリンク先パターンマッチ 1 回にまとめている
+resolve_rollout_path() {
+    local session="$1" pane_pid home_real fd_dirs=() pid best_path best_mtime target mtime
+
+    # tmux はターゲットが "0" のような裸の数字だと、セッション名ではなく
+    # 「未指定」とみなして現在アクティブなセッションへフォールバックしてしまう
+    # ため、末尾に ":" を付けてセッション名指定であることを明示する
+    pane_pid=$(tmux display-message -t "${session}:" -p '#{pane_pid}' 2>/dev/null) || return 1
+    [ -n "$pane_pid" ] || return 1
+
+    # readlink -f はシンボリックリンクを最後まで解決した絶対パスを返すため、$HOME 自体に
+    # シンボリックリンク成分が含まれる環境ではそのまま比較すると常に不一致になる。
+    # 比較対象も同じ readlink -f で正規化しておく
+    home_real=$(readlink -f "$HOME" 2>/dev/null) || home_real="$HOME"
+
+    for pid in $(collect_descendant_pids "$pane_pid"); do
+        [ -d "/proc/$pid/fd" ] && fd_dirs+=("/proc/$pid/fd")
+    done
+    [ "${#fd_dirs[@]}" -gt 0 ] || return 1
+
+    best_path=""
+    best_mtime=-1
+    while IFS= read -r target; do
+        [ -n "$target" ] || continue
+        mtime=$(stat -c %Y "$target" 2>/dev/null) || continue
+        if [ "$mtime" -gt "$best_mtime" ]; then
+            best_mtime="$mtime"
+            best_path="$target"
+        fi
+    done < <(find "${fd_dirs[@]}" -lname "${home_real}/.codex/sessions/*/*/*/rollout-*.jsonl" -printf '%l\n' 2>/dev/null)
+
+    [ -n "$best_path" ] || return 1
+    echo "$best_path"
+}
+
+# rollout jsonl の直近のイベントを見て、リミット到達中かどうかと再開予定時刻(epoch)を
+# 判定する。標準出力: "<status:0|1|2>\t<reset_epoch>\t<reset_text>"
+# status: 0 = リミットなし、1 = リミット到達中、2 = 判定不能(jsonl の走査対象範囲を
+# jq が解析できなかった等)。2 を 0 と区別せず返すと、解析エラーを「解除」と誤判定して
+# しまうため、呼び出し元(detect_limited_sessions)は 2 を resolve 失敗と同様に扱う
+check_limit_status() {
+    local jsonl="$1" tail_lines last_task_complete jq_exit is_err text completed_at
+    local token_line reset_epoch date_text
+
+    [ -f "$jsonl" ] || { printf '0\t-\t-\n'; return; }
+
+    # jsonl は会話全体で大きくなりうるが直近のイベントが分かればよいため、
+    # 末尾のみを走査対象にして cron の定期実行での毎回フルパースを避ける
+    tail_lines=$(tail -n 200 "$jsonl")
+
+    last_task_complete=$(echo "$tail_lines" | jq -c 'select(.type == "event_msg" and .payload.type == "task_complete")' 2>/dev/null)
+    jq_exit=$?
+    if [ "$jq_exit" -ne 0 ]; then
+        printf '2\t-\t-\n'
+        return
+    fi
+    last_task_complete=$(echo "$last_task_complete" | tail -1)
+    [ -n "$last_task_complete" ] || { printf '0\t-\t-\n'; return; }
+
+    is_err=$(echo "$last_task_complete" | jq -r '(.payload.error != null) and (.payload.error.codex_error_info == "usage_limit_exceeded")' 2>/dev/null)
+    if [ "$is_err" != "true" ]; then
+        printf '0\t-\t-\n'
+        return
+    fi
+
+    text=$(echo "$last_task_complete" | jq -r '.payload.error.message // ""' 2>/dev/null)
+    # text は会話ログ由来の自由形式文字列。タブ・改行を含み得るため、そのまま
+    # 状態ファイル(タブ区切り 1 行 1 レコード)へ埋め込むとレコード構造が壊れる。
+    # 通知文言としての可読性は保ったまま、区切り文字だけを空白に置き換える
+    text=$(echo "$text" | tr '\t\n' '  ')
+    completed_at=$(echo "$last_task_complete" | jq -r '.payload.completed_at // empty' 2>/dev/null)
+
+    token_line=$(echo "$tail_lines" | jq -c 'select(.type == "event_msg" and .payload.type == "token_count")' 2>/dev/null | tail -1)
+    reset_epoch=""
+    if [ -n "$token_line" ]; then
+        # primary/secondary のうち実際に上限(100%)へ達しているウィンドウの resets_at を
+        # 優先する。無条件に primary を優先すると、primary がまだ余裕のある状態で
+        # secondary (weekly 等) が先に上限に達しているケースの再開予定時刻を取り違える
+        reset_epoch=$(echo "$token_line" | jq -r '
+            .payload.rate_limits as $rl
+            | if (($rl.primary.used_percent // 0) >= 100) then $rl.primary.resets_at
+              elif (($rl.secondary.used_percent // 0) >= 100) then $rl.secondary.resets_at
+              else ($rl.primary.resets_at // $rl.secondary.resets_at)
+              end
+            // empty
+        ' 2>/dev/null)
+    fi
+
+    if ! [[ "$reset_epoch" =~ ^[0-9]+$ ]]; then
+        # 取得できない場合のみ payload.error.message 内の "try again at ..." という
+        # 日付文言をフォールバックとしてパースする(序数接尾辞 st/nd/rd/th は
+        # date -d が解釈できないため事前に取り除く)
+        date_text=$(echo "$text" | grep -oiE 'try again at [^.]+' | sed -E 's/^[Tt]ry again at //')
+        date_text=$(echo "$date_text" | sed -E 's/([0-9]+)(st|nd|rd|th)/\1/')
+        if [ -n "$date_text" ]; then
+            reset_epoch=$(date -d "$date_text" +%s 2>/dev/null)
+        fi
+    fi
+
+    if ! [[ "$reset_epoch" =~ ^[0-9]+$ ]]; then
+        # それも失敗した場合は completed_at + 24 時間を仮の再開予定とする
+        if [[ "$completed_at" =~ ^[0-9]+$ ]]; then
+            reset_epoch=$((completed_at + 24 * 3600))
+        else
+            reset_epoch=""
+        fi
+    fi
+
+    printf '1\t%s\t%s\n' "${reset_epoch:--}" "$text"
+}
+
+# resolve_rollout_path の特定失敗(または check_limit_status の判定不能)が
+# 連続して何回続いているかを保持するファイルのパス。プロセス終了などで恒久的に
+# 特定不能になったセッションを、前回記録のまま無期限に引き継ぎ続けないための
+# カウンタとして使う
+resolve_failure_count_file() {
+    echo "$HOME/.codex/scripts/limit-unlocked/data/resolve_failures.txt"
+}
+
+get_resolve_failure_count() {
+    local session="$1" file count
+    file=$(resolve_failure_count_file)
+    [ -f "$file" ] || { echo 0; return; }
+    count=$(awk -F'\t' -v s="$session" '$1 == s { print $2; exit }' "$file")
+    [[ "$count" =~ ^[0-9]+$ ]] && echo "$count" || echo 0
+}
+
+set_resolve_failure_count() {
+    local session="$1" count="$2" file tmp_file
+    file=$(resolve_failure_count_file)
+    mkdir -p "$(dirname "$file")"
+    touch "$file"
+    tmp_file="${file}.tmp.$$"
+    if [ "$count" -le 0 ]; then
+        awk -F'\t' -v s="$session" '$1 != s { print }' "$file" > "$tmp_file"
+    else
+        { awk -F'\t' -v s="$session" '$1 != s { print }' "$file"; printf '%s\t%s\n' "$session" "$count"; } > "$tmp_file"
+    fi
+    mv "$tmp_file" "$file"
+}
+
+# 前回記録(STATE_FILE)の該当セッション行を、confirmed=0(このポーリングでは
+# 再検証できていない)として $NEW_STATE_FILE へ引き継ぐ。連続失敗回数が閾値を
+# 超えた場合は引き継がず(=解除として扱う)、カウンタもリセットする
+carry_forward_previous_entry() {
+    local session="$1"
+    local -r max_resolve_failures=12 # 5 分間隔の cron で概ね 1 時間相当
+    local failure_count
+
+    failure_count=$(($(get_resolve_failure_count "$session") + 1))
+    if [ "$failure_count" -ge "$max_resolve_failures" ]; then
+        set_resolve_failure_count "$session" 0
+        return
+    fi
+    set_resolve_failure_count "$session" "$failure_count"
+
+    awk -F'\t' -v s="$session" '$1 == s { print $1"\t"$2"\t"$3"\t"$4"\t0"; exit }' "$STATE_FILE" >> "$NEW_STATE_FILE"
+}
+
+# 現在リミット中の tmux セッション一覧を検出し、$NEW_STATE_FILE に書き出す。
+# 各行は "<session>\t<cwd>\t<reset_epoch>\t<reset_text>\t<confirmed:0|1>" の形式。
+# confirmed=1 は今回のポーリングで実際に is_limited=1 と確認できたことを示し、
+# confirmed=0 は特定失敗・判定不能により前回の記録を引き継いだだけであることを示す
+# (呼び出し元は confirmed=1 の場合のみ resume_session を試みる)。
+# tmux セッション一覧の取得自体に失敗した場合は終了コード 1 を返し、
+# $NEW_STATE_FILE を書き換えない(呼び出し元は前回の STATE_FILE をそのまま使う)
+detect_limited_sessions() {
+    local sessions list_exit jsonl status_line status reset_epoch reset_text cwd session
+
+    sessions=$(tmux list-sessions -F "#{session_name}" 2>/dev/null)
+    list_exit=$?
+    if [ "$list_exit" -ne 0 ] && [ -s "$STATE_FILE" ]; then
+        # tmux セッション一覧の取得自体に失敗しており(cron 環境の TMUX_TMPDIR 不一致等)、
+        # かつ前回追跡中のセッションが存在した場合、実際にセッションが消えたのか
+        # 単なる列挙失敗なのか区別できない。誤って全セッションを「解除」と
+        # 判定してしまわないよう、この回の検出結果は使わない
+        return 1
+    fi
+
+    : > "$NEW_STATE_FILE"
+
+    for session in $sessions; do
+        jsonl=$(resolve_rollout_path "$session")
+        if [ -z "$jsonl" ]; then
+            # fd 走査は他ツール実行中のプロセス入れ替わり等で一時的に失敗しうる
+            carry_forward_previous_entry "$session"
+            continue
+        fi
+
+        status_line=$(check_limit_status "$jsonl")
+        IFS=$'\t' read -r status reset_epoch reset_text <<< "$status_line"
+        if [ "$status" = "2" ]; then
+            # jq がこのポーリングの走査対象範囲を解析できなかった(判定不能)。
+            # 「リミットなし」と誤判定すると解除通知が誤って飛んでしまうため、
+            # resolve 失敗と同様に前回の記録を引き継ぐ
+            carry_forward_previous_entry "$session"
+            continue
+        fi
+        [ "$status" = "1" ] || { set_resolve_failure_count "$session" 0; continue; }
+        set_resolve_failure_count "$session" 0
+
+        cwd=$(tmux display-message -t "${session}:" -p '#{pane_current_path}' 2>/dev/null || echo "unknown")
+        printf '%s\t%s\t%s\t%s\t1\n' "$session" "$cwd" "$reset_epoch" "$reset_text" >> "$NEW_STATE_FILE"
+    done
+
+    sort -u "$NEW_STATE_FILE" -o "$NEW_STATE_FILE"
+    return 0
+}
+
+# reset_epoch を JST の可読文字列に変換する。数値でない・空の場合は "-" を返す
+format_jst() {
+    local epoch="$1"
+    [[ "$epoch" =~ ^[0-9]+$ ]] || { echo "-"; return; }
+    TZ="Asia/Tokyo" date -d "@${epoch}" "+%Y-%m-%d %H:%M JST" 2>/dev/null || echo "-"
+}
+
+# Discord Embed 通知を送信する。HTTP レスポンスが 2xx でない場合は失敗として
+# 終了コード 1 を返す(呼び出し元は通知の再送要否を判断できる)
+send_discord() {
+    local title="$1" description="$2" color="$3"
+    local content="" http_code payload
+
+    [ -n "$MENTION_USER_ID" ] && content="<@${MENTION_USER_ID}>"
+
+    payload=$(jq -n \
+        --arg content "$content" \
+        --arg title "$title" \
+        --arg description "$description" \
+        --argjson color "$color" \
+        '{content: $content, embeds: [{title: $title, description: $description, color: $color}]}'
+    )
+
+    http_code=$(curl -s -o /dev/null -w '%{http_code}' -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL")
+    if [[ ! "$http_code" =~ ^2 ]]; then
+        echo "send_discord: Discord notification failed (HTTP ${http_code:-unknown})" >&2
+        return 1
+    fi
+}
+
+# 「リミット到達」通知を送信済みかどうかを reset_epoch 単位で記録するファイルのパス。
+# STATE_FILE への記録は通知成否と無関係に確定してしまうため、送信失敗を独立に
+# 追跡し、次回ポーリングでの再送を可能にする
+notified_marker_file() {
+    echo "$HOME/.codex/scripts/limit-unlocked/data/notified_limited.txt"
+}
+
+already_notified_for() {
+    local session="$1" reset_epoch="$2" file recorded
+    file=$(notified_marker_file)
+    [ -f "$file" ] || return 1
+    recorded=$(awk -F'\t' -v s="$session" '$1 == s { print $2; exit }' "$file")
+    [ -n "$recorded" ] && [ "$recorded" = "$reset_epoch" ]
+}
+
+record_notified_for() {
+    local session="$1" reset_epoch="$2" file tmp_file
+    file=$(notified_marker_file)
+    mkdir -p "$(dirname "$file")"
+    touch "$file"
+    tmp_file="${file}.tmp.$$"
+    { awk -F'\t' -v s="$session" '$1 != s { print }' "$file"; printf '%s\t%s\n' "$session" "$reset_epoch"; } > "$tmp_file"
+    mv "$tmp_file" "$file"
+}
+
+# 同一の再開予定(reset_epoch)に対して resume_session を再送していないかを
+# reset_epoch 単位で記録するファイルのパス。Codex の check_limit_status は
+# event_msg/task_complete のみを見ており、送信した再開メッセージ自体は
+# task_complete を発生させないため、ターン完了までは最後の task_complete が
+# usage_limit_exceeded のまま残り続ける。この記録がないと、ターン完了までの間
+# 5 分ごとの cron 実行のたびに再開キーを送り続けてしまう
+resumed_marker_file() {
+    echo "$HOME/.codex/scripts/limit-unlocked/data/resumed_sessions.txt"
+}
+
+already_resumed_for() {
+    local session="$1" reset_epoch="$2" file recorded
+    file=$(resumed_marker_file)
+    [ -f "$file" ] || return 1
+    recorded=$(awk -F'\t' -v s="$session" '$1 == s { print $2; exit }' "$file")
+    [ -n "$recorded" ] && [ "$recorded" = "$reset_epoch" ]
+}
+
+record_resumed_for() {
+    local session="$1" reset_epoch="$2" file tmp_file
+    file=$(resumed_marker_file)
+    mkdir -p "$(dirname "$file")"
+    touch "$file"
+    tmp_file="${file}.tmp.$$"
+    { awk -F'\t' -v s="$session" '$1 != s { print }' "$file"; printf '%s\t%s\n' "$session" "$reset_epoch"; } > "$tmp_file"
+    mv "$tmp_file" "$file"
+}
+
+# 指定した tmux セッションに再開キーを送る。
+# ウィンドウ/ペイン番号を固定せずセッション名のみを指定し、tmux の base-index 設定
+# (0 始まりとは限らない)に依存せず常にアクティブなウィンドウ・ペインへ送信する
+#
+# Codex はリミット到達後もブロッキングメニューを表示せず(Claude Code の
+# "What do you want to do?" 相当の挙動はない)、入力プロンプトはそのまま
+# 使用可能であるため、Escape でメニューを閉じる処理は不要
+resume_session() {
+    local session="$1"
+
+    # "0" のような裸の数字セッション名は tmux に「未指定」とみなされ
+    # 現在のセッションへフォールバックしてしまうため、末尾に ":" を付けて
+    # セッション名指定であることを明示する(display-message と同様の理由)
+    tmux send-keys -t "${session}:" "<system-reminder>Codex's rate limit has been lifted. Continue the task you were working on before the interruption.</system-reminder>"
+    sleep 1
+    tmux send-keys -t "${session}:" Enter
+}
+
+# セッション名が対象ファイルに存在するか確認する
+session_recorded_in() {
+    local session="$1" file="$2"
+    awk -F'\t' -v s="$session" '$1 == s { found=1 } END { exit !found }' "$file" 2>/dev/null
+}
+
+# メイン処理: このファイルが直接実行された場合のみ実行する。
+# テスト等から source されたとき(BASH_SOURCE がスクリプト自身と一致しない)は
+# 関数定義のみを提供し、mkdir・Discord 通知・tmux 操作などの副作用は起こさない。
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+
+    mkdir -p "$HOME/.codex/scripts/limit-unlocked/data"
+    STATE_FILE="$HOME/.codex/scripts/limit-unlocked/data/limited_sessions.txt"
+    NEW_STATE_FILE="${STATE_FILE}.new"
+    touch "$STATE_FILE"
+
+    # shellcheck source=/dev/null
+    source ./.env
+
+    if detect_limited_sessions; then
+        now=$(date +%s)
+
+        # 新規にリミットへ到達したセッションを通知する
+        while IFS=$'\t' read -r session cwd reset_epoch reset_text confirmed; do
+            [ -n "$session" ] || continue
+            if ! already_notified_for "$session" "$reset_epoch"; then
+                echo "Limit detected: $session ($cwd)"
+                description="${cwd} (session: ${session}) が利用制限に達しました。"
+                description="${description}"$'\n'"再開予定: $(format_jst "$reset_epoch")"
+                [ -n "$reset_text" ] && [ "$reset_text" != "-" ] && description="${description}"$'\n'"${reset_text}"
+                if send_discord \
+                    "Codex CLI のリミット到達" \
+                    "$description" \
+                    15158332 # 赤系色
+                then
+                    record_notified_for "$session" "$reset_epoch"
+                fi
+            fi
+
+            # confirmed=1(このポーリングで実際にリミット中と確認できた)場合のみ
+            # 再開を試みる。confirmed=0 の引き継ぎ行は未検証のため対象にしない
+            if [ "$confirmed" = "1" ] && [[ "$reset_epoch" =~ ^[0-9]+$ ]] && [ "$now" -ge "$reset_epoch" ]; then
+                if ! already_resumed_for "$session" "$reset_epoch"; then
+                    echo "Resuming: $session ($cwd)"
+                    resume_session "$session"
+                    record_resumed_for "$session" "$reset_epoch"
+                fi
+            fi
+        done < "$NEW_STATE_FILE"
+
+        # リミットが解除された(前回は記録されていたが今回は検出されなかった)セッションを通知する
+        while IFS=$'\t' read -r session cwd reset_epoch reset_text confirmed; do
+            [ -n "$session" ] || continue
+            session_recorded_in "$session" "$NEW_STATE_FILE" && continue # まだリミット中
+
+            if tmux has-session -t "${session}:" 2>/dev/null; then
+                echo "Limit unlocked: $session ($cwd)"
+                send_discord \
+                    "Codex CLI のリミット解除" \
+                    "${cwd} (session: ${session}) のリミットが解除されました。" \
+                    5814783 # 青系色
+            fi
+        done < "$STATE_FILE"
+
+        mv "$NEW_STATE_FILE" "$STATE_FILE"
+    else
+        echo "detect_limited_sessions: tmux session enumeration appears unreliable this run; preserving previous state" >&2
+    fi
+fi

--- a/home/dot_env.example
+++ b/home/dot_env.example
@@ -39,6 +39,15 @@ DISCORD_CODEX_WEBHOOK="https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEB
 DISCORD_CODEX_MENTION_USER_ID=""
 
 # -----------------------------------------
+# Discord Webhooks - Codex CLI limit-unlocked
+# -----------------------------------------
+# Codex CLI の制限解除を通知する Webhook URL
+DISCORD_CODEX_LIMIT_WEBHOOK="https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+
+# Discord でメンションするユーザー ID（オプション）
+DISCORD_CODEX_LIMIT_MENTION_USER_ID=""
+
+# -----------------------------------------
 # Trilium Notes - ドキュメントアップロード用
 # -----------------------------------------
 # Trilium サーバーの HTTP ベース URL（末尾スラッシュなし）

--- a/tests/unit/test_notifications.sh
+++ b/tests/unit/test_notifications.sh
@@ -15,6 +15,7 @@ NOTIFICATION_SCRIPTS=(
   "home/dot_claude/scripts/completion-notify/executable_notify-permission-request.sh"
   "home/dot_claude/scripts/completion-notify/executable_notify-user-prompt-submit.sh"
   "home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh"
+  "home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
   "home/dot_codex/scripts/completion-notify/executable_send-discord-notification.sh"
   "home/dot_codex/scripts/completion-notify/executable_notify-completion.sh"
   "home/dot_codex/scripts/completion-notify/executable_notify-permission-request.sh"
@@ -91,7 +92,15 @@ TEST_HOME=$(mktemp -d)
 TEST_BIN_DIR=$(mktemp -d)
 mkdir -p "$TEST_HOME/.claude/sessions"
 
-CLAUDE_CONFIG_DIR="$TEST_HOME/.claude" sleep 60 &
+# resolve_claude_pid は /proc/<pid>/comm が実際に "claude" であることを検証するため、
+# 単なる sleep ではなく "claude" という名前の実行ファイルとして起動する
+cat > "$TEST_BIN_DIR/claude" <<'EOF'
+#!/bin/bash
+sleep 60
+EOF
+chmod +x "$TEST_BIN_DIR/claude"
+
+CLAUDE_CONFIG_DIR="$TEST_HOME/.claude" "$TEST_BIN_DIR/claude" &
 FAKE_CLAUDE_PID=$!
 echo '{}' > "$TEST_HOME/.claude/sessions/${FAKE_CLAUDE_PID}.json"
 
@@ -107,7 +116,13 @@ chmod +x "$TEST_BIN_DIR/tmux"
 
 cat > "$TEST_BIN_DIR/pgrep" <<EOF
 #!/bin/bash
-echo "$FAKE_CLAUDE_PID"
+# collect_descendant_pids は pane pid から再帰的に子を辿るため、pane pid (12345)
+# へのクエリにのみ子として \$FAKE_CLAUDE_PID を返し、それ以外(\$FAKE_CLAUDE_PID 自身
+# への再帰クエリ含む)には子なしを返して探索を打ち切る
+if [[ "\$2" == "12345" ]]; then
+  echo "$FAKE_CLAUDE_PID"
+fi
+exit 0
 EOF
 chmod +x "$TEST_BIN_DIR/pgrep"
 
@@ -128,6 +143,59 @@ else
   echo "✅ resolve_config_dir resolved the mocked claude process's CLAUDE_CONFIG_DIR"
 fi
 rm -rf "$TEST_HOME" "$TEST_BIN_DIR"
+
+echo "Testing resolve_claude_pid matches a claude process invoked via a resolved absolute path, even as a grandchild of the pane pid..."
+TEST_BIN_DIR=$(mktemp -d)
+
+# 実際の cron ジョブ (CLAUDE_BIN="$(command -v claude)"; ... "$CLAUDE_BIN" ...) を模し、
+# 絶対パスで実行される実体を「claude」という名前の実ファイルとして用意する。
+# Linux では shebang スクリプトの comm はインタプリタ名ではなく実行された
+# ファイルのベース名になるため、この方法で実際の comm=claude プロセスを再現できる
+cat > "$TEST_BIN_DIR/claude" <<'EOF'
+#!/bin/bash
+sleep 60
+EOF
+chmod +x "$TEST_BIN_DIR/claude"
+
+# pane pid 自体ではなく、その子プロセス(ラッパー)がさらに claude を起動する
+# 孫プロセスの構成にして、collect_descendant_pids の再帰走査を検証する
+PIDFILE=$(mktemp)
+bash -c '
+  "'"$TEST_BIN_DIR"'/claude" &
+  echo $! > "'"$PIDFILE"'"
+  wait
+' &
+WRAPPER_PID=$!
+sleep 0.3
+CLAUDE_PID=$(cat "$PIDFILE")
+
+cat > "$TEST_BIN_DIR/tmux" <<EOF
+#!/bin/bash
+if [[ "\$1" == "display-message" ]]; then
+  echo "$WRAPPER_PID"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$TEST_BIN_DIR/tmux"
+
+RESULT=$(
+  PATH="$TEST_BIN_DIR:$PATH" bash -c '
+    source "'"$PWD"'/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh"
+    resolve_claude_pid "dummy-session"
+  '
+)
+
+kill "$CLAUDE_PID" "$WRAPPER_PID" 2>/dev/null || true
+wait "$WRAPPER_PID" 2>/dev/null || true
+
+if [[ "$RESULT" != "$CLAUDE_PID" ]]; then
+  echo "❌ resolve_claude_pid did not find the path-invoked, grandchild claude process (got: '$RESULT', want: '$CLAUDE_PID')"
+  FAILED=1
+else
+  echo "✅ resolve_claude_pid found the path-invoked claude process via comm, even as a grandchild of the pane pid"
+fi
+rm -rf "$TEST_BIN_DIR" "$PIDFILE"
 
 echo "Testing fetch_usage_status..."
 TEST_HOME=$(mktemp -d)
@@ -493,6 +561,294 @@ else
 fi
 
 rm -rf "$TEST_HOME"
+
+echo "Testing Codex check-notify.sh is safely sourceable (no side effects)..."
+TEST_HOME=$(mktemp -d)
+if ! (
+  HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    if declare -p STATE_FILE >/dev/null 2>&1; then
+      echo "STATE_FILE should not be set when sourced" >&2
+      exit 1
+    fi
+    if ! declare -F resolve_rollout_path >/dev/null 2>&1; then
+      echo "resolve_rollout_path should be defined after sourcing" >&2
+      exit 1
+    fi
+  '
+); then
+  echo "❌ Codex check-notify.sh executed main logic (or failed) when sourced"
+  FAILED=1
+else
+  echo "✅ Codex check-notify.sh only defines functions when sourced"
+fi
+if [ -d "$TEST_HOME/.codex/scripts/limit-unlocked/data" ]; then
+  echo "❌ Codex check-notify.sh created state directory as a side effect of sourcing"
+  FAILED=1
+fi
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex check_limit_status parses a usage_limit_exceeded task_complete with a token_count resets_at..."
+TEST_HOME=$(mktemp -d)
+FIXTURE_JSONL="$TEST_HOME/fixture-rollout.jsonl"
+cat > "$FIXTURE_JSONL" <<'EOF'
+{"timestamp":"2026-08-02T11:47:20.000Z","type":"event_msg","payload":{"type":"token_count","info":{},"rate_limits":{"limit_id":"codex","limit_name":null,"primary":{"used_percent":100.0,"window_minutes":10080,"resets_at":1786165193},"secondary":null,"credits":{"has_credits":false,"unlimited":false,"balance":"0"},"individual_limit":null,"spend_control_reached":null,"plan_type":"plus","rate_limit_reached_type":null}}}
+{"timestamp":"2026-08-02T11:47:24.660Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":null,"error":{"message":"You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 1:59 PM.","codex_error_info":"usage_limit_exceeded"},"started_at":1785671243,"completed_at":1785671244,"duration_ms":1410}}
+EOF
+
+RESULT=$(
+  bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    check_limit_status "'"$FIXTURE_JSONL"'"
+  '
+)
+IFS=$'\t' read -r is_limited reset_epoch reset_text <<< "$RESULT"
+
+if [[ "$is_limited" != "1" ]]; then
+  echo "❌ check_limit_status did not detect a usage_limit_exceeded task_complete (got: '$RESULT')"
+  FAILED=1
+else
+  echo "✅ check_limit_status detected a usage_limit_exceeded task_complete"
+fi
+
+if [[ "$reset_epoch" != "1786165193" ]]; then
+  echo "❌ check_limit_status did not use the token_count rate_limits.primary.resets_at epoch (got: '$reset_epoch')"
+  FAILED=1
+else
+  echo "✅ check_limit_status used the token_count rate_limits.primary.resets_at epoch"
+fi
+
+if [[ "$reset_text" != *"usage limit"* ]]; then
+  echo "❌ check_limit_status did not carry through the error message text (got: '$reset_text')"
+  FAILED=1
+else
+  echo "✅ check_limit_status carried through the error message text"
+fi
+
+echo "Testing Codex check_limit_status treats error:null task_complete as not limited..."
+FIXTURE_JSONL_OK="$TEST_HOME/fixture-rollout-ok.jsonl"
+cat > "$FIXTURE_JSONL_OK" <<'EOF'
+{"timestamp":"2026-08-02T11:50:00.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t2","last_agent_message":"done","error":null,"started_at":1785671300,"completed_at":1785671301,"duration_ms":900}}
+EOF
+
+RESULT_OK=$(
+  bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    check_limit_status "'"$FIXTURE_JSONL_OK"'"
+  '
+)
+
+if [[ "$RESULT_OK" != $'0\t-\t-' ]]; then
+  echo "❌ check_limit_status incorrectly reported a limited state for an error:null task_complete (got: '$RESULT_OK')"
+  FAILED=1
+else
+  echo "✅ check_limit_status correctly reported not-limited for an error:null task_complete"
+fi
+
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex resolve_rollout_path discovers the rollout jsonl via /proc fd scan and picks the newest mtime..."
+TEST_HOME=$(mktemp -d)
+TEST_HOME=$(readlink -f "$TEST_HOME") # /proc/<pid>/fd の readlink -f 結果と文字列比較できるよう正規化する
+TEST_BIN_DIR=$(mktemp -d)
+mkdir -p "$TEST_HOME/.codex/sessions/2026/08/02"
+
+OLD_ROLLOUT="$TEST_HOME/.codex/sessions/2026/08/02/rollout-1785660000-old.jsonl"
+NEW_ROLLOUT="$TEST_HOME/.codex/sessions/2026/08/02/rollout-1785671200-new.jsonl"
+echo '{}' > "$OLD_ROLLOUT"
+touch -d "-1 hour" "$OLD_ROLLOUT"
+echo '{}' > "$NEW_ROLLOUT"
+
+# 実際に fd を開いたまま維持するバックグラウンドプロセスを立て、fd スキャンが
+# 実プロセスの /proc/<pid>/fd を正しく辿れることを end-to-end で検証する
+# (同一 pid が複数の rollout fd を開いたままにする、という実運用のケースを再現する)。
+# 新しい方の rollout を若い fd 番号(3)に、古い方を後の fd 番号(4)に割り当てることで、
+# /proc/<pid>/fd の走査順(数字の小さい順)と mtime の新旧が逆になるようにし、
+# 「単に最後に見つかったものを採用する」実装ではこのテストを通せないようにする
+bash -c "exec 3<'$NEW_ROLLOUT' 4<'$OLD_ROLLOUT'; sleep 60" &
+FAKE_CODEX_PID=$!
+sleep 0.2
+
+cat > "$TEST_BIN_DIR/tmux" <<EOF
+#!/bin/bash
+if [[ "\$1" == "display-message" ]]; then
+  echo "$FAKE_CODEX_PID"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$TEST_BIN_DIR/tmux"
+
+RESULT=$(
+  PATH="$TEST_BIN_DIR:$PATH" HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    resolve_rollout_path "dummy-session"
+  '
+)
+
+kill "$FAKE_CODEX_PID" 2>/dev/null || true
+wait "$FAKE_CODEX_PID" 2>/dev/null || true
+
+if [[ "$RESULT" != "$NEW_ROLLOUT" ]]; then
+  echo "❌ resolve_rollout_path did not pick the rollout jsonl with the newest mtime via /proc fd scan (got: '$RESULT', want: '$NEW_ROLLOUT')"
+  FAILED=1
+else
+  echo "✅ resolve_rollout_path discovered the rollout jsonl via /proc fd scan and picked the newest mtime"
+fi
+
+rm -rf "$TEST_HOME" "$TEST_BIN_DIR"
+
+echo "Testing Codex check_limit_status reports status=2 (undetermined) when jq fails to parse the scanned window..."
+TEST_HOME=$(mktemp -d)
+FIXTURE_JSONL_BROKEN="$TEST_HOME/fixture-rollout-broken.jsonl"
+printf '{not valid json\n' > "$FIXTURE_JSONL_BROKEN"
+
+RESULT_BROKEN=$(
+  bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    check_limit_status "'"$FIXTURE_JSONL_BROKEN"'"
+  '
+)
+
+if [[ "$RESULT_BROKEN" != $'2\t-\t-' ]]; then
+  echo "❌ check_limit_status did not report status=2 for an unparseable jsonl window (got: '$RESULT_BROKEN')"
+  FAILED=1
+else
+  echo "✅ check_limit_status reported status=2 (undetermined) instead of silently treating a parse failure as not-limited"
+fi
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex check_limit_status prefers the rate-limit window actually at 100% used_percent over an unconditional primary preference..."
+TEST_HOME=$(mktemp -d)
+FIXTURE_JSONL_SECONDARY="$TEST_HOME/fixture-rollout-secondary.jsonl"
+cat > "$FIXTURE_JSONL_SECONDARY" <<'EOF'
+{"timestamp":"2026-08-02T11:47:20.000Z","type":"event_msg","payload":{"type":"token_count","info":{},"rate_limits":{"limit_id":"codex","limit_name":null,"primary":{"used_percent":40.0,"window_minutes":300,"resets_at":1111111111},"secondary":{"used_percent":100.0,"window_minutes":10080,"resets_at":2222222222},"credits":{"has_credits":false,"unlimited":false,"balance":"0"},"individual_limit":null,"spend_control_reached":null,"plan_type":"plus","rate_limit_reached_type":null}}}
+{"timestamp":"2026-08-02T11:47:24.660Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":null,"error":{"message":"usage limit hit","codex_error_info":"usage_limit_exceeded"},"started_at":1785671243,"completed_at":1785671244,"duration_ms":1410}}
+EOF
+
+RESULT_SECONDARY=$(
+  bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    check_limit_status "'"$FIXTURE_JSONL_SECONDARY"'"
+  '
+)
+IFS=$'\t' read -r _ reset_epoch_secondary _ <<< "$RESULT_SECONDARY"
+
+if [[ "$reset_epoch_secondary" != "2222222222" ]]; then
+  echo "❌ check_limit_status did not prefer the secondary window's resets_at even though only secondary is at 100% used_percent (got: '$reset_epoch_secondary')"
+  FAILED=1
+else
+  echo "✅ check_limit_status preferred the at-cap secondary window's resets_at over an unconditional primary preference"
+fi
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex already_resumed_for / record_resumed_for dedup resume_session for the same reset_epoch..."
+TEST_HOME=$(mktemp -d)
+RESULT_RESUME_DEDUP=$(
+  HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    already_resumed_for "sess-1" "1700000000" && echo "unexpected-already-resumed"
+    record_resumed_for "sess-1" "1700000000"
+    already_resumed_for "sess-1" "1700000000" && echo "resumed-for-same-epoch"
+    already_resumed_for "sess-1" "1700000001" || echo "not-resumed-for-different-epoch"
+  '
+)
+if [[ "$RESULT_RESUME_DEDUP" != $'resumed-for-same-epoch\nnot-resumed-for-different-epoch' ]]; then
+  echo "❌ already_resumed_for/record_resumed_for did not correctly dedup resume attempts per reset_epoch (got: '$RESULT_RESUME_DEDUP')"
+  FAILED=1
+else
+  echo "✅ already_resumed_for/record_resumed_for correctly dedup resume attempts keyed by reset_epoch"
+fi
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex already_notified_for / record_notified_for dedup Discord notifications for the same reset_epoch..."
+TEST_HOME=$(mktemp -d)
+RESULT_NOTIFY_DEDUP=$(
+  HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    already_notified_for "sess-1" "1700000000" && echo "unexpected-already-notified"
+    record_notified_for "sess-1" "1700000000"
+    already_notified_for "sess-1" "1700000000" && echo "notified-for-same-epoch"
+    already_notified_for "sess-1" "1700000001" || echo "not-notified-for-different-epoch"
+  '
+)
+if [[ "$RESULT_NOTIFY_DEDUP" != $'notified-for-same-epoch\nnot-notified-for-different-epoch' ]]; then
+  echo "❌ already_notified_for/record_notified_for did not correctly dedup notifications per reset_epoch (got: '$RESULT_NOTIFY_DEDUP')"
+  FAILED=1
+else
+  echo "✅ already_notified_for/record_notified_for correctly dedup notifications keyed by reset_epoch"
+fi
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex send_discord returns failure on a non-2xx HTTP response instead of silently swallowing it..."
+TEST_BIN_DIR=$(mktemp -d)
+cat > "$TEST_BIN_DIR/curl" <<'EOF'
+#!/bin/bash
+echo -n "500"
+EOF
+chmod +x "$TEST_BIN_DIR/curl"
+
+if PATH="$TEST_BIN_DIR:$PATH" bash -c '
+  source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+  DISCORD_WEBHOOK_URL="https://example.invalid/webhook"
+  send_discord "title" "description" 123
+' 2>/dev/null; then
+  echo "❌ send_discord did not report failure for a non-2xx Discord HTTP response"
+  FAILED=1
+else
+  echo "✅ send_discord reported failure for a non-2xx Discord HTTP response"
+fi
+rm -rf "$TEST_BIN_DIR"
+
+echo "Testing Codex carry_forward_previous_entry drops a session after enough consecutive resolve failures instead of preserving it forever..."
+TEST_HOME=$(mktemp -d)
+STATE_FILE_STALE="$TEST_HOME/limited_sessions.txt"
+NEW_STATE_FILE_STALE="${STATE_FILE_STALE}.new"
+printf 'stale-sess\t/tmp/proj\t1111111111\tsome text\t1\n' > "$STATE_FILE_STALE"
+: > "$NEW_STATE_FILE_STALE"
+
+RESULT_STALE=$(
+  HOME="$TEST_HOME" STATE_FILE="$STATE_FILE_STALE" NEW_STATE_FILE="$NEW_STATE_FILE_STALE" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    for _ in $(seq 1 12); do
+      : > "$NEW_STATE_FILE"
+      carry_forward_previous_entry "stale-sess"
+    done
+    cat "$NEW_STATE_FILE"
+  '
+)
+
+if [[ -n "$RESULT_STALE" ]]; then
+  echo "❌ carry_forward_previous_entry kept carrying a session forward past the consecutive-failure threshold (got: '$RESULT_STALE')"
+  FAILED=1
+else
+  echo "✅ carry_forward_previous_entry stopped carrying a session forward after the consecutive-failure threshold was reached"
+fi
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex detect_limited_sessions preserves STATE_FILE when tmux list-sessions itself fails..."
+TEST_HOME=$(mktemp -d)
+TEST_BIN_DIR=$(mktemp -d)
+STATE_FILE_ENUM_FAIL="$TEST_HOME/limited_sessions.txt"
+NEW_STATE_FILE_ENUM_FAIL="${STATE_FILE_ENUM_FAIL}.new"
+printf 'tracked-sess\t/tmp/proj\t1111111111\tsome text\t1\n' > "$STATE_FILE_ENUM_FAIL"
+
+cat > "$TEST_BIN_DIR/tmux" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$TEST_BIN_DIR/tmux"
+
+if PATH="$TEST_BIN_DIR:$PATH" HOME="$TEST_HOME" STATE_FILE="$STATE_FILE_ENUM_FAIL" NEW_STATE_FILE="$NEW_STATE_FILE_ENUM_FAIL" bash -c '
+  source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+  detect_limited_sessions
+'; then
+  echo "❌ detect_limited_sessions did not report failure when tmux list-sessions failed with existing tracked state"
+  FAILED=1
+else
+  echo "✅ detect_limited_sessions reported failure instead of silently wiping tracked state when tmux list-sessions failed"
+fi
+rm -rf "$TEST_HOME" "$TEST_BIN_DIR"
 
 if [ $FAILED -eq 0 ]; then
   echo "✅ All notification script tests passed"


### PR DESCRIPTION
## 概要

Claude Code のリミット監視スクリプトの不具合修正と、Codex CLI 向けの同等のリミット監視・自動再開機能の新設を行う。

## 修正: Claude Code のリミット検出漏れ

`resolve_claude_pid` が pane pid の子孫プロセスを再帰的に列挙し、`/proc/<pid>/comm` が `claude` と一致するものを探す方式に変更する。cron ジョブが `CLAUDE_BIN="$(command -v claude)"` のように解決した絶対パスで claude を起動する場合や、シェルのラッパー経由で claude が孫プロセスとして起動される場合も検出できるようにする。

## 新機能: Codex CLI 向けリミット監視 (`home/dot_codex/scripts/limit-unlocked/`)

Codex CLI の tmux セッションについて、rollout jsonl (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`) 内の構造化イベントからリミット到達・解除を検出し、Discord 通知とセッション再開を行う。

- 子孫プロセスの列挙は `ps -eo pid,ppid` 1 回の呼び出しと awk での木構築にまとめ、fork コストを抑える
- fd の走査は `find -lname` によるシンボリックリンク先パターンマッチ 1 回にまとめる
- `$HOME` はシンボリックリンクの可能性があるため `readlink -f` で正規化してから比較する
- jq のパース失敗は判定不能(status=2)として扱い、直前の状態を保持する(false unlock 防止)
- primary/secondary のレート制限ウィンドウは、実際に使用率 100% に達している方の `resets_at` を優先する
- `tmux list-sessions` 自体が失敗した場合は状態ファイルを空で上書きせず、既存の状態を保持する
- 解決不能なセッションは一定回数の連続失敗で持ち越しを打ち切る
- Discord 通知本文の組み立ては `printf` を使用する(`echo -e` はログ本文中のバックスラッシュエスケープを再展開してしまい、通知内容の偽装を招くため)
- `send_discord` は HTTP ステータスコードを確認し、送信失敗を検知する
- 同一 reset_epoch に対する Discord 通知・resume_session の重複実行をマーカーファイルで防ぐ

環境変数は `home/dot_codex/scripts/limit-unlocked/dot_env` と `home/dot_env.example` に追加する。

## テスト

- `tests/unit/test_notifications.sh` に Claude/Codex 双方の回帰テストを追加(全 47 件成功)
- `tests/syntax/test_bash_syntax.sh` / `tests/syntax/test_shellcheck.sh` 成功
