### PR TITLE
fix: 各エージェント定義に SendMessage ツールの使用を明示的に許可する

### DIFF
--- a/home/dot_claude/agents/container-error-investigator.md
+++ b/home/dot_claude/agents/container-error-investigator.md
@@ -1,7 +1,7 @@
 ---
 name: container-error-investigator
 description: Investigates the root cause and fix for a Docker Compose project flagged as "warning" or "error" by container-status-checker, using web research. Use once per flagged directory, after all directories have finished their status check (check-container-status skill's Phase D).
-tools: Read, Edit, WebSearch, WebFetch
+tools: Read, Edit, WebSearch, WebFetch, SendMessage
 model: sonnet
 ---
 

--- a/home/dot_claude/agents/container-status-checker.md
+++ b/home/dot_claude/agents/container-status-checker.md
@@ -1,7 +1,7 @@
 ---
 name: container-status-checker
 description: Checks one Docker Compose project directory comprehensively (running state, defined-vs-running service diff, restart count, resource usage, logs, connectivity) and records the result in STATE.md. Use once per compose project directory, dispatched in parallel (bounded concurrency, see the check-container-status skill's Phase C) by the check-container-status skill.
-tools: Bash, Read, Edit
+tools: Bash, Read, Edit, SendMessage
 model: sonnet
 ---
 

--- a/home/dot_claude/agents/plan-reviewer.md
+++ b/home/dot_claude/agents/plan-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: plan-reviewer
 description: Reviews a plan document (docs/superpowers/plans/*.md) for placeholders, contradictions, missing coverage, missing code blocks, and mid-sentence line breaks, then fixes issues in place. Use after writing a plan file, before the user reviews it.
-tools: Read, Edit
+tools: Read, Edit, SendMessage
 model: sonnet
 ---
 

--- a/home/dot_claude/agents/spec-reviewer.md
+++ b/home/dot_claude/agents/spec-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-reviewer
 description: Reviews a spec document (docs/superpowers/specs/*.md) for placeholders, contradictions, missing coverage, and mid-sentence line breaks, then fixes issues in place. Use after writing a spec file, before the user reviews it.
-tools: Read, Edit
+tools: Read, Edit, SendMessage
 model: sonnet
 ---
 


### PR DESCRIPTION
## 概要

`home/dot_claude/agents/*.md` で定義されているカスタム sub-agent の `tools:` frontmatter に `SendMessage` を明示的に追加した。

## 背景

`rules/workflow-sub-agents.md` の規約により、バックグラウンドで起動される sub-agent は完了・停止前に `SendMessage` で親セッションへ報告する必要がある。しかし以下の 4 つのエージェント定義は `tools:` に `SendMessage` を含んでいなかったため、指示されても報告できなかった。

- `container-status-checker.md`
- `container-error-investigator.md`
- `plan-reviewer.md`
- `spec-reviewer.md`

## 変更内容

各ファイルの `tools:` 行の末尾に `, SendMessage` を追加(既存のカンマ区切りフォーマットを維持)。他の内容は変更していない。

Closes #325