### PR TITLE
docs: サブスキルの stop 指示が制御返却であることを明記する

### DIFF
--- a/home/dot_claude/rules/superpowers.md
+++ b/home/dot_claude/rules/superpowers.md
@@ -51,4 +51,4 @@ When an orchestrating skill instructs a superpowers sub-skill (e.g. `brainstormi
 
 Unless the orchestrating skill's next phase is an explicit `AskUserQuestion`-based approval gate (e.g. `issue-pr-deep`'s Phase 6 spec approval) or a failure condition, the orchestrating skill must continue immediately into its next automatic phase once the sub-skill returns — no waiting, no "stopping here" language directed at the user.
 
-This distinction matters because an orchestrating skill telling a sub-skill to "stop" can be misread as a cue for the orchestrating skill itself to also stop, producing an unnecessary pause where the flow was designed to continue automatically (see Issue #324 for a concrete recurrence: `issue-pr-deep`'s Phase 3→4 transition around `brainstorming`).
+This distinction matters because an orchestrating skill telling a sub-skill to "stop" can be misread as a cue for the orchestrating skill itself to also stop, producing an unnecessary pause where the flow was designed to continue automatically (see book000/dotfiles#324 for a concrete recurrence: `issue-pr-deep`'s Phase 3→4 transition around `brainstorming`).

--- a/home/dot_claude/rules/superpowers.md
+++ b/home/dot_claude/rules/superpowers.md
@@ -44,3 +44,11 @@ under these paths are local-only working artifacts — after uploading them
 to Trilium (per the `trilium` skill), do NOT force-add or commit them
 to git (no `git add -f`, no `--force`). The durable record is the
 Trilium note, not the git history.
+
+## Sub-Skill "Stop" Instructions Return Control, Not Pause
+
+When an orchestrating skill instructs a superpowers sub-skill (e.g. `brainstorming`, `writing-plans`) to "stop" or "stop here" after some step, that instruction means the sub-skill returns control to the orchestrating skill — it does not mean the orchestrating skill itself pauses for user input.
+
+Unless the orchestrating skill's next phase is an explicit `AskUserQuestion`-based approval gate (e.g. `issue-pr-deep`'s Phase 6 spec approval) or a failure condition, the orchestrating skill must continue immediately into its next automatic phase once the sub-skill returns — no waiting, no "stopping here" language directed at the user.
+
+This distinction matters because an orchestrating skill telling a sub-skill to "stop" can be misread as a cue for the orchestrating skill itself to also stop, producing an unnecessary pause where the flow was designed to continue automatically (see Issue #324 for a concrete recurrence: `issue-pr-deep`'s Phase 3→4 transition around `brainstorming`).

--- a/home/dot_claude/skills/glitchtip-pr-deep/SKILL.md
+++ b/home/dot_claude/skills/glitchtip-pr-deep/SKILL.md
@@ -69,6 +69,8 @@ Review Gate" and must not auto-chain into invoking writing-plans. This
 flow's own Phase 4 through Phase 7 own spec review, posting, approval, and
 plan creation instead.
 
+Once brainstorming returns control here after writing the spec file, this is a control return, not a pause for user input — proceed immediately into Phase 4 below without waiting for the user or announcing a stop.
+
 ## Phase 4: Review the Spec
 
 `rules/superpowers.md` requires a sub-agent review of every spec file; it

--- a/home/dot_claude/skills/issue-pr-deep/SKILL.md
+++ b/home/dot_claude/skills/issue-pr-deep/SKILL.md
@@ -73,6 +73,8 @@ Phase 4 through Phase 7 own spec review, posting, approval, and plan
 creation instead — chaining from within brainstorming would duplicate
 Phase 6's approval and invoke writing-plans out of order.
 
+Once brainstorming returns control here after writing the spec file, this is a control return, not a pause for user input — proceed immediately into Phase 4 below without waiting for the user or announcing a stop.
+
 ## Phase 4: Review the Spec
 
 `rules/superpowers.md` requires a sub-agent review of every spec file; it


### PR DESCRIPTION
## 概要

サブスキル (`superpowers:brainstorming`) への「stop」指示が呼び出し元スキルへの制御返却であることを明示し、呼び出し元 (`issue-pr-deep` / `glitchtip-pr-deep`) がユーザー入力待ちと誤解して不要に停止する再発を防ぐ。

Closes #324

## 変更内容

- `home/dot_claude/rules/superpowers.md`: サブスキルの「stop」指示は制御返却であり、呼び出し元は次の自動フェーズへ待たずに継続すべきという一般原則を追記。
- `home/dot_claude/skills/issue-pr-deep/SKILL.md`: Phase 3 で `brainstorming` に「stop」を指示する段落の直後に、制御返却後は直ちに Phase 4 へ進む旨を明記。
- `home/dot_claude/skills/glitchtip-pr-deep/SKILL.md`: 同様の一文を Phase 3 に追加。

いずれも chezmoi source (`home/dot_claude/...`) への追記のみで、デプロイ先 (`~/.claude/` 配下) は変更していない。

## テスト

- `tests/syntax/test_bash_syntax.sh` / `tests/syntax/test_shellcheck.sh`: PASS(Markdown のみの変更のため影響なし)
- Markdown への文言追加のみで実行可能なロジック変更はないため、新規テスト追加は不要。

Spec: https://github.com/book000/dotfiles/issues/324#issuecomment-5261694275
Plan: https://github.com/book000/dotfiles/issues/324#issuecomment-5261751643