### PR TITLE
fix: include chezmoi mise config in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,5 +26,8 @@
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "semver-coerced"
     }
-  ]
+  ],
+  "mise": {
+    "managerFilePatterns": ["/^home/dot_config/mise/config\\.toml$/"]
+  }
 }

--- a/tests/syntax/test_json_schema.sh
+++ b/tests/syntax/test_json_schema.sh
@@ -83,6 +83,26 @@ assert config["notice"]["model_migrations"]["gpt_5_4"] == "gpt-5.6"
   FILES_CHECKED=$((FILES_CHECKED + 1))
 fi
 
+# Renovate が chezmoi source state の mise config を対象にすること
+if [ -f "renovate.json" ]; then
+  echo "Validating Renovate mise manager file pattern..."
+  if ! python3 - <<'PYRENOVATE'
+import json
+from pathlib import Path
+
+config = json.loads(Path("renovate.json").read_text())
+patterns = config.get("mise", {}).get("managerFilePatterns", [])
+assert r'/^home/dot_config/mise/config\.toml$/' in patterns
+PYRENOVATE
+  then
+    echo "❌ Renovate mise manager does not include chezmoi source config"
+    FAILED=1
+  else
+    echo "✅ Renovate mise manager includes chezmoi source config"
+  fi
+  FILES_CHECKED=$((FILES_CHECKED + 1))
+fi
+
 # 検証対象のファイルが存在しない場合はエラー
 if [ $FILES_CHECKED -eq 0 ]; then
   echo "❌ No AI agent configuration files found to validate"


### PR DESCRIPTION
## Summary

- extend the native Renovate `mise` manager's `managerFilePatterns` to include `home/dot_config/mise/config.toml`
- add a regression check so the chezmoi source-state path cannot silently drop out of Renovate coverage

## Verification

- `renovate-config-validator --strict` passes
- `renovate --platform=local --dry-run=extract` matches `home/dot_config/mise/config.toml`
- Renovate reports 1 mise package file with 17 extracted dependencies
- all unit, syntax, and integration tests passed on Pine
- `git diff --check` passed

Closes #319