### PR TITLE
feat: コードコメントレビュー観点に issue/spec/plan 参照と経過情報の禁止を追加する

### DIFF
--- a/home/dot_agents/skills/deep-review/reviewers/e-code-comment-quality.md
+++ b/home/dot_agents/skills/deep-review/reviewers/e-code-comment-quality.md
@@ -14,6 +14,8 @@ Judge each comment against the Content layer "Code comments" allow/deny conditio
 - Redundant comments that merely restate what the code already makes obvious (e.g. a comment saying "increment i by 1" directly above `i++`).
 - Obvious descriptions or comments that can be removed without issue.
 - "What" comments and temporary progress-report comments left in the diff.
+- A comment justified by a GitHub Issue/PR number or a spec/plan file path instead of the code itself — flag this even if the reference still resolves, since it ties the comment's meaning to an external system that can change independently of the code.
+- A "why not" comment that includes the quantitative process behind its conclusion (sample counts, percentages, corpus sizes, benchmark numbers, verification steps) rather than stating only the conclusion.
 
 Also flag the following mechanical defects, independent of the allow/deny judgment above — these are about a comment's accuracy or formatting, not about whether it should exist:
 

--- a/home/dot_agents/skills/deep-review/reviewers/e-code-comment-quality.md
+++ b/home/dot_agents/skills/deep-review/reviewers/e-code-comment-quality.md
@@ -16,6 +16,7 @@ Judge each comment against the Content layer "Code comments" allow/deny conditio
 - "What" comments and temporary progress-report comments left in the diff.
 - A comment justified by a GitHub Issue/PR number or a spec/plan file path instead of the code itself — flag this even if the reference still resolves, since it ties the comment's meaning to an external system that can change independently of the code.
 - A "why not" comment that includes the quantitative process behind its conclusion (sample counts, percentages, corpus sizes, benchmark numbers, verification steps) rather than stating only the conclusion.
+- A comment sentence that needs more than one line break to fit — flag this as a signal that the sentence itself should be shortened (split into shorter sentences), not merely rewrapped. This is independent of the "line dramatically longer than surrounding comments" escape hatch used for the mid-sentence-break-placement check below — that escape hatch concerns where a break falls, not whether the sentence needed splitting in the first place.
 
 Also flag the following mechanical defects, independent of the allow/deny judgment above — these are about a comment's accuracy or formatting, not about whether it should exist:
 

--- a/home/dot_claude/rules/coding-common.md
+++ b/home/dot_claude/rules/coding-common.md
@@ -37,6 +37,7 @@ Rules that apply regardless of language.
     - Never add: comments that restate what the code already shows, comments that only repeat what a function/variable name already makes obvious, "what" comments (e.g. "initialize the value", "increment the counter"), or temporary progress-report comments.
     - Never add: a reference to a GitHub Issue/PR number or a spec/plan file path as the comment's justification — the tracker item can be renamed, closed, or deleted independently of the code, leaving the comment unverifiable.
     - When stating a why-not conclusion, keep only the conclusion itself — drop the quantitative process behind it (sample counts, percentages, corpus sizes, benchmark numbers, verification steps), since that detail goes stale independently of the code and cannot be re-verified later.
+    - If a single sentence needs more than one line break to fit, shorten the sentence itself instead of adding another break point — a sentence that keeps needing new breaks should be split into shorter sentences, not wrapped further.
     - Before finishing a task, review the comments you added or changed and remove any that fall under the "Never add" rules above.
   - **Test code** expresses *what*: test/spec names and assertions state the behavior being verified, not the internal implementation steps.
   - **Commit messages** express *why*: the description/body explains the motivation/reasoning for the change. The diff itself already shows *what* changed — do not restate it.

--- a/home/dot_claude/rules/coding-common.md
+++ b/home/dot_claude/rules/coding-common.md
@@ -35,7 +35,9 @@ Rules that apply regardless of language.
   - **Code comments** express *why not*: do not add comments by default.
     - Allowed only for: the reasoning behind the implementation choice (why this approach and not a rejected alternative), non-obvious constraints from the spec, security/performance/compatibility caveats, or assumptions likely to break in the future.
     - Never add: comments that restate what the code already shows, comments that only repeat what a function/variable name already makes obvious, "what" comments (e.g. "initialize the value", "increment the counter"), or temporary progress-report comments.
-    - Before finishing a task, review the comments you added or changed and remove any that fall under "Never add" above.
+    - Never add: a reference to a GitHub Issue/PR number or a spec/plan file path as the comment's justification — the tracker item can be renamed, closed, or deleted independently of the code, leaving the comment unverifiable.
+    - When stating a why-not conclusion, keep only the conclusion itself — drop the quantitative process behind it (sample counts, percentages, corpus sizes, benchmark numbers, verification steps), since that detail goes stale independently of the code and cannot be re-verified later.
+    - Before finishing a task, review the comments you added or changed and remove any that fall under the "Never add" rules above.
   - **Test code** expresses *what*: test/spec names and assertions state the behavior being verified, not the internal implementation steps.
   - **Commit messages** express *why*: the description/body explains the motivation/reasoning for the change. The diff itself already shows *what* changed — do not restate it.
 - Never leave edit-history notes (e.g. "Deleted X") in code — history belongs in commit messages / PRs

--- a/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
+++ b/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
@@ -16,6 +16,7 @@ Judge each comment against the Content layer "Code comments" allow/deny conditio
 - "What" comments and temporary progress-report comments left in the diff.
 - A comment whose justification is a GitHub Issue/PR number or a spec/plan file path rather than the code itself — flag this regardless of whether the reference still resolves, since it makes the comment's meaning depend on an external system that can change independently of the code.
 - A "why not" comment padded with the quantitative process behind its conclusion (sample counts, percentages, corpus sizes, benchmark numbers, verification steps) instead of stating only the conclusion.
+- A comment sentence that needs more than one line break to fit — flag it as a signal that the sentence itself should be shortened (split into shorter sentences), not merely rewrapped. This is independent of the "line dramatically longer than surrounding comments" escape hatch used for the mid-sentence-break-placement check below — that escape hatch is about where a break falls, not about whether the sentence needed splitting in the first place.
 
 Also flag the following mechanical defects, independent of the allow/deny judgment above — these are about a comment's accuracy or formatting, not about whether it should exist:
 

--- a/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
+++ b/home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md
@@ -14,6 +14,8 @@ Judge each comment against the Content layer "Code comments" allow/deny conditio
 - Redundant comments that merely restate what the code already makes obvious (e.g. a comment saying "increment i by 1" directly above `i++`).
 - Obvious descriptions or comments that can be removed without issue.
 - "What" comments and temporary progress-report comments left in the diff.
+- A comment whose justification is a GitHub Issue/PR number or a spec/plan file path rather than the code itself — flag this regardless of whether the reference still resolves, since it makes the comment's meaning depend on an external system that can change independently of the code.
+- A "why not" comment padded with the quantitative process behind its conclusion (sample counts, percentages, corpus sizes, benchmark numbers, verification steps) instead of stating only the conclusion.
 
 Also flag the following mechanical defects, independent of the allow/deny judgment above — these are about a comment's accuracy or formatting, not about whether it should exist:
 

--- a/home/dot_codex/references/coding-and-security.md
+++ b/home/dot_codex/references/coding-and-security.md
@@ -1,6 +1,6 @@
 # Coding and Security Rules
 
-- Keep each artifact to one information layer: code explains how, tests explain behavior, comments explain only non-obvious rationale or constraints, and commits explain motivation. Remove comments that restate code and never leave edit-history notes.
+- Keep each artifact to one information layer: code explains how, tests explain behavior, comments explain only non-obvious rationale or constraints, and commits explain motivation. Remove comments that restate code, never leave edit-history notes, never justify a comment with a GitHub Issue/PR number or a spec/plan file path, and state only the why-not conclusion — drop the sample counts, percentages, or verification steps behind it.
 - Match existing naming and error-message conventions. Keep a file's existing emoji convention consistent. Insert a half-width space between Japanese and alphanumeric text.
 - Never commit, log, or publish API keys, tokens, passwords, or internal URLs. If a secret is staged, stop and rotate it. Keep personal secrets outside chezmoi-managed files.
 - Avoid destructive commands without explicit user approval and a recovery plan; use dry-run options first. Do not run destructive database commands without a confirmed backup.

--- a/home/dot_codex/references/coding-and-security.md
+++ b/home/dot_codex/references/coding-and-security.md
@@ -1,6 +1,6 @@
 # Coding and Security Rules
 
-- Keep each artifact to one information layer: code explains how, tests explain behavior, comments explain only non-obvious rationale or constraints, and commits explain motivation. Remove comments that restate code, never leave edit-history notes, never justify a comment with a GitHub Issue/PR number or a spec/plan file path, and state only the why-not conclusion — drop the sample counts, percentages, or verification steps behind it.
+- Keep each artifact to one information layer: code explains how, tests explain behavior, comments explain only non-obvious rationale or constraints, and commits explain motivation. Remove comments that restate code, never leave edit-history notes, never justify a comment with a GitHub Issue/PR number or a spec/plan file path, state only the why-not conclusion — drop the sample counts, percentages, or verification steps behind it, and shorten a sentence that needs more than one line break instead of adding further break points.
 - Match existing naming and error-message conventions. Keep a file's existing emoji convention consistent. Insert a half-width space between Japanese and alphanumeric text.
 - Never commit, log, or publish API keys, tokens, passwords, or internal URLs. If a secret is staged, stop and rotate it. Keep personal secrets outside chezmoi-managed files.
 - Avoid destructive commands without explicit user approval and a recovery plan; use dry-run options first. Do not run destructive database commands without a confirmed backup.


### PR DESCRIPTION
## 概要

コードコメントレビュー観点(`e-code-comment-quality` レビュアー、および対応する共通ルール)に、tomacheese/twitter-accounts-classifier#30 で提案されたコメント規約のうち、既存のチェック項目でカバーされていなかった3点を追加する。

## 変更内容

- `home/dot_claude/rules/coding-common.md` の「Code comments」規約に、次の3つの禁止事項を追加する。
  - GitHub Issue/PR 番号や spec/plan ファイルパスをコメントの根拠にしない(参照先が改名・クローズ・削除されるとコメントが検証不能になるため)。
  - why not の結論を書く際は結論のみを残し、裏付けとなる検証件数・割合・ベンチマーク数値・検証手順などの経過情報は書かない(経過情報はコードと無関係に陳腐化し、後から再検証できないため)。
  - 一文が長すぎて複数回の改行が必要になる場合は、改行を増やすのではなく一文自体を短くする。
- `home/dot_codex/references/coding-and-security.md`(Codex 版の同等ルール)に同内容を追記する。
- `home/dot_claude/skills/deep-review/reviewers/e-code-comment-quality.md`(Claude Code 用 `deep-review`/`lite-review` が参照するレビュアー定義)にフラグ対象として同内容を追加する。
- `home/dot_agents/skills/deep-review/reviewers/e-code-comment-quality.md`(Codex 用の同等レビュアー定義)に同内容を追加する。

`lite-review`(Claude Code / Codex 双方)は上記レビュアー定義を参照で再利用するため、`lite-review` 側のファイルは変更していない。

## 検証

- `/deep-review`(ローカル diff モード)を実行し、findings なしを確認済み(docs-only 変更のため `a-claude-md-compliance` / `c-history-context` の2観点で実施)。
- CI(Bash Syntax Check、Chezmoi Configuration Verify、JSON Schema Validation、Shellcheck、Test chezmoi apply、Test chezmoi apply in Docker、Unit Tests)がすべてパスすることを確認済み。
