### PR TITLE
fix: Claude Code の parked session のレート制限を追跡する

### DIFF
--- a/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh
@@ -185,6 +185,7 @@ record_usage_checked() {
 # 既に解決済みの値を再利用でき、pgrep・/proc・sessions ファイル探索の再実行を避けられる。
 resolve_jsonl_path() {
     local session="$1" claude_pid="${2:-}" config_dir="${3:-}" session_file session_id jsonl
+    local parked_job_id parked_session_id
 
     if [ -z "$claude_pid" ]; then
         claude_pid=$(resolve_claude_pid "$session") || return 1
@@ -195,6 +196,25 @@ resolve_jsonl_path() {
         config_dir=$(resolve_config_dir_for_pid "$claude_pid") || return 1
     fi
     session_file="$config_dir/sessions/${claude_pid}.json"
+
+    # Claude Code が interactive session を parked/background job に移した場合、
+    # rate limit は元 session ではなく background session 側の JSONL に記録される。
+    # metadata の parkedJobId と background session の jobId を対応付けて優先する。
+    parked_job_id=$(jq -r '.parkedJobId // empty' "$session_file" 2>/dev/null)
+    if [ -n "$parked_job_id" ]; then
+        while IFS= read -r parked_session_id; do
+            [ -n "$parked_session_id" ] || continue
+            jsonl=$(find "$HOME/.claude/projects" -maxdepth 2 -name "${parked_session_id}.jsonl" -print -quit 2>/dev/null)
+            if [ -n "$jsonl" ]; then
+                echo "$jsonl"
+                return 0
+            fi
+        done < <(
+            find "$config_dir/sessions" -maxdepth 1 -type f -name '*.json' -exec \
+                jq -r --arg job_id "$parked_job_id" \
+                    'select(.kind == "bg" and .jobId == $job_id) | .sessionId // empty' {} + 2>/dev/null
+        )
+    fi
 
     session_id=$(jq -r '.sessionId // empty' "$session_file" 2>/dev/null)
     [ -n "$session_id" ] || return 1

--- a/tests/unit/test_notifications.sh
+++ b/tests/unit/test_notifications.sh
@@ -144,6 +144,51 @@ else
 fi
 rm -rf "$TEST_HOME" "$TEST_BIN_DIR"
 
+echo "Testing resolve_jsonl_path prefers a parked/background session JSONL..."
+TEST_HOME=$(mktemp -d)
+TEST_CONFIG_DIR="$TEST_HOME/.claude"
+mkdir -p "$TEST_CONFIG_DIR/sessions" "$TEST_HOME/.claude/projects/test-project"
+
+cat > "$TEST_CONFIG_DIR/sessions/4242.json" <<'EOF'
+{"pid":4242,"sessionId":"interactive-session","parkedJobId":"job-123"}
+EOF
+cat > "$TEST_CONFIG_DIR/sessions/5252.json" <<'EOF'
+{"pid":5252,"sessionId":"background-session","kind":"bg","jobId":"job-123"}
+EOF
+touch "$TEST_HOME/.claude/projects/test-project/interactive-session.jsonl"
+touch "$TEST_HOME/.claude/projects/test-project/background-session.jsonl"
+
+RESULT=$(
+  HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh"
+    resolve_jsonl_path "dummy-session" 4242 "'"$TEST_CONFIG_DIR"'"
+  '
+)
+EXPECTED="$TEST_HOME/.claude/projects/test-project/background-session.jsonl"
+if [[ "$RESULT" != "$EXPECTED" ]]; then
+  echo "❌ resolve_jsonl_path did not prefer the parked/background session JSONL (got: '$RESULT', want: '$EXPECTED')"
+  FAILED=1
+else
+  echo "✅ resolve_jsonl_path preferred the parked/background session JSONL"
+fi
+
+echo "Testing resolve_jsonl_path falls back to the interactive session when the parked session cannot be resolved..."
+rm -f "$TEST_CONFIG_DIR/sessions/5252.json"
+RESULT=$(
+  HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_claude/scripts/limit-unlocked/executable_check-notify.sh"
+    resolve_jsonl_path "dummy-session" 4242 "'"$TEST_CONFIG_DIR"'"
+  '
+)
+EXPECTED="$TEST_HOME/.claude/projects/test-project/interactive-session.jsonl"
+if [[ "$RESULT" != "$EXPECTED" ]]; then
+  echo "❌ resolve_jsonl_path did not fall back to the interactive session JSONL (got: '$RESULT', want: '$EXPECTED')"
+  FAILED=1
+else
+  echo "✅ resolve_jsonl_path fell back to the interactive session JSONL"
+fi
+rm -rf "$TEST_HOME"
+
 echo "Testing resolve_claude_pid matches a claude process invoked via a resolved absolute path, even as a grandchild of the pane pid..."
 TEST_BIN_DIR=$(mktemp -d)
 


### PR DESCRIPTION
## 概要

Claude Code が interactive session を parked/background session に移した後、rate limit が background session 側の JSONL に記録されるケースを `limit-unlocked` で追跡できるようにします。

Closes #299

## 変更内容

- interactive session metadata の `parkedJobId` を確認
- 同じ config dir の `sessions/*.json` から `kind: "bg"` かつ `jobId` が一致する background session を解決
- 対応する background session の JSONL が存在する場合はそちらを優先
- background session を解決できない場合は従来の interactive session JSONL にフォールバック
- parked/background session 優先と fallback の回帰テストを追加

## 検証

- `bash tests/unit/test_install.sh`
- `bash tests/unit/test_notifications.sh`
- `bash tests/unit/test_hooks.sh`
- `bash tests/unit/test_pr_monitor.sh`
- `bash tests/unit/test_trilium_validation.sh`
- `bash tests/syntax/test_bash_syntax.sh`
- `bash tests/syntax/test_shellcheck.sh`
- `bash tests/syntax/test_json_schema.sh`
- Pine の実 tmux session 29 / PID 3855569 で、修正版 `resolve_jsonl_path` が rate limit の記録された background session `208a3594-aeb0-4dd7-a68b-743cae5876ad` の JSONL を解決することを確認

`chezmoi apply --dry-run` は Pine に chezmoi 実行体がないためローカル未実施です。PR CI の `Chezmoi Configuration Verify` で確認します。