### PR TITLE
fix: dotfiles 更新経路と gitleaks 検証を強化する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@
 - トークン・Webhook URL・パスワード等を平文でコミットしていないか確認する。
 - `~/.env` や `~/.gitconfig.local` はリポジトリ管理外。`.env.example` / `.gitconfig.local.example` などサンプルのみを含める。
 - pre-commit フック(`home/dot_config/git/hooks/executable_pre-commit`)や `home/dot_gitleaks.toml` の allowlist を変更する場合、誤検知抑制が広すぎて実際のシークレット検知を無効化していないか確認する。
-- `gitleaks` コマンド自体は `install.sh` に直接インストールロジックを持たず、mise 経由でインストールされる(下記「mise 管理下のツール」参照)。
+- `gitleaks` コマンド自体は `install.sh` に直接インストールロジックを持たず、mise 経由で固定バージョンをインストールする(下記「mise 管理下のツール」参照)。バージョン更新時は `tests/integration/test_gitleaks.sh` の実検知テストが通ることを確認する。
 
 ### テストの追随
 
@@ -30,7 +30,7 @@
 
 ### mise 管理下のツール
 
-- `gh`・`ghq`・`roots`・`gitleaks` などの CLI ツールは `home/dot_config/mise/config.toml` の宣言に基づき `mise` 経由でインストールする。`install.sh` に直接インストールロジックを追加していないか確認する。
+- `gh`・`ghq`・`roots`・`gitleaks` などの CLI ツールは `home/dot_config/mise/config.toml` の宣言に基づき `mise` 経由でインストールする。gitleaks は検証済みの exact version とし、Renovate の mise manager で更新する。`install.sh` に直接インストールロジックを追加していないか確認する。
 - `install.sh` に固定記述された mise 本体のバージョン(`MISE_VERSION`)を変更する場合、`renovate.json` の対応する `regexManagers` エントリと矛盾していないか確認する。
 
 ### エージェント定義

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,8 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run integration test
+      - name: Run chezmoi integration test
         run: bash tests/integration/test_chezmoi_apply.sh
+
+      - name: Run gitleaks regression test
+        run: bash tests/integration/test_gitleaks.sh
 
   docker-integration-test:
     name: Test chezmoi apply in Docker

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,6 +21,11 @@ jobs:
         background: true
         run: bash tests/unit/test_install.sh
 
+      - name: Run update.sh unit test
+        id: run-update-sh-unit-test
+        background: true
+        run: bash tests/unit/test_update.sh
+
       - name: Run notification unit test
         id: run-notification-unit-test
         background: true
@@ -44,6 +49,7 @@ jobs:
       - name: Wait for unit tests
         wait:
           - run-install-sh-unit-test
+          - run-update-sh-unit-test
           - run-notification-unit-test
           - run-hooks-unit-test
           - run-pr-monitor-unit-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ chezmoi はソース側のプレフィックスを解釈してデプロイする
 
 - `tests/` 配下にシェルスクリプトのテストがあり、以下の 3 系統に分かれる:
   - `tests/syntax/`: `test_bash_syntax.sh` / `test_shellcheck.sh` / `test_json_schema.sh`(構文・shellcheck・JSON スキーマ)。
-  - `tests/unit/`: `test_install.sh` / `test_notifications.sh` / `test_hooks.sh`(単体テスト)。
-  - `tests/integration/`: `test_chezmoi_apply.sh`(`chezmoi apply` の統合テスト)。
+  - `tests/unit/`: `test_install.sh` / `test_update.sh` / `test_notifications.sh` / `test_hooks.sh`(単体テスト)。
+  - `tests/integration/`: `test_chezmoi_apply.sh`(`chezmoi apply` の統合テスト) / `test_gitleaks.sh`(固定した gitleaks 実バイナリの回帰テスト)。
 - CI は `.github/workflows/` の `unit-test.yml` / `integration-test.yml` / `pr-checks.yml` で pull_request 時に自動実行される(`unit-test.yml` / `integration-test.yml` は master への push 時にも実行)。
 - 通知・フック関連スクリプト(`home/dot_claude/scripts/`、`home/dot_claude/hooks/`、`home/dot_codex/` 等)や `home/bin/` のヘルパーを変更・削除した場合、対応するテストの参照が古くなっていないか確認する。
 - 変更後はローカルでも Docker 上で `chezmoi apply` を実行して結果を確認する。
@@ -101,4 +101,4 @@ Claude Code のフックは `home/dot_claude/private_settings.json` で設定さ
 
 `home/dot_config/git/hooks/executable_pre-commit`(デプロイ後 `~/.config/git/hooks/pre-commit`)が `core.hooksPath` 経由でグローバル pre-commit フックとして登録され、`gitleaks` によるステージ済み差分のシークレットスキャンを行う。フォールバック設定は `home/dot_gitleaks.toml`(デプロイ後 `~/.gitleaks.toml`)。
 
-このフックや `gitleaks` コマンド自体のインストール方法(`home/dot_config/mise/config.toml` 経由の mise 管理、`install.sh` の `install_mise_tools`)を変更した場合、`tests/unit/test_hooks.sh` / `tests/unit/test_install.sh` / `tests/integration/test_chezmoi_apply.sh` の参照が古くなっていないか確認する。
+このフックや `gitleaks` コマンド自体のインストール方法(`home/dot_config/mise/config.toml` 経由の mise 管理、`install.sh` の `install_mise_tools`)を変更した場合、`tests/unit/test_hooks.sh` / `tests/unit/test_install.sh` / `tests/integration/test_chezmoi_apply.sh` / `tests/integration/test_gitleaks.sh` の参照が古くなっていないか確認する。

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ macOS と Windows は現在サポートされていません。
 ## コミット時のシークレットスキャン
 
 `git commit` 実行時に、ステージ済み差分内のシークレット(API キー、トークンなど)を [gitleaks](https://github.com/gitleaks/gitleaks) で検知し、検知した場合はコミットをブロックします。`git config --global core.hooksPath` を `~/.config/git/hooks` に設定することで、dotfiles を導入した全 Git リポジトリで有効になります。
+gitleaks は `home/dot_config/mise/config.toml` で検証済みバージョンに固定し、Renovate の mise manager で更新します。更新 PR では既知形式のダミーシークレットを実バイナリで検知できることを統合テストで確認します。
 
 **既知の制約:**
 

--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -7,7 +7,7 @@ pnpm = "latest"
 ghq = "latest"
 gh = "latest"
 "github:k1LoW/roots" = "latest"
-gitleaks = "latest"
+gitleaks = "8.22.1"
 
 [settings]
 idiomatic_version_file_enable_tools = ["node"]

--- a/tests/integration/test_gitleaks.sh
+++ b/tests/integration/test_gitleaks.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# mise で固定した gitleaks が実際に既知形式のシークレットを検出できることを確認する
+set -euo pipefail
+
+CONFIG="home/dot_config/mise/config.toml"
+VERSION=$(sed -n 's/^gitleaks = "\([0-9][0-9.]*\)"$/\1/p' "$CONFIG")
+if [[ -z "$VERSION" ]]; then
+  echo "❌ gitleaks must be pinned to an exact version in $CONFIG"
+  exit 1
+fi
+
+case "$(uname -m)" in
+  x86_64) ASSET_ARCH="x64" ;;
+  aarch64|arm64) ASSET_ARCH="arm64" ;;
+  *) echo "❌ unsupported architecture for gitleaks smoke test: $(uname -m)"; exit 1 ;;
+esac
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+ARCHIVE="$TMP_DIR/gitleaks.tar.gz"
+URL="https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_${ASSET_ARCH}.tar.gz"
+curl -fsSL "$URL" -o "$ARCHIVE"
+tar -xzf "$ARCHIVE" -C "$TMP_DIR" gitleaks
+
+FIXTURE="$TMP_DIR/fixture.txt"
+printf 'token = "ghp_%s%s"\n' 'aBcDeFgHiJkLmNoPqRsT' 'uVwXyZ0123456789' > "$FIXTURE"
+set +e
+"$TMP_DIR/gitleaks" detect --no-git --source "$FIXTURE" --no-banner --redact > "$TMP_DIR/output" 2>&1
+RC=$?
+set -e
+if [[ $RC -eq 0 ]]; then
+  cat "$TMP_DIR/output"
+  echo "❌ gitleaks $VERSION failed to detect the regression fixture"
+  exit 1
+fi
+if ! grep -qi 'leaks found' "$TMP_DIR/output"; then
+  cat "$TMP_DIR/output"
+  echo "❌ gitleaks $VERSION failed for an unexpected reason"
+  exit 1
+fi
+
+echo "✅ gitleaks $VERSION detects the regression fixture"
+
+# 実際の pre-commit hook と固定バージョンの組み合わせでもコミットをブロックできることを確認する。
+TEST_REPO="$TMP_DIR/repo"
+TEST_HOME="$TMP_DIR/home"
+TEST_BIN="$TMP_DIR/bin"
+mkdir -p "$TEST_REPO" "$TEST_HOME" "$TEST_BIN"
+cp "$TMP_DIR/gitleaks" "$TEST_BIN/gitleaks"
+cp home/dot_gitleaks.toml "$TEST_HOME/.gitleaks.toml"
+(
+  cd "$TEST_REPO"
+  git init -q
+  git config user.name test
+  git config user.email test@example.invalid
+  cp "$FIXTURE" secret.txt
+  git add secret.txt
+  set +e
+  HOME="$TEST_HOME" PATH="$TEST_BIN:/usr/bin:/bin" bash "$OLDPWD/home/dot_config/git/hooks/executable_pre-commit" > "$TMP_DIR/hook-output" 2>&1
+  HOOK_RC=$?
+  set -e
+  if [[ $HOOK_RC -eq 0 ]]; then
+    cat "$TMP_DIR/hook-output"
+    echo "❌ pre-commit hook did not block the regression fixture with gitleaks $VERSION"
+    exit 1
+  fi
+)
+echo "✅ pre-commit hook blocks the regression fixture with gitleaks $VERSION"

--- a/tests/unit/test_update.sh
+++ b/tests/unit/test_update.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# update.sh のユニットテスト
+set -euo pipefail
+
+SCRIPT="$(pwd)/update.sh"
+
+make_fake_curl() {
+  local bin_dir="$1"
+  cat > "$bin_dir/curl" <<'EOF'
+#!/bin/bash
+if [[ "${FAKE_CURL_FAIL:-0}" == "1" ]]; then
+  exit 22
+fi
+cat <<'INSTALLER'
+#!/bin/sh
+bindir="$PWD/bin"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -b) bindir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$bindir"
+cat > "$bindir/chezmoi" <<'CHEZMOI'
+#!/bin/bash
+printf '%s\n' "$*" > "$HOME/chezmoi-invocation"
+exit "${FAKE_CHEZMOI_EXIT:-0}"
+CHEZMOI
+chmod +x "$bindir/chezmoi"
+INSTALLER
+EOF
+  chmod +x "$bin_dir/curl"
+}
+
+run_update() {
+  local home="$1"
+  local bin_dir="$2"
+  HOME="$home" PATH="$bin_dir:/usr/bin:/bin" bash "$SCRIPT"
+}
+
+echo "Testing update.sh canonical chezmoi path..."
+TEST_HOME=$(mktemp -d)
+TEST_BIN=$(mktemp -d)
+make_fake_curl "$TEST_BIN"
+run_update "$TEST_HOME" "$TEST_BIN"
+[[ -x "$TEST_HOME/.local/bin/chezmoi" ]] || { echo "❌ update.sh did not install chezmoi to ~/.local/bin"; exit 1; }
+[[ ! -e "$TEST_HOME/bin/chezmoi" ]] || { echo "❌ update.sh installed a second chezmoi under ~/bin"; exit 1; }
+[[ "$(cat "$TEST_HOME/chezmoi-invocation")" == "update" ]] || { echo "❌ update.sh did not invoke the canonical chezmoi binary with update"; exit 1; }
+[[ -f "$TEST_HOME/.cache/chezmoi-update/last-update" ]] || { echo "❌ update.sh did not record successful update"; exit 1; }
+rm -rf "$TEST_HOME" "$TEST_BIN"
+echo "✅ canonical chezmoi path test passed"
+
+echo "Testing update.sh curl failure propagation..."
+TEST_HOME=$(mktemp -d)
+TEST_BIN=$(mktemp -d)
+make_fake_curl "$TEST_BIN"
+set +e
+FAKE_CURL_FAIL=1 run_update "$TEST_HOME" "$TEST_BIN"
+RC=$?
+set -e
+[[ $RC -ne 0 ]] || { echo "❌ update.sh returned success after curl failure"; exit 1; }
+[[ ! -f "$TEST_HOME/.cache/chezmoi-update/last-update" ]] || { echo "❌ update.sh recorded success after curl failure"; exit 1; }
+rm -rf "$TEST_HOME" "$TEST_BIN"
+echo "✅ curl failure propagation test passed"
+
+echo "Testing update.sh chezmoi failure propagation..."
+TEST_HOME=$(mktemp -d)
+TEST_BIN=$(mktemp -d)
+make_fake_curl "$TEST_BIN"
+set +e
+FAKE_CHEZMOI_EXIT=42 run_update "$TEST_HOME" "$TEST_BIN"
+RC=$?
+set -e
+[[ $RC -eq 42 ]] || { echo "❌ update.sh did not return chezmoi exit code (got $RC)"; exit 1; }
+[[ ! -f "$TEST_HOME/.cache/chezmoi-update/last-update" ]] || { echo "❌ update.sh recorded success after chezmoi failure"; exit 1; }
+rm -rf "$TEST_HOME" "$TEST_BIN"
+echo "✅ chezmoi failure propagation test passed"

--- a/tests/unit/test_update.sh
+++ b/tests/unit/test_update.sh
@@ -42,9 +42,12 @@ echo "Testing update.sh canonical chezmoi path..."
 TEST_HOME=$(mktemp -d)
 TEST_BIN=$(mktemp -d)
 make_fake_curl "$TEST_BIN"
+mkdir -p "$TEST_HOME/bin"
+printf '#!/bin/bash\nexit 0\n' > "$TEST_HOME/bin/chezmoi"
+chmod +x "$TEST_HOME/bin/chezmoi"
 run_update "$TEST_HOME" "$TEST_BIN"
 [[ -x "$TEST_HOME/.local/bin/chezmoi" ]] || { echo "❌ update.sh did not install chezmoi to ~/.local/bin"; exit 1; }
-[[ ! -e "$TEST_HOME/bin/chezmoi" ]] || { echo "❌ update.sh installed a second chezmoi under ~/bin"; exit 1; }
+[[ ! -e "$TEST_HOME/bin/chezmoi" ]] || { echo "❌ update.sh did not remove the legacy ~/bin/chezmoi"; exit 1; }
 [[ "$(cat "$TEST_HOME/chezmoi-invocation")" == "update" ]] || { echo "❌ update.sh did not invoke the canonical chezmoi binary with update"; exit 1; }
 [[ -f "$TEST_HOME/.cache/chezmoi-update/last-update" ]] || { echo "❌ update.sh did not record successful update"; exit 1; }
 rm -rf "$TEST_HOME" "$TEST_BIN"

--- a/update.sh
+++ b/update.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 CACHE_DIR="$HOME/.cache/chezmoi-update"
 TIMESTAMP_FILE="$CACHE_DIR/last-update"
 CHEZMOI_BIN="$HOME/.local/bin/chezmoi"
+LEGACY_CHEZMOI_BIN="$HOME/bin/chezmoi"
 
 mkdir -p "$CACHE_DIR"
 
@@ -26,5 +27,8 @@ sh -c "$installer" -- -b "$HOME/.local/bin"
 
 # インストーラ経由の暗黙実行に依存せず、管理対象のバイナリを明示して更新する。
 "$CHEZMOI_BIN" update
+
+# 旧 updater が作成した ~/bin/chezmoi は、正常更新後に削除して二重管理を解消する。
+rm -f -- "$LEGACY_CHEZMOI_BIN"
 
 date +%s > "$TIMESTAMP_FILE"

--- a/update.sh
+++ b/update.sh
@@ -2,8 +2,11 @@
 # chezmoi の自動更新スクリプト
 # 24 時間以内に実行済みの場合はスキップする
 
+set -euo pipefail
+
 CACHE_DIR="$HOME/.cache/chezmoi-update"
 TIMESTAMP_FILE="$CACHE_DIR/last-update"
+CHEZMOI_BIN="$HOME/.local/bin/chezmoi"
 
 mkdir -p "$CACHE_DIR"
 
@@ -17,10 +20,11 @@ if [[ -f "$TIMESTAMP_FILE" ]]; then
   fi
 fi
 
-cd "$HOME" || exit
-# curl の失敗を検知するため先にインストーラを取得し、成功した場合のみ実行する
-if installer=$(curl -fsSL get.chezmoi.io); then
-  if sh -c "$installer" -- update; then
-    date +%s > "$TIMESTAMP_FILE"
-  fi
-fi
+# chezmoi の公式インストーラで ~/.local/bin の単一バイナリを更新する。
+installer=$(curl -fsSL https://get.chezmoi.io)
+sh -c "$installer" -- -b "$HOME/.local/bin"
+
+# インストーラ経由の暗黙実行に依存せず、管理対象のバイナリを明示して更新する。
+"$CHEZMOI_BIN" update
+
+date +%s > "$TIMESTAMP_FILE"


### PR DESCRIPTION
## 概要

- gitleaks を検証済みの exact version に固定し、Renovate の mise manager で更新できる状態にする
- gitleaks の既知回帰を実バイナリ + pre-commit hook で検知する統合テストを追加する
- chezmoi updater の実行バイナリを `~/.local/bin/chezmoi` に統一する
- curl / installer / chezmoi update の失敗を non-zero で伝播し、成功時のみ更新時刻を記録する
- updater の unit test と CI 実行を追加する

## 検証

- `tests/unit/test_install.sh`
- `tests/unit/test_update.sh`
- `tests/unit/test_hooks.sh`
- `tests/unit/test_notifications.sh`
- `tests/unit/test_list_compose_dirs.sh`
- `tests/unit/test_pr_monitor.sh`
- `tests/unit/test_trilium_validation.sh`
- `tests/syntax/test_bash_syntax.sh`
- `tests/syntax/test_shellcheck.sh`
- `tests/syntax/test_json_schema.sh`
- `tests/integration/test_chezmoi_apply.sh`
- `tests/integration/test_gitleaks.sh`
- `git diff --check`
