### PR TITLE
feat: chezmoi 更新後に mise install を実行する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@
 
 ### テストの追随
 
-- `update.sh` や user systemd timer を変更する場合、scheduled `--force`、AI CLI の throttle、同時実行ロック、timer の `Persistent=true` が維持されているか確認する。
+- `update.sh` や user systemd timer を変更する場合、scheduled `--force`、AI CLI の throttle、同時実行ロック、timer の `Persistent=true`、`chezmoi update` 後の managed global config に対する `mise install` が維持されているか確認する。
 - `home/dot_codex/`、`home/dot_claude/scripts/` など通知・フック関連スクリプトを変更・削除した場合、`tests/unit/`、`tests/integration/`、`tests/syntax/` 配下の対応するテストが古い参照を残していないか確認する。
 - managed file の rename / delete では、旧 target が残らないよう `home/.chezmoiremove` の更新が必要か確認する。`.claude` / `.codex` 全体を `exact_` にして runtime state を削除しない。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ chezmoi はソース側のプレフィックスを解釈してデプロイする
 - 依存バージョンの更新は `renovate.json` の Renovate (GitHub App) で管理する。`home/dot_claude/private_settings.json` の `statusLine.command` に埋め込まれた `ccstatusline` の npm バージョンや、`install.sh` に固定記述された mise 本体のバージョンなど、通常の `package.json` では追跡できない箇所は `regexManagers` で個別に対象化する。`gh`/`ghq`/`roots`/`gitleaks` など mise 管理下のツールバージョンは `home/dot_config/mise/config.toml` への宣言により Renovate のネイティブな mise サポートで自動追跡される(`regexManagers` の追加設定は不要)。
 - chezmoi によるデプロイ先 (`~/.claude/` 配下など、`home/dot_*` から展開される全ての実体) を直接編集してはならない。必ず対応する `home/dot_*` 配下のソースファイルを編集し、動作確認が必要な場合は `chezmoi apply` (または `chezmoi diff`) で反映すること。デプロイ先を直接編集すると、その後の `chezmoi apply`/`chezmoi update` (自動実行される場合を含む) によってソース側の内容で無言のまま上書き・巻き戻しされる。
 - 既存の managed file を rename / delete して target 側からも消す場合は、`home/.chezmoiremove` に旧 target path を追加する。`.claude` / `.codex` のように runtime state を持つディレクトリを `exact_` 化してはならない。
-- Linux の定期更新は `home/dot_config/systemd/user/chezmoi-update.{service,timer}` と `timers.target.wants` の symlink で管理する。scheduled service は `update.sh --force`、AI CLI 起動時は引き続き 24 時間 throttle を使い、`update.sh` の `flock` で競合を防ぐ。
+- Linux の定期更新は `home/dot_config/systemd/user/chezmoi-update.{service,timer}` と `timers.target.wants` の symlink で管理する。scheduled service は `update.sh --force`、AI CLI 起動時は引き続き 24 時間 throttle を使い、`update.sh` の `flock` で競合を防ぐ。`chezmoi update` 成功後は managed global config (`~/.config/mise/config.toml`) を明示して `mise install` を実行し、mise まで成功した場合だけ更新 timestamp を記録する。
 - `home/dot_claude/skills/check-container-status/` は、多数の Docker Compose プロジェクトが同居するディレクトリ(例: `/mnt/hdd/<マシン名>`)の稼働状況を、並列サブエージェント(`home/dot_claude/agents/container-status-checker.md` / `container-error-investigator.md`)で網羅的に確認するグローバルスキル。
 
 ## Claude Code フック / 通知機能

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 chezmoi 管理から削除・rename した旧ファイルは `home/.chezmoiremove` に旧 target path を記録し、次回の `chezmoi apply` / `chezmoi update` で自動削除します。Claude Code / Codex の session・cache・plugin などの runtime state は対象外です。
 
-Linux では user-level systemd timer が `chezmoi update` を日次実行します。AI CLI 起動時の更新もフォールバックとして残しており、updater のロックにより同時実行は直列化されます。timer は `Persistent=true` のため、停止中に予定時刻を逃した場合は次の user manager 起動時に補完されます。
+Linux では user-level systemd timer が `chezmoi update` を日次実行し、反映後に `~/.config/mise/config.toml` の宣言に対して `mise install` を実行します。AI CLI 起動時の更新もフォールバックとして残しており、updater のロックにより同時実行は直列化されます。timer は `Persistent=true` のため、停止中に予定時刻を逃した場合は次の user manager 起動時に補完されます。
 
 ## インストール方法
 

--- a/tests/unit/test_update.sh
+++ b/tests/unit/test_update.sh
@@ -36,11 +36,40 @@ EOF
   chmod +x "$bin_dir/curl"
 }
 
+make_fake_mise() {
+  local home="$1"
+  mkdir -p "$home/.local/bin"
+  cat > "$home/.local/bin/mise" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" > "$HOME/mise-invocation"
+printf '%s\n' "${MISE_GLOBAL_CONFIG_FILE:-}" > "$HOME/mise-global-config"
+exit "${FAKE_MISE_EXIT:-0}"
+EOF
+  chmod +x "$home/.local/bin/mise"
+}
+
 run_update() {
   local home="$1"
   local bin_dir="$2"
+  if [[ ! -x "$home/.local/bin/mise" ]]; then
+    make_fake_mise "$home"
+  fi
   HOME="$home" PATH="$bin_dir:/usr/bin:/bin" bash "$SCRIPT" "${@:3}"
 }
+
+echo "Testing update.sh mise failure propagation..."
+TEST_HOME=$(mktemp -d)
+TEST_BIN=$(mktemp -d)
+make_fake_curl "$TEST_BIN"
+set +e
+FAKE_MISE_EXIT=43 run_update "$TEST_HOME" "$TEST_BIN"
+RC=$?
+set -e
+[[ $RC -eq 43 ]] || { echo "❌ update.sh did not return mise exit code (got $RC)"; exit 1; }
+[[ "$(cat "$TEST_HOME/mise-invocation")" == "install" ]] || { echo "❌ update.sh did not invoke mise before returning failure"; exit 1; }
+[[ ! -f "$TEST_HOME/.cache/chezmoi-update/last-update" ]] || { echo "❌ update.sh recorded success after mise failure"; exit 1; }
+rm -rf "$TEST_HOME" "$TEST_BIN"
+echo "✅ mise failure propagation test passed"
 
 echo "Testing update.sh canonical chezmoi path..."
 TEST_HOME=$(mktemp -d)
@@ -53,6 +82,8 @@ run_update "$TEST_HOME" "$TEST_BIN"
 [[ -x "$TEST_HOME/.local/bin/chezmoi" ]] || { echo "❌ update.sh did not install chezmoi to ~/.local/bin"; exit 1; }
 [[ ! -e "$TEST_HOME/bin/chezmoi" ]] || { echo "❌ update.sh did not remove the legacy ~/bin/chezmoi"; exit 1; }
 [[ "$(cat "$TEST_HOME/chezmoi-invocation")" == "update" ]] || { echo "❌ update.sh did not invoke the canonical chezmoi binary with update"; exit 1; }
+[[ "$(cat "$TEST_HOME/mise-invocation")" == "install" ]] || { echo "❌ update.sh did not invoke mise install"; exit 1; }
+[[ "$(cat "$TEST_HOME/mise-global-config")" == "$TEST_HOME/.config/mise/config.toml" ]] || { echo "❌ update.sh did not point mise at the managed global config"; exit 1; }
 [[ -f "$TEST_HOME/.cache/chezmoi-update/last-update" ]] || { echo "❌ update.sh did not record successful update"; exit 1; }
 rm -rf "$TEST_HOME" "$TEST_BIN"
 echo "✅ canonical chezmoi path test passed"

--- a/update.sh
+++ b/update.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 CACHE_DIR="$HOME/.cache/chezmoi-update"
 TIMESTAMP_FILE="$CACHE_DIR/last-update"
 CHEZMOI_BIN="$HOME/.local/bin/chezmoi"
+MISE_BIN="$HOME/.local/bin/mise"
+MISE_GLOBAL_CONFIG_FILE="$HOME/.config/mise/config.toml"
 LEGACY_CHEZMOI_BIN="$HOME/bin/chezmoi"
 FORCE_UPDATE=0
 
@@ -48,6 +50,9 @@ sh -c "$installer" -- -b "$HOME/.local/bin"
 
 # インストーラ経由の暗黙実行に依存せず、管理対象のバイナリを明示して更新する。
 "$CHEZMOI_BIN" update
+
+# chezmoi で反映された global config に宣言済みの tool を揃える。
+MISE_GLOBAL_CONFIG_FILE="$MISE_GLOBAL_CONFIG_FILE" "$MISE_BIN" install
 
 # 旧 updater が作成した ~/bin/chezmoi は、正常更新後に削除して二重管理を解消する。
 rm -f -- "$LEGACY_CHEZMOI_BIN"


### PR DESCRIPTION
## 概要

- `chezmoi update` 成功後に `mise install` を実行
- `MISE_GLOBAL_CONFIG_FILE=~/.config/mise/config.toml` を明示し、systemd の working directory に依存しないようにする
- mise が失敗した場合は updater 全体を失敗扱いにし、`last-update` timestamp を記録しない
- unit test で mise 呼び出し・global config 指定・失敗伝播を検証
- README / CLAUDE / Copilot guidance を更新

## 検証

- `tests/unit/test_update.sh`
- 全 `tests/unit/test_*.sh`
- `tests/integration/test_chezmoi_apply.sh`
- `tests/syntax/test_bash_syntax.sh`
- `tests/syntax/test_shellcheck.sh`
- `tests/syntax/test_json_schema.sh`
- managed mise config に対する `mise install --dry-run`
- `git diff --check`