### PR TITLE
feat: Claude Code に Ponytail plugin を追加し Renovate 管理する

### DIFF
--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -162,7 +162,8 @@
     "ponytail": {
       "source": {
         "source": "github",
-        "repo": "DietrichGebert/ponytail"
+        "repo": "DietrichGebert/ponytail",
+        "ref": "v4.8.4"
       }
     }
   },

--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -158,11 +158,20 @@
     "type": "command",
     "command": "npx -y --offline ccstatusline@2.2.23 || npx -y ccstatusline@2.2.23"
   },
+  "extraKnownMarketplaces": {
+    "ponytail": {
+      "source": {
+        "source": "github",
+        "repo": "DietrichGebert/ponytail"
+      }
+    }
+  },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": true
+    "superpowers@claude-plugins-official": true,
+    "ponytail@ponytail": true
   },
   "language": "Use Japanese for interaction with humans and creating plans. Write the Markdown below .claude in English.",
   "feedbackSurveyRate": 0,

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,30 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>book000/templates//renovate/base-public"],
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": ["^home/dot_claude/private_settings\\.json$"],
+      "customType": "regex",
+      "managerFilePatterns": ["/^home/dot_claude/private_settings\\.json$/"],
       "matchStrings": ["ccstatusline@(?<currentValue>[0-9.]+)"],
       "depNameTemplate": "ccstatusline",
       "datasourceTemplate": "npm"
     },
     {
-      "fileMatch": ["^install\\.sh$"],
+      "customType": "regex",
+      "managerFilePatterns": ["/^install\\.sh$/"],
       "matchStrings": ["MISE_VERSION=\"(?<currentValue>v[0-9.]+)\""],
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/^home/dot_claude/private_settings\\.json$/"],
+      "matchStrings": [
+        "extraKnownMarketplaces.ponytail.source.{ \"packageName\": repo, \"currentValue\": ref }"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver-coerced"
     }
   ]
 }


### PR DESCRIPTION
## 概要

- Claude Code の `extraKnownMarketplaces` に `DietrichGebert/ponytail` を追加
- Ponytail marketplace を `ref: "v4.8.4"` でタグ固定
- `enabledPlugins` で `ponytail@ponytail` を有効化
- Renovate の JSONata custom manager + `github-tags` で Ponytail のタグ更新を追従
- 既存の `regexManagers` を現行の `customManagers` 形式へ移行
- Codex、既存 hooks、`statusLine` は変更なし

## 検証

- `renovate-config-validator renovate.json`
- Renovate `--platform=local --dry-run=extract` で `DietrichGebert/ponytail` / `v4.8.4` の依存抽出を確認
- `tests/syntax/*.sh`
- `tests/unit/*.sh`
- `tests/integration/*.sh`
- Ponytail marketplace / plugin / ref 設定の直接 assertion
- `git diff --check`

ローカル環境に `rg` が存在しないため、`tests/unit/test_pr_monitor.sh` の `rg -n` 呼び出しだけ一時互換 shim で実行しました。リポジトリへの追加変更はありません。

Closes #301