### PR TITLE
fix: install libatomic runtime for pnpm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -416,6 +416,7 @@ install_apt_packages() {
     "fzf"
     "powerline"
     "jq"
+    "libatomic1"
   )
 
   # apt update

--- a/tests/unit/test_install.sh
+++ b/tests/unit/test_install.sh
@@ -7,7 +7,8 @@ echo "Testing install.sh with parameters..."
 
 # テスト 1: --help オプション
 echo "Test 1: --help option"
-if ! bash install.sh --help 2>&1 | grep -q "使用方法"; then
+HELP_OUTPUT=$(bash install.sh --help 2>&1)
+if ! grep -q "使用方法" <<< "$HELP_OUTPUT"; then
   echo "❌ --help option test failed"
   exit 1
 fi
@@ -15,8 +16,9 @@ echo "✅ --help option test passed"
 
 # テスト 2: --dry-run オプション (環境チェックのみ)
 echo "Test 2: --dry-run option"
-# ANSI カラーコードを削除してから grep
-if ! bash install.sh --dry-run --skip-interactive --skip-apt --skip-gh --skip-ghq --skip-mkwork --skip-roots --skip-mise --skip-gitleaks 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -q "DRY RUN"; then
+# ANSI カラーコードを削除してから確認
+DRY_RUN_OUTPUT=$(bash install.sh --dry-run --skip-interactive --skip-apt --skip-gh --skip-ghq --skip-mkwork --skip-roots --skip-mise --skip-gitleaks 2>&1 | sed 's/\x1b\[[0-9;]*m//g')
+if ! grep -q "DRY RUN" <<< "$DRY_RUN_OUTPUT"; then
   echo "❌ --dry-run option test failed"
   exit 1
 fi
@@ -24,17 +26,27 @@ echo "✅ --dry-run option test passed"
 
 # テスト 2.5: --help が --skip-gitleaks を案内していること
 echo "Test 2.5: --help mentions --skip-gitleaks"
-if ! bash install.sh --help 2>&1 | grep -q -- "--skip-gitleaks"; then
+if ! grep -q -- "--skip-gitleaks" <<< "$HELP_OUTPUT"; then
   echo "❌ --help does not mention --skip-gitleaks"
   exit 1
 fi
 echo "✅ --help mentions --skip-gitleaks"
 
+# テスト 2.6: apt パッケージに libatomic1 が含まれること
+echo "Test 2.6: apt packages include libatomic1"
+APT_DRY_RUN=$(bash install.sh --dry-run --skip-interactive --skip-gh --skip-ghq --skip-mkwork --skip-roots --skip-mise --skip-gitleaks 2>&1 | sed 's/\x1b\[[0-9;]*m//g')
+APT_INSTALL_LINE=$(grep -F "[DRY RUN] sudo apt install -y " <<< "$APT_DRY_RUN")
+if ! grep -qw "libatomic1" <<< "$APT_INSTALL_LINE"; then
+  echo "❌ apt package list does not include libatomic1"
+  exit 1
+fi
+echo "✅ apt package list includes libatomic1"
+
 # テスト 3: 無効なオプション
 echo "Test 3: invalid option"
 # install.sh は無効なオプションで exit 1 を返すため、終了コードを無視
 OUTPUT=$(bash install.sh --invalid-option 2>&1 || true)
-if echo "$OUTPUT" | grep -q "Unknown option"; then
+if grep -q "Unknown option" <<< "$OUTPUT"; then
   echo "✅ invalid option test passed"
 else
   echo "❌ invalid option test failed"


### PR DESCRIPTION
## Summary
- add `libatomic1` to the apt packages installed by `install.sh`
- add a unit assertion that the apt dry-run includes `libatomic1`
- stabilize existing `test_install.sh` assertions by avoiding `pipefail` + `grep -q` SIGPIPE races

## Why
On Ubuntu 24.04 ARM64 (tomapi), mise resolves `pnpm` to the Aqua native ARM64 binary. That binary links against `libatomic.so.1`, but the dotfiles bootstrap did not install `libatomic1`, causing `pnpm` to fail at process startup.

The failure was reproduced and isolated locally: the same pnpm binary starts successfully when the Ubuntu `libatomic1` library is supplied.

## Verification
- `tests/unit/test_install.sh` passed 3 consecutive runs
- all unit tests passed
- bash syntax checks passed
- shellcheck passed
- `git diff --check` passed

No change to pnpm backend/version selection is included; this only makes the existing Aqua pnpm runtime dependency explicit.
