### PR TITLE
fix: Codex の古いリミット状態を解除する

### DIFF
--- a/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh
@@ -106,8 +106,8 @@ resolve_rollout_path() {
 # jq が解析できなかった等)。2 を 0 と区別せず返すと、解析エラーを「解除」と誤判定して
 # しまうため、呼び出し元(detect_limited_sessions)は 2 を resolve 失敗と同様に扱う
 check_limit_status() {
-    local jsonl="$1" tail_lines last_task_complete jq_exit is_err text completed_at
-    local token_line reset_epoch date_text
+    local jsonl="$1" tail_lines last_task_complete last_task_complete_line jq_exit is_err text completed_at
+    local token_line later_token_line reset_epoch date_text
 
     [ -f "$jsonl" ] || { printf '0\t-\t-\n'; return; }
 
@@ -115,7 +115,7 @@ check_limit_status() {
     # 末尾のみを走査対象にして cron の定期実行での毎回フルパースを避ける
     tail_lines=$(tail -n 200 "$jsonl")
 
-    last_task_complete=$(echo "$tail_lines" | jq -c 'select(.type == "event_msg" and .payload.type == "task_complete")' 2>/dev/null)
+    last_task_complete=$(echo "$tail_lines" | jq -c 'select(.type == "event_msg" and .payload.type == "task_complete") | {event: ., line: input_line_number}' 2>/dev/null)
     jq_exit=$?
     if [ "$jq_exit" -ne 0 ]; then
         printf '2\t-\t-\n'
@@ -123,6 +123,8 @@ check_limit_status() {
     fi
     last_task_complete=$(echo "$last_task_complete" | tail -1)
     [ -n "$last_task_complete" ] || { printf '0\t-\t-\n'; return; }
+    last_task_complete_line=$(echo "$last_task_complete" | jq -r '.line' 2>/dev/null)
+    last_task_complete=$(echo "$last_task_complete" | jq -c '.event' 2>/dev/null)
 
     is_err=$(echo "$last_task_complete" | jq -r '(.payload.error != null) and (.payload.error.codex_error_info == "usage_limit_exceeded")' 2>/dev/null)
     if [ "$is_err" != "true" ]; then
@@ -136,6 +138,23 @@ check_limit_status() {
     # 通知文言としての可読性は保ったまま、区切り文字だけを空白に置き換える
     text=$(echo "$text" | tr '\t\n' '  ')
     completed_at=$(echo "$last_task_complete" | jq -r '.payload.completed_at // empty' 2>/dev/null)
+
+    later_token_line=$(echo "$tail_lines" | jq -c --argjson task_complete_line "$last_task_complete_line" 'select(input_line_number > $task_complete_line and .type == "event_msg" and .payload.type == "token_count")' 2>/dev/null | tail -1)
+    if [ -n "$later_token_line" ] && [ "$(echo "$later_token_line" | jq -r '
+        (.payload.rate_limits? // null) as $rate_limits
+        | if ($rate_limits | type) != "object" then false
+          else [
+              $rate_limits.primary?,
+              $rate_limits.secondary?
+              | select(type == "object")
+          ] as $windows
+          | ($windows | length) > 0
+            and all($windows[]; (.used_percent? | type) == "number" and .used_percent < 100)
+          end
+    ' 2>/dev/null)" = "true" ]; then
+        printf '0\t-\t-\n'
+        return
+    fi
 
     token_line=$(echo "$tail_lines" | jq -c 'select(.type == "event_msg" and .payload.type == "token_count")' 2>/dev/null | tail -1)
     reset_epoch=""

--- a/tests/unit/test_notifications.sh
+++ b/tests/unit/test_notifications.sh
@@ -690,6 +690,27 @@ else
   echo "✅ check_limit_status correctly reported not-limited for an error:null task_complete"
 fi
 
+echo "Testing Codex check_limit_status clears a stale usage_limit_exceeded state after a later below-cap token_count..."
+FIXTURE_JSONL_STALE_LIMIT="$TEST_HOME/fixture-rollout-stale-limit.jsonl"
+cat > "$FIXTURE_JSONL_STALE_LIMIT" <<'EOF'
+{"timestamp":"2026-08-02T11:47:24.660Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":null,"error":{"message":"usage limit hit","codex_error_info":"usage_limit_exceeded"},"started_at":1785671243,"completed_at":1785671244,"duration_ms":1410}}
+{"timestamp":"2026-08-08T05:00:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{},"rate_limits":{"primary":{"used_percent":1.0,"window_minutes":300,"resets_at":1786168800},"secondary":null}}}
+EOF
+
+RESULT_STALE_LIMIT=$(
+  bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    check_limit_status "'"$FIXTURE_JSONL_STALE_LIMIT"'"
+  '
+)
+
+if [[ "$RESULT_STALE_LIMIT" != $'0\t-\t-' ]]; then
+  echo "❌ check_limit_status did not clear a stale usage_limit_exceeded state (got: '$RESULT_STALE_LIMIT')"
+  FAILED=1
+else
+  echo "✅ check_limit_status cleared a stale usage_limit_exceeded state"
+fi
+
 rm -rf "$TEST_HOME"
 
 echo "Testing Codex resolve_rollout_path discovers the rollout jsonl via /proc fd scan and picks the newest mtime..."


### PR DESCRIPTION
## 概要

Codex の利用制限解除後も、同じ親 rollout に残った古い `usage_limit_exceeded` の `task_complete` を現在の制限状態として扱い続け、誤通知する問題を修正します。

## 変更内容

- 最後の `usage_limit_exceeded` より後に記録された `token_count` だけを解除判定に使用
- 存在する rate-limit window の `used_percent` がすべて 100% 未満なら古い制限状態を解除
- rate-limit 情報が欠落・null の場合は解除根拠にせず、保守的に制限状態を維持
- `token_count=100%` 単独では新しい制限到達とは判定せず、既存の reset epoch 選択を維持

## 確認

- 回帰テストで修正前に `1\t1786168800\tusage limit hit` を再現し、修正後は `0\t-\t-`
- `bash tests/unit/test_notifications.sh`
- `bash tests/syntax/test_bash_syntax.sh`
- `bash tests/syntax/test_shellcheck.sh`
- `bash tests/integration/test_chezmoi_apply.sh`
- Pine の実 tmux session 4 で `check_limit_status` が `0\t-\t-` を返すことを確認
- 後続 token が 100% の場合と rate-limit window が null の場合は `status=1` を維持することを確認
- gitleaks commit scan