### PR TITLE
fix: Codex の親 rollout を優先して制限監視する

### DIFF
--- a/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh
@@ -47,12 +47,14 @@ collect_descendant_pids() {
 # パスを特定する。Codex には Claude Code の sessions/<pid>.json のような
 # pid→セッション対応表が存在しないため、pane の pid とその子孫すべての
 # オープン fd を走査し、rollout-*.jsonl を指しているものを集めた上で、
+# 親セッションの rollout を subagent の rollout より優先し、同種の候補内では
 # 最終更新時刻が最も新しいもの(実際に追記され続けている rollout)を選ぶ。
 # fd ごとに readlink -f を fork する方式は procfs 上のソケット・パイプ等の
 # 無関係な fd も含めて全数チェックしてしまい低速なため、find -lname による
 # シンボリックリンク先パターンマッチ 1 回にまとめている
 resolve_rollout_path() {
-    local session="$1" pane_pid home_real fd_dirs=() pid best_path best_mtime target mtime
+    local session="$1" pane_pid home_real fd_dirs=() pid best_path best_mtime best_is_subagent
+    local target mtime thread_source is_subagent
 
     # tmux はターゲットが "0" のような裸の数字だと、セッション名ではなく
     # 「未指定」とみなして現在アクティブなセッションへフォールバックしてしまう
@@ -72,12 +74,25 @@ resolve_rollout_path() {
 
     best_path=""
     best_mtime=-1
+    best_is_subagent=1
     while IFS= read -r target; do
         [ -n "$target" ] || continue
         mtime=$(stat -c %Y "$target" 2>/dev/null) || continue
-        if [ "$mtime" -gt "$best_mtime" ]; then
+
+        # multi-agent 実行では親と subagent の rollout が同時に開かれる。subagent が
+        # 親より数秒遅く完了すると mtime だけでは subagent を選び、親側に記録された
+        # usage_limit_exceeded を見落とすため session_meta で親を優先する。
+        thread_source=$(head -n 1 "$target" 2>/dev/null | jq -r 'select(.type == "session_meta") | .payload.thread_source // empty' 2>/dev/null)
+        is_subagent=0
+        [ "$thread_source" = "subagent" ] && is_subagent=1
+
+        if [ -z "$best_path" ] \
+            || { [ "$best_is_subagent" -eq 1 ] && [ "$is_subagent" -eq 0 ]; } \
+            || { [ "$best_is_subagent" -eq "$is_subagent" ] && [ "$mtime" -gt "$best_mtime" ]; }
+        then
             best_mtime="$mtime"
             best_path="$target"
+            best_is_subagent="$is_subagent"
         fi
     done < <(find "${fd_dirs[@]}" -lname "${home_real}/.codex/sessions/*/*/*/rollout-*.jsonl" -printf '%l\n' 2>/dev/null)
 

--- a/tests/unit/test_notifications.sh
+++ b/tests/unit/test_notifications.sh
@@ -743,6 +743,51 @@ fi
 
 rm -rf "$TEST_HOME" "$TEST_BIN_DIR"
 
+echo "Testing Codex resolve_rollout_path prefers the root session rollout over a newer subagent rollout..."
+TEST_HOME=$(mktemp -d)
+TEST_HOME=$(readlink -f "$TEST_HOME")
+TEST_BIN_DIR=$(mktemp -d)
+mkdir -p "$TEST_HOME/.codex/sessions/2026/08/02"
+
+ROOT_ROLLOUT="$TEST_HOME/.codex/sessions/2026/08/02/rollout-root.jsonl"
+SUBAGENT_ROLLOUT="$TEST_HOME/.codex/sessions/2026/08/02/rollout-subagent.jsonl"
+printf '%s\n' '{"type":"session_meta","payload":{"id":"root","session_id":"root","source":"cli","thread_source":"user"}}' > "$ROOT_ROLLOUT"
+touch -d "-1 minute" "$ROOT_ROLLOUT"
+printf '%s\n' '{"type":"session_meta","payload":{"id":"subagent","session_id":"root","source":{"subagent":{}},"thread_source":"subagent"}}' > "$SUBAGENT_ROLLOUT"
+
+bash -c "exec 3<'$SUBAGENT_ROLLOUT' 4<'$ROOT_ROLLOUT'; sleep 60" &
+FAKE_CODEX_PID=$!
+sleep 0.2
+
+cat > "$TEST_BIN_DIR/tmux" <<EOF
+#!/bin/bash
+if [[ "\$1" == "display-message" ]]; then
+  echo "$FAKE_CODEX_PID"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$TEST_BIN_DIR/tmux"
+
+RESULT_ROOT=$(
+  PATH="$TEST_BIN_DIR:$PATH" HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    resolve_rollout_path "dummy-session"
+  '
+)
+
+kill "$FAKE_CODEX_PID" 2>/dev/null || true
+wait "$FAKE_CODEX_PID" 2>/dev/null || true
+
+if [[ "$RESULT_ROOT" != "$ROOT_ROLLOUT" ]]; then
+  echo "❌ resolve_rollout_path preferred a newer subagent rollout over the root session rollout (got: '$RESULT_ROOT', want: '$ROOT_ROLLOUT')"
+  FAILED=1
+else
+  echo "✅ resolve_rollout_path preferred the root session rollout over a newer subagent rollout"
+fi
+
+rm -rf "$TEST_HOME" "$TEST_BIN_DIR"
+
 echo "Testing Codex check_limit_status reports status=2 (undetermined) when jq fails to parse the scanned window..."
 TEST_HOME=$(mktemp -d)
 FIXTURE_JSONL_BROKEN="$TEST_HOME/fixture-rollout-broken.jsonl"


### PR DESCRIPTION
## 概要

Codex の multi-agent 実行中、親セッションより後に完了した subagent の rollout が mtime だけで選ばれ、親側の `usage_limit_exceeded` を監視が見落とす問題を修正します。

## 変更内容

- `session_meta.payload.thread_source` を使い、親セッションの rollout を subagent より優先
- 同じ種別の候補では従来どおり最新 mtime を選択
- 親より新しい subagent rollout が同時に open されているケースの回帰テストを追加

## 確認

- `bash tests/unit/test_notifications.sh`
- `bash tests/syntax/test_bash_syntax.sh`
- `bash tests/syntax/test_shellcheck.sh`
- `bash tests/integration/test_chezmoi_apply.sh`
- `git diff --check`
- Pine の実 tmux session 4 で親 rollout を解決し、`check_limit_status` が `status=1` を返すことを確認
- `gitleaks protect --staged --redact -v`