### PR TITLE
feat: warn before Claude with remote settings

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,6 +26,11 @@ jobs:
         background: true
         run: bash tests/unit/test_update.sh
 
+      - name: Run AI alias unit test
+        id: run-ai-alias-unit-test
+        background: true
+        run: bash tests/unit/test_ai_alias.sh
+
       - name: Run notification unit test
         id: run-notification-unit-test
         background: true
@@ -50,6 +55,7 @@ jobs:
         wait:
           - run-install-sh-unit-test
           - run-update-sh-unit-test
+          - run-ai-alias-unit-test
           - run-notification-unit-test
           - run-hooks-unit-test
           - run-pr-monitor-unit-test

--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -31,7 +31,23 @@ _claude_trust_cwd() {
     fi
   fi
 }
+
+# remote-settings.json が空オブジェクト以外なら警告し、Claude 起動前に 10 秒待機する。
+_claude_warn_remote_settings() {
+  local env_dir="${CLAUDE_ENV_FILE:-}"
+  [ -n "$env_dir" ] || return 0
+
+  local settings="$env_dir/remote-settings.json"
+  [ -f "$settings" ] || return 0
+
+  if ! jq -e 'type == "object" and length == 0' "$settings" > /dev/null 2>&1; then
+    printf 'WARNING: %s is not an empty JSON object ({}). Claude will start in 10 seconds.\n' "$settings" >&2
+    sleep 10
+  fi
+}
+
 claude() {
+  _claude_warn_remote_settings
   [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only claude
   ~/.local/share/chezmoi/update.sh
   case "$1" in

--- a/tests/unit/test_ai_alias.sh
+++ b/tests/unit/test_ai_alias.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# AI CLI alias/functions のユニットテスト
+set -euo pipefail
+
+SCRIPT="$(pwd)/home/dot_bashrc.d/executable_90-ai-alias.sh"
+set +e
+# shellcheck source=/dev/null
+source "$SCRIPT"
+SOURCE_RC=$?
+set -e
+[[ $SOURCE_RC -eq 0 ]] || { echo "❌ failed to source AI alias definitions"; exit 1; }
+
+declare -F _claude_warn_remote_settings >/dev/null || {
+  echo "❌ _claude_warn_remote_settings is not defined"
+  exit 1
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+SLEEP_LOG="$TEST_ROOT/sleep.log"
+
+sleep() {
+  printf '%s\n' "$1" >> "$SLEEP_LOG"
+  if [[ -n "${EVENT_LOG:-}" ]]; then
+    printf 'sleep:%s\n' "$1" >> "$EVENT_LOG"
+  fi
+}
+
+run_check() {
+  local env_dir="$1"
+  local output_file="$2"
+  : > "$SLEEP_LOG"
+  CLAUDE_ENV_FILE="$env_dir" _claude_warn_remote_settings 2> "$output_file"
+}
+
+echo "Testing empty remote-settings.json does not warn..."
+EMPTY_DIR="$TEST_ROOT/empty"
+mkdir -p "$EMPTY_DIR"
+printf '{ }\n' > "$EMPTY_DIR/remote-settings.json"
+run_check "$EMPTY_DIR" "$TEST_ROOT/empty.err"
+[[ ! -s "$SLEEP_LOG" ]] || { echo "❌ empty settings triggered sleep"; exit 1; }
+[[ ! -s "$TEST_ROOT/empty.err" ]] || { echo "❌ empty settings triggered warning"; exit 1; }
+echo "✅ empty settings test passed"
+
+echo "Testing non-empty remote-settings.json warns and sleeps 10 seconds..."
+NONEMPTY_DIR="$TEST_ROOT/nonempty"
+mkdir -p "$NONEMPTY_DIR"
+printf '{"model":"opus"}\n' > "$NONEMPTY_DIR/remote-settings.json"
+run_check "$NONEMPTY_DIR" "$TEST_ROOT/nonempty.err"
+[[ "$(cat "$SLEEP_LOG")" == "10" ]] || { echo "❌ non-empty settings did not sleep 10 seconds"; exit 1; }
+grep -Fq 'remote-settings.json' "$TEST_ROOT/nonempty.err" || { echo "❌ warning does not identify remote-settings.json"; exit 1; }
+grep -Fq '10' "$TEST_ROOT/nonempty.err" || { echo "❌ warning does not mention 10 seconds"; exit 1; }
+echo "✅ non-empty settings test passed"
+
+echo "Testing invalid JSON warns and sleeps 10 seconds..."
+INVALID_DIR="$TEST_ROOT/invalid"
+mkdir -p "$INVALID_DIR"
+printf 'not-json\n' > "$INVALID_DIR/remote-settings.json"
+run_check "$INVALID_DIR" "$TEST_ROOT/invalid.err"
+[[ "$(cat "$SLEEP_LOG")" == "10" ]] || { echo "❌ invalid JSON did not sleep 10 seconds"; exit 1; }
+echo "✅ invalid JSON test passed"
+
+echo "Testing missing remote-settings.json does not warn..."
+MISSING_DIR="$TEST_ROOT/missing"
+mkdir -p "$MISSING_DIR"
+run_check "$MISSING_DIR" "$TEST_ROOT/missing.err"
+[[ ! -s "$SLEEP_LOG" ]] || { echo "❌ missing settings triggered sleep"; exit 1; }
+[[ ! -s "$TEST_ROOT/missing.err" ]] || { echo "❌ missing settings triggered warning"; exit 1; }
+echo "✅ missing settings test passed"
+
+echo "Testing unset CLAUDE_ENV_FILE does not warn..."
+: > "$SLEEP_LOG"
+unset CLAUDE_ENV_FILE
+_claude_warn_remote_settings 2> "$TEST_ROOT/unset.err"
+[[ ! -s "$SLEEP_LOG" ]] || { echo "❌ unset CLAUDE_ENV_FILE triggered sleep"; exit 1; }
+[[ ! -s "$TEST_ROOT/unset.err" ]] || { echo "❌ unset CLAUDE_ENV_FILE triggered warning"; exit 1; }
+echo "✅ unset CLAUDE_ENV_FILE test passed"
+
+echo "Testing claude wrapper checks settings before launching Claude..."
+FAKE_HOME="$TEST_ROOT/home"
+FAKE_BIN="$TEST_ROOT/bin"
+WRAPPER_ENV="$TEST_ROOT/wrapper-env"
+EVENT_LOG="$TEST_ROOT/events.log"
+mkdir -p "$FAKE_HOME/.local/share/chezmoi" "$FAKE_BIN" "$WRAPPER_ENV"
+printf '#!/bin/bash\nexit 0\n' > "$FAKE_HOME/.local/share/chezmoi/update.sh"
+cat > "$FAKE_BIN/claude" <<'EOF'
+#!/bin/bash
+printf 'claude:%s\n' "$*" >> "$EVENT_LOG"
+EOF
+chmod +x "$FAKE_HOME/.local/share/chezmoi/update.sh" "$FAKE_BIN/claude"
+printf '{"model":"opus"}\n' > "$WRAPPER_ENV/remote-settings.json"
+: > "$SLEEP_LOG"
+: > "$EVENT_LOG"
+export EVENT_LOG
+HOME="$FAKE_HOME" PATH="$FAKE_BIN:/usr/bin:/bin" CLAUDE_ENV_FILE="$WRAPPER_ENV" claude --version 2> "$TEST_ROOT/wrapper.err"
+[[ "$(cat "$SLEEP_LOG")" == "10" ]] || { echo "❌ claude wrapper did not sleep 10 seconds"; exit 1; }
+[[ "$(sed -n '1p' "$EVENT_LOG")" == "sleep:10" ]] || { echo "❌ warning delay did not occur before Claude launch"; exit 1; }
+grep -Fq 'claude:--permission-mode auto --version' "$EVENT_LOG" || { echo "❌ wrapped Claude command was not launched"; exit 1; }
+echo "✅ claude wrapper warning order test passed"


### PR DESCRIPTION
## Summary
- warn before launching `claude` when `$CLAUDE_ENV_FILE/remote-settings.json` is not an empty JSON object
- wait 10 seconds before continuing startup
- add unit coverage and wire it into CI

## Verification
- unit tests
- bash syntax checks
- ShellCheck
- JSON schema check
- workflow YAML parse
- `git diff --check`
- smoke test confirming an actual 10-second delay before a fake Claude executable launches