### PR TITLE
fix: Codex Goal のリミット解除時に自動再開する

### DIFF
--- a/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh
+++ b/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh
@@ -376,7 +376,27 @@ record_resumed_for() {
     mv "$tmp_file" "$file"
 }
 
-# 指定した tmux セッションに再開キーを送る。
+# rollout の直近の Goal 状態が usageLimited か確認する。
+# Codex の Goal runtime は usage limit 到達時に thread_goal_updated を記録して
+# Goal を usageLimited に遷移させるため、この状態だけは通常メッセージではなく
+# /goal resume で active に戻す必要がある。
+goal_resume_required() {
+    local jsonl="$1" goal_statuses last_goal_status
+
+    [ -f "$jsonl" ] || return 1
+
+    if ! goal_statuses=$(
+        tail -n 200 "$jsonl" \
+            | jq -r 'select(.type == "event_msg" and .payload.type == "thread_goal_updated") | .payload.goal.status // empty' 2>/dev/null
+    ); then
+        return 1
+    fi
+    last_goal_status=$(printf '%s\n' "$goal_statuses" | tail -1)
+
+    [ "$last_goal_status" = "usageLimited" ]
+}
+
+# 指定した tmux セッションに再開入力を送る。
 # ウィンドウ/ペイン番号を固定せずセッション名のみを指定し、tmux の base-index 設定
 # (0 始まりとは限らない)に依存せず常にアクティブなウィンドウ・ペインへ送信する
 #
@@ -384,12 +404,18 @@ record_resumed_for() {
 # "What do you want to do?" 相当の挙動はない)、入力プロンプトはそのまま
 # 使用可能であるため、Escape でメニューを閉じる処理は不要
 resume_session() {
-    local session="$1"
+    local session="$1" jsonl resume_input
+
+    resume_input="<system-reminder>Codex's rate limit has been lifted. Continue the task you were working on before the interruption.</system-reminder>"
+    jsonl=$(resolve_rollout_path "$session" 2>/dev/null || true)
+    if [ -n "$jsonl" ] && goal_resume_required "$jsonl"; then
+        resume_input="/goal resume"
+    fi
 
     # "0" のような裸の数字セッション名は tmux に「未指定」とみなされ
     # 現在のセッションへフォールバックしてしまうため、末尾に ":" を付けて
     # セッション名指定であることを明示する(display-message と同様の理由)
-    tmux send-keys -t "${session}:" "<system-reminder>Codex's rate limit has been lifted. Continue the task you were working on before the interruption.</system-reminder>"
+    tmux send-keys -t "${session}:" "$resume_input"
     sleep 1
     tmux send-keys -t "${session}:" Enter
 }

--- a/tests/unit/test_notifications.sh
+++ b/tests/unit/test_notifications.sh
@@ -853,6 +853,83 @@ else
 fi
 rm -rf "$TEST_HOME"
 
+echo "Testing Codex goal_resume_required fails safely when the rollout window contains malformed JSON..."
+TEST_HOME=$(mktemp -d)
+FIXTURE_JSONL_GOAL_PARSE_ERROR="$TEST_HOME/fixture-rollout-goal-parse-error.jsonl"
+cat > "$FIXTURE_JSONL_GOAL_PARSE_ERROR" <<'EOF'
+{"timestamp":"2026-08-08T05:00:00.000Z","type":"event_msg","payload":{"type":"thread_goal_updated","threadId":"thread-1","goal":{"threadId":"thread-1","objective":"finish the task","status":"usageLimited","tokensUsed":100,"timeUsedSeconds":60,"createdAt":1,"updatedAt":2}}}
+{not-json
+EOF
+
+RESULT_GOAL_PARSE_ERROR=$(
+  HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    if goal_resume_required "'"$FIXTURE_JSONL_GOAL_PARSE_ERROR"'"; then
+      printf "%s\n" required
+    else
+      printf "%s\n" not-required
+    fi
+  '
+)
+if [[ "$RESULT_GOAL_PARSE_ERROR" != "not-required" ]]; then
+  echo "❌ goal_resume_required treated a malformed rollout as safely resumable (got: '$RESULT_GOAL_PARSE_ERROR')"
+  FAILED=1
+else
+  echo "✅ goal_resume_required failed safely on malformed rollout JSON"
+fi
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex resume_session keeps the generic resume message for a non-goal session..."
+TEST_HOME=$(mktemp -d)
+FIXTURE_JSONL_NON_GOAL="$TEST_HOME/fixture-rollout-non-goal.jsonl"
+cat > "$FIXTURE_JSONL_NON_GOAL" <<'EOF'
+{"timestamp":"2026-08-08T05:00:00.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":null,"error":{"message":"usage limit hit","codex_error_info":"usage_limit_exceeded"},"started_at":1,"completed_at":2,"duration_ms":1000}}
+EOF
+
+RESULT_NON_GOAL_RESUME=$(
+  HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    resolve_rollout_path() { printf "%s\n" "'"$FIXTURE_JSONL_NON_GOAL"'"; }
+    sleep() { :; }
+    tmux() { printf "%s\n" "$*"; }
+    resume_session "sess-1"
+  '
+)
+EXPECTED_NON_GOAL_RESUME="send-keys -t sess-1: <system-reminder>Codex's rate limit has been lifted. Continue the task you were working on before the interruption.</system-reminder>"
+EXPECTED_NON_GOAL_RESUME="${EXPECTED_NON_GOAL_RESUME}"$'\n'"send-keys -t sess-1: Enter"
+if [[ "$RESULT_NON_GOAL_RESUME" != "$EXPECTED_NON_GOAL_RESUME" ]]; then
+  echo "❌ resume_session changed the non-goal resume input unexpectedly (got: '$RESULT_NON_GOAL_RESUME')"
+  FAILED=1
+else
+  echo "✅ resume_session kept the generic resume message for a non-goal session"
+fi
+rm -rf "$TEST_HOME"
+
+echo "Testing Codex resume_session sends /goal resume when the current goal is usage limited..."
+TEST_HOME=$(mktemp -d)
+FIXTURE_JSONL_GOAL_LIMITED="$TEST_HOME/fixture-rollout-goal-limited.jsonl"
+cat > "$FIXTURE_JSONL_GOAL_LIMITED" <<'EOF'
+{"timestamp":"2026-08-08T05:00:00.000Z","type":"event_msg","payload":{"type":"thread_goal_updated","threadId":"thread-1","goal":{"threadId":"thread-1","objective":"finish the task","status":"usageLimited","tokensUsed":100,"timeUsedSeconds":60,"createdAt":1,"updatedAt":2}}}
+EOF
+
+RESULT_GOAL_RESUME=$(
+  HOME="$TEST_HOME" bash -c '
+    source "'"$PWD"'/home/dot_codex/scripts/limit-unlocked/executable_check-notify.sh"
+    resolve_rollout_path() { printf "%s\n" "'"$FIXTURE_JSONL_GOAL_LIMITED"'"; }
+    sleep() { :; }
+    tmux() { printf "%s\n" "$*"; }
+    resume_session "sess-1"
+  '
+)
+EXPECTED_GOAL_RESUME=$'send-keys -t sess-1: /goal resume\nsend-keys -t sess-1: Enter'
+if [[ "$RESULT_GOAL_RESUME" != "$EXPECTED_GOAL_RESUME" ]]; then
+  echo "❌ resume_session did not use /goal resume for a usage-limited goal (got: '$RESULT_GOAL_RESUME')"
+  FAILED=1
+else
+  echo "✅ resume_session used /goal resume for a usage-limited goal"
+fi
+rm -rf "$TEST_HOME"
+
 echo "Testing Codex already_resumed_for / record_resumed_for dedup resume_session for the same reset_epoch..."
 TEST_HOME=$(mktemp -d)
 RESULT_RESUME_DEDUP=$(


### PR DESCRIPTION
## 概要

- Codex rollout の直近の `thread_goal_updated` を確認し、Goal が `usageLimited` の場合はリミット解除時に `/goal resume` を送信する
- 非 Goal セッションでは従来の継続メッセージを維持する
- rollout の JSON 解析に失敗した場合は `/goal resume` を送らない安全側の挙動にする
- Goal / 非 Goal / malformed JSON の unit test を追加する

## テスト

- `for test in tests/unit/test_*.sh; do bash "$test"; done`
- `bash tests/syntax/test_bash_syntax.sh`
- `bash tests/syntax/test_shellcheck.sh`
- `bash tests/integration/test_chezmoi_apply.sh`
- `git diff --check`

Closes #306