### PR TITLE
fix: ccstatusline / tmux Powerline の高 CPU 負荷を軽量化する

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -36,6 +36,11 @@ jobs:
         background: true
         run: bash tests/unit/test_hooks.sh
 
+      - name: Run powerline daemon launch unit test
+        id: run-powerline-daemon-launch-unit-test
+        background: true
+        run: bash tests/unit/test_powerline_daemon_launch.sh
+
       - name: Run PR monitor unit test
         id: run-pr-monitor-unit-test
         background: true
@@ -52,5 +57,6 @@ jobs:
           - run-update-sh-unit-test
           - run-notification-unit-test
           - run-hooks-unit-test
+          - run-powerline-daemon-launch-unit-test
           - run-pr-monitor-unit-test
           - run-trilium-validation-unit-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ chezmoi はソース側のプレフィックスを解釈してデプロイする
 - `.env.example` と `.gitconfig.local.example` をサンプルとして提供。
 - wakatime は別途管理するため、dotfiles での暗号化管理は行わない。
 - PR 作成先は `upstream` remote があればそれを既定とし、`home/bin/executable_gh-pr-target-repo.sh`（デプロイ後 `~/bin/gh-pr-target-repo.sh`）で解決する。
-- 依存バージョンの更新は `renovate.json` の Renovate (GitHub App) で管理する。`home/dot_claude/private_settings.json` の `statusLine.command` に埋め込まれた `ccstatusline` の npm バージョンや、`install.sh` に固定記述された mise 本体のバージョンなど、通常の `package.json` では追跡できない箇所は `regexManagers` で個別に対象化する。`gh`/`ghq`/`roots`/`gitleaks` など mise 管理下のツールバージョンは `home/dot_config/mise/config.toml` への宣言により Renovate のネイティブな mise サポートで自動追跡される(`regexManagers` の追加設定は不要)。
+- 依存バージョンの更新は `renovate.json` の Renovate (GitHub App) で管理する。`install.sh` に固定記述された mise 本体のバージョンなど、通常の `package.json` では追跡できない箇所は `regexManagers` で個別に対象化する。`gh`/`ghq`/`roots`/`gitleaks`/`ccstatusline` など mise 管理下のツールバージョンは `home/dot_config/mise/config.toml` への宣言により Renovate のネイティブな mise サポートで自動追跡される(`regexManagers` の追加設定は不要)。
 - chezmoi によるデプロイ先 (`~/.claude/` 配下など、`home/dot_*` から展開される全ての実体) を直接編集してはならない。必ず対応する `home/dot_*` 配下のソースファイルを編集し、動作確認が必要な場合は `chezmoi apply` (または `chezmoi diff`) で反映すること。デプロイ先を直接編集すると、その後の `chezmoi apply`/`chezmoi update` (自動実行される場合を含む) によってソース側の内容で無言のまま上書き・巻き戻しされる。
 - 既存の managed file を rename / delete して target 側からも消す場合は、`home/.chezmoiremove` に旧 target path を追加する。`.claude` / `.codex` のように runtime state を持つディレクトリを `exact_` 化してはならない。
 - `chezmoi-update.service` / `.timer` など systemd の定期更新設定は dotfiles では管理しない。AI CLI 起動時の `update.sh` は 24 時間 throttle と `flock` を使い、`chezmoi update` 成功後は managed global config (`~/.config/mise/config.toml`) を明示して `mise install` を実行し、mise まで成功した場合だけ更新 timestamp を記録する。

--- a/home/bin/executable_powerline-daemon-launch.sh
+++ b/home/bin/executable_powerline-daemon-launch.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Powerline daemon 起動ラッパー
+#
+# tmux.conf から呼ばれ、以下を行う:
+#   1. native の /usr/bin/powerline-daemon が Python 3.14 の argparse
+#      非互換で起動できるかを feature detection する。
+#   2. native が動く場合はそのまま exec する。
+#   3. native が動かない場合、powerline.commands.daemon.get_argparser()
+#      のみを nested argument group を使わない同等のパーサーへ
+#      monkeypatch した上で、本来の /usr/bin/powerline-daemon の
+#      main() をそのまま実行する (daemon化・socket bind等は無改変)。
+#
+# ponytail: 差し替え対象は get_argparser() の1関数のみ。
+#   upstream/Ubuntu パッケージが Python 3.14 対応した後は feature
+#   detection が成功するため、本 fallback は自動的に使われなくなる。
+set -euo pipefail
+
+PYTHON3="${POWERLINE_DAEMON_LAUNCH_PYTHON3:-/usr/bin/python3}"
+DAEMON="${POWERLINE_DAEMON_LAUNCH_DAEMON:-/usr/bin/powerline-daemon}"
+
+# PATH 上の python3 は mise の shim を指す可能性があり、
+# /usr/bin/powerline-daemon 自身の shebang (/usr/bin/python3) と
+# 異なるバージョンで判定すると誤判定するため、明示的に固定する。
+if "$PYTHON3" -c 'from powerline.commands.daemon import get_argparser as g; g()' >/dev/null 2>&1; then
+  exec "$DAEMON" "$@"
+fi
+
+exec "$PYTHON3" - "$@" <<PYEOF
+import argparse
+import runpy
+import sys
+
+import powerline.commands.daemon as d
+
+DAEMON = "$DAEMON"
+
+
+def get_argparser(ArgumentParser=argparse.ArgumentParser):
+    p = ArgumentParser(description="Daemon that improves powerline performance.")
+    p.add_argument("--quiet", "-q", action="store_true")
+    p.add_argument("--socket", "-s")
+    ex = p.add_mutually_exclusive_group()
+    ex.add_argument("--kill", "-k", action="store_true")
+    # Python 3.14 では mutually-exclusive-group への
+    # add_argument_group() がネストとして拒否される。
+    # --foreground/--replace は元コードでも互いに排他ではなく
+    # (--kill との排他は main() 側の明示チェックで行われる)、
+    # ネストせずトップレベルへ追加しても挙動は同一。
+    p.add_argument("--foreground", "-f", action="store_true")
+    p.add_argument("--replace", "-r", action="store_true")
+    return p
+
+
+d.get_argparser = get_argparser
+sys.argv[0] = DAEMON
+runpy.run_path(DAEMON, run_name="__main__")
+PYEOF

--- a/home/bin/executable_powerline-daemon-launch.sh
+++ b/home/bin/executable_powerline-daemon-launch.sh
@@ -1,26 +1,16 @@
 #!/bin/bash
-# Powerline daemon 起動ラッパー
+# Powerline daemon 起動ラッパー。tmux.conf から呼ばれる。
 #
-# tmux.conf から呼ばれ、以下を行う:
-#   1. native の /usr/bin/powerline-daemon が Python 3.14 の argparse
-#      非互換で起動できるかを feature detection する。
-#   2. native が動く場合はそのまま exec する。
-#   3. native が動かない場合、powerline.commands.daemon.get_argparser()
-#      のみを nested argument group を使わない同等のパーサーへ
-#      monkeypatch した上で、本来の /usr/bin/powerline-daemon の
-#      main() をそのまま実行する (daemon化・socket bind等は無改変)。
+# get_argparser() のみを monkeypatch し、daemon 本体の main() は無改変で実行する。
 #
-# ponytail: 差し替え対象は get_argparser() の1関数のみ。
-#   upstream/Ubuntu パッケージが Python 3.14 対応した後は feature
-#   detection が成功するため、本 fallback は自動的に使われなくなる。
+# ponytail: 差し替え対象は get_argparser() の 1 関数のみ。
+# upstream が Python 3.14 に対応すれば feature detection が成功し、fallback は自動的に使われなくなる。
 set -euo pipefail
 
 PYTHON3="${POWERLINE_DAEMON_LAUNCH_PYTHON3:-/usr/bin/python3}"
 DAEMON="${POWERLINE_DAEMON_LAUNCH_DAEMON:-/usr/bin/powerline-daemon}"
 
-# PATH 上の python3 は mise の shim を指す可能性があり、
-# /usr/bin/powerline-daemon 自身の shebang (/usr/bin/python3) と
-# 異なるバージョンで判定すると誤判定するため、明示的に固定する。
+# PATH 上の python3 は mise shim を指しうるため、shebang と同じ /usr/bin/python3 を明示的に固定する。
 if "$PYTHON3" -c 'from powerline.commands.daemon import get_argparser as g; g()' >/dev/null 2>&1; then
   exec "$DAEMON" "$@"
 fi
@@ -41,11 +31,8 @@ def get_argparser(ArgumentParser=argparse.ArgumentParser):
     p.add_argument("--socket", "-s")
     ex = p.add_mutually_exclusive_group()
     ex.add_argument("--kill", "-k", action="store_true")
-    # Python 3.14 では mutually-exclusive-group への
-    # add_argument_group() がネストとして拒否される。
-    # --foreground/--replace は元コードでも互いに排他ではなく
-    # (--kill との排他は main() 側の明示チェックで行われる)、
-    # ネストせずトップレベルへ追加しても挙動は同一。
+    # Python 3.14 では mutually-exclusive-group への add_argument_group() がネストとして拒否される。
+    # --foreground/--replace は元々 --kill と排他ではないため、トップレベルへ移しても挙動は同一。
     p.add_argument("--foreground", "-f", action="store_true")
     p.add_argument("--replace", "-r", action="store_true")
     return p

--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -156,7 +156,7 @@
   "enableWorkflows": false,
   "statusLine": {
     "type": "command",
-    "command": "npx -y --offline ccstatusline@2.2.23 || npx -y ccstatusline@2.2.23"
+    "command": "ccstatusline"
   },
   "extraKnownMarketplaces": {
     "ponytail": {

--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -16,6 +16,7 @@ hadolint = "2.15.1"
 shfmt = "3.13.1"
 devcontainer-cli = "0.88.0"
 delta = "0.19.2"
+"npm:ccstatusline" = "2.2.23"
 
 [settings]
 idiomatic_version_file_enable_tools = ["node"]

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -48,5 +48,6 @@ set -sg escape-time 1000
 
 # powerline の設定を条件付きで読み込む
 # powerline が存在しない環境ではエラーを抑制
+# powerline-base.conf が status-interval を 2 秒へ上書きするため、読み込み後に 5 秒へ戻す
 if-shell "test -f /usr/share/powerline/bindings/tmux/powerline.conf" \
   "run-shell '~/bin/powerline-daemon-launch.sh -q'; source /usr/share/powerline/bindings/tmux/powerline.conf; set -g status-interval 5"

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -49,4 +49,4 @@ set -sg escape-time 1000
 # powerline の設定を条件付きで読み込む
 # powerline が存在しない環境ではエラーを抑制
 if-shell "test -f /usr/share/powerline/bindings/tmux/powerline.conf" \
-  "run-shell 'powerline-daemon -q'; source /usr/share/powerline/bindings/tmux/powerline.conf"
+  "run-shell '~/bin/powerline-daemon-launch.sh -q'; source /usr/share/powerline/bindings/tmux/powerline.conf; set -g status-interval 5"

--- a/install.sh
+++ b/install.sh
@@ -510,11 +510,13 @@ install_mise_tools() {
     run_command mise install "$tool"
   done
 
-  # devcontainer-cli は npm backend を使うため、mise 管理の Node.js を先に用意する。
-  log_info "devcontainer-cli 用の Node.js を mise 経由でインストールしています..."
+  # devcontainer-cli / ccstatusline は npm backend を使うため、mise 管理の Node.js を先に用意する。
+  log_info "devcontainer-cli / ccstatusline 用の Node.js を mise 経由でインストールしています..."
   run_command mise install node
   log_info "devcontainer-cli を mise 経由でインストールしています..."
   run_command mise exec node -- mise install devcontainer-cli
+  log_info "ccstatusline を mise 経由でインストールしています..."
+  run_command mise exec node -- mise install npm:ccstatusline
 }
 
 # mkwork のインストール

--- a/install.sh
+++ b/install.sh
@@ -429,7 +429,7 @@ install_apt_packages() {
 }
 
 # mise のバージョン (Renovate で追跡するため固定文字列として記述する)
-MISE_VERSION="v2026.7.6"
+MISE_VERSION="v2026.8.5"
 
 # mise のインストール
 install_mise() {

--- a/renovate.json
+++ b/renovate.json
@@ -4,13 +4,6 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^home/dot_claude/private_settings\\.json$/"],
-      "matchStrings": ["ccstatusline@(?<currentValue>[0-9.]+)"],
-      "depNameTemplate": "ccstatusline",
-      "datasourceTemplate": "npm"
-    },
-    {
-      "customType": "regex",
       "managerFilePatterns": ["/^install\\.sh$/"],
       "matchStrings": ["MISE_VERSION=\"(?<currentValue>v[0-9.]+)\""],
       "depNameTemplate": "jdx/mise",

--- a/tests/integration/test_chezmoi_apply.sh
+++ b/tests/integration/test_chezmoi_apply.sh
@@ -113,6 +113,11 @@ if [ ! -x "$HOME/bin/gh-pr-target-repo.sh" ]; then
   exit 1
 fi
 
+if [ ! -x "$HOME/bin/powerline-daemon-launch.sh" ]; then
+  echo "❌ powerline-daemon-launch helper not generated"
+  exit 1
+fi
+
 if [ ! -x "$HOME/.agents/skills/pr-health-monitor/scripts/wait-for-copilot-review.sh" ]; then
   echo "❌ Codex Copilot review watcher script not generated"
   exit 1

--- a/tests/integration/test_mise_tools.sh
+++ b/tests/integration/test_mise_tools.sh
@@ -21,7 +21,8 @@ curl -fsSL https://mise.run | MISE_VERSION="$MISE_VERSION" sh
 # npm backend の devcontainer-cli と Maven の実行依存を先に用意する。
 mise install node java
 mise install pnpm ghq gh github:k1LoW/roots gitleaks \
-  maven ripgrep yq actionlint hadolint shfmt devcontainer-cli delta
+  maven ripgrep yq actionlint hadolint shfmt devcontainer-cli delta \
+  npm:ccstatusline@2.2.23
 
 checks=(
   "pnpm|pnpm --version"
@@ -37,6 +38,7 @@ checks=(
   "shfmt|shfmt --version"
   "node,devcontainer-cli|devcontainer --version"
   "delta|delta --version"
+  "node,npm:ccstatusline@2.2.23|ccstatusline --version"
 )
 
 for check in "${checks[@]}"; do

--- a/tests/integration/test_mise_tools.sh
+++ b/tests/integration/test_mise_tools.sh
@@ -22,7 +22,7 @@ curl -fsSL https://mise.run | MISE_VERSION="$MISE_VERSION" sh
 mise install node java
 mise install pnpm ghq gh github:k1LoW/roots gitleaks \
   maven ripgrep yq actionlint hadolint shfmt devcontainer-cli delta \
-  npm:ccstatusline@2.2.23
+  npm:ccstatusline
 
 checks=(
   "pnpm|pnpm --version"
@@ -38,7 +38,7 @@ checks=(
   "shfmt|shfmt --version"
   "node,devcontainer-cli|devcontainer --version"
   "delta|delta --version"
-  "node,npm:ccstatusline@2.2.23|ccstatusline --version"
+  "node,npm:ccstatusline|ccstatusline --version"
 )
 
 for check in "${checks[@]}"; do

--- a/tests/unit/test_install.sh
+++ b/tests/unit/test_install.sh
@@ -45,7 +45,7 @@ echo "✅ apt package list includes libatomic1"
 # テスト 2.7: 開発用 CLI が mise config に宣言されていること
 echo "Test 2.7: mise config includes development tools"
 MISE_CONFIG="home/dot_config/mise/config.toml"
-MISE_TOOLS=(maven ripgrep yq actionlint hadolint shfmt devcontainer-cli delta)
+MISE_TOOLS=(maven ripgrep yq actionlint hadolint shfmt devcontainer-cli delta "npm:ccstatusline")
 for tool in "${MISE_TOOLS[@]}"; do
   if ! grep -Eq "^\"?${tool}\"? = " "$MISE_CONFIG"; then
     echo "❌ mise config does not include $tool"
@@ -82,8 +82,9 @@ for tool in "${MISE_DIRECT_TOOLS[@]}"; do
   fi
 done
 if ! grep -Fq "[DRY RUN] mise install node" <<< "$MISE_DRY_RUN" \
-  || ! grep -Fq "[DRY RUN] mise exec node -- mise install devcontainer-cli" <<< "$MISE_DRY_RUN"; then
-  echo "❌ install flow does not bootstrap devcontainer-cli with mise-managed Node"
+  || ! grep -Fq "[DRY RUN] mise exec node -- mise install devcontainer-cli" <<< "$MISE_DRY_RUN" \
+  || ! grep -Fq "[DRY RUN] mise exec node -- mise install npm:ccstatusline" <<< "$MISE_DRY_RUN"; then
+  echo "❌ install flow does not bootstrap devcontainer-cli/ccstatusline with mise-managed Node"
   exit 1
 fi
 echo "✅ install flow installs development tools via mise"

--- a/tests/unit/test_powerline_daemon_launch.sh
+++ b/tests/unit/test_powerline_daemon_launch.sh
@@ -39,9 +39,9 @@ OUTPUT=$(POWERLINE_DAEMON_LAUNCH_PYTHON3="$TEST_DIR/python3-ok.sh" \
   POWERLINE_DAEMON_LAUNCH_DAEMON="$TEST_DIR/daemon.sh" \
   bash "$SCRIPT" -q)
 if [[ "$OUTPUT" == "NATIVE_INVOKED -q" ]]; then
-  echo "✅ native daemon が動作可能な場合、native をそのまま exec する"
+  echo "✅ native branch execs the native daemon directly"
 else
-  echo "❌ native 分岐が期待通りに動作しなかった: $OUTPUT"
+  echo "❌ native branch did not behave as expected: $OUTPUT"
   FAILED=1
 fi
 
@@ -59,9 +59,9 @@ OUTPUT=$(POWERLINE_DAEMON_LAUNCH_PYTHON3="$TEST_DIR/python3-broken.sh" \
   POWERLINE_DAEMON_LAUNCH_DAEMON="$TEST_DIR/daemon.sh" \
   bash "$SCRIPT" -q)
 if [[ "$OUTPUT" == "COMPAT_INVOKED - -q" ]]; then
-  echo "✅ native daemon が動作不可の場合、compat fallback を実行する"
+  echo "✅ compat branch runs the fallback when native is broken"
 else
-  echo "❌ compat 分岐が期待通りに動作しなかった: $OUTPUT"
+  echo "❌ compat branch did not behave as expected: $OUTPUT"
   FAILED=1
 fi
 

--- a/tests/unit/test_powerline_daemon_launch.sh
+++ b/tests/unit/test_powerline_daemon_launch.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# powerline-daemon-launch.sh のユニットテスト
+#
+# 実際の python3-powerline パッケージの有無に依存せず、
+# native/compat 分岐ロジックのみを fake バイナリで検証する。
+
+set -euo pipefail
+
+echo "Testing powerline-daemon-launch.sh..."
+
+FAILED=0
+SCRIPT="home/bin/executable_powerline-daemon-launch.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "❌ Script not found: $SCRIPT"
+  exit 1
+fi
+
+bash -n "$SCRIPT" || { echo "❌ Syntax error: $SCRIPT"; exit 1; }
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# 1. native (get_argparser 呼び出し成功) の場合、native daemon をそのまま exec する
+cat > "$TEST_DIR/python3-ok.sh" <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "-c" ]]; then
+  exit 0
+fi
+echo "COMPAT_INVOKED $*"
+EOF
+cat > "$TEST_DIR/daemon.sh" <<'EOF'
+#!/bin/bash
+echo "NATIVE_INVOKED $*"
+EOF
+chmod +x "$TEST_DIR/python3-ok.sh" "$TEST_DIR/daemon.sh"
+
+OUTPUT=$(POWERLINE_DAEMON_LAUNCH_PYTHON3="$TEST_DIR/python3-ok.sh" \
+  POWERLINE_DAEMON_LAUNCH_DAEMON="$TEST_DIR/daemon.sh" \
+  bash "$SCRIPT" -q)
+if [[ "$OUTPUT" == "NATIVE_INVOKED -q" ]]; then
+  echo "✅ native daemon が動作可能な場合、native をそのまま exec する"
+else
+  echo "❌ native 分岐が期待通りに動作しなかった: $OUTPUT"
+  FAILED=1
+fi
+
+# 2. native (get_argparser 呼び出し失敗) の場合、compat fallback を実行する
+cat > "$TEST_DIR/python3-broken.sh" <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "-c" ]]; then
+  exit 1
+fi
+echo "COMPAT_INVOKED $*"
+EOF
+chmod +x "$TEST_DIR/python3-broken.sh"
+
+OUTPUT=$(POWERLINE_DAEMON_LAUNCH_PYTHON3="$TEST_DIR/python3-broken.sh" \
+  POWERLINE_DAEMON_LAUNCH_DAEMON="$TEST_DIR/daemon.sh" \
+  bash "$SCRIPT" -q)
+if [[ "$OUTPUT" == "COMPAT_INVOKED - -q" ]]; then
+  echo "✅ native daemon が動作不可の場合、compat fallback を実行する"
+else
+  echo "❌ compat 分岐が期待通りに動作しなかった: $OUTPUT"
+  FAILED=1
+fi
+
+exit $FAILED


### PR DESCRIPTION
## 概要

Issue #328 で報告された、ccstatusline / tmux Powerline の常時 CPU/メモリオーバーヘッドを軽量化する。

## 変更内容

1. **ccstatusline を mise で直接管理する**
   - `home/dot_config/mise/config.toml` の `[tools]` に `"npm:ccstatusline" = "2.2.23"` を追加
   - `home/dot_claude/private_settings.json` の `statusLine.command` を `npx` 経由から `ccstatusline` の直接実行に変更(npx オーバーヘッド ~4.0秒/1.87 CPU秒 → 直接実行 ~1.46秒/0.88 CPU秒)
   - `renovate.json` の ccstatusline 用 regex customManager を削除し、mise のネイティブサポートに一本化
   - `install.sh` の `install_mise_tools()` で `npm:ccstatusline` を明示的に導入するようにし、フレッシュな環境でも `statusLine.command` が command not found にならないようにした

2. **tmux の status-interval を全マシン共通で 5 秒にする**
   - `home/dot_tmux.conf` で Powerline 読み込み後に `status-interval 5` を再設定(Powerline の `powerline-base.conf` が 2 秒へ上書きする問題への対処)

3. **Powerline daemon の Python 3.14 互換対応**
   - `home/bin/executable_powerline-daemon-launch.sh` を新規追加(tmux から呼ばれる起動ラッパー)
   - native-first: `/usr/bin/powerline-daemon` が正常に動く場合はそのまま exec する
   - Python 3.14 の argparse 非互換(`get_argparser()` のネストした mutually-exclusive-group)を feature detection し、壊れている場合のみ `get_argparser()` のみを monkeypatch した compat 実行にフォールバックする
   - feature detection・compat 実行では PATH 上の `python3`(mise shim を指す可能性がある)ではなく `/usr/bin/python3` / `/usr/bin/powerline-daemon` を明示的に固定
   - systemd 等の常駐管理層は追加しない(Powerline daemon 自体は従来通り daemon 化される)
   - upstream/Ubuntu パッケージが Python 3.14 対応した後は feature detection が成功するため、自動的に native 実装へ戻る
   - Powerline 未導入環境では `home/dot_tmux.conf` 側の条件分岐によりラッパー自体が呼ばれない(no-op)

## テスト

- `tests/unit/test_powerline_daemon_launch.sh` を新規追加(fake バイナリで native/compat 分岐ロジックを検証)
- `tests/integration/test_mise_tools.sh` に ccstatusline のスモークテストを追加
- `tests/integration/test_chezmoi_apply.sh` に `powerline-daemon-launch.sh` のデプロイ検証を追加
- `tests/unit/test_install.sh` に ccstatusline の mise 導入検証を追加
- `.github/workflows/unit-test.yml` に新規ユニットテストのステップを追加
- 既存の `tests/syntax/`・`tests/unit/` 一式、`/deep-review` (ローカル diff モード、指摘 8 件はすべて修正済み) を実行し、すべて成功を確認済み
- 実機(Ubuntu 26.04 / Python 3.14.6 環境)で compat フォールバックの daemon 起動・`powerline` コマンドによる正常描画、および `status-interval` が Powerline 読み込み後も 5 秒のままであることを確認済み

Closes #328

Spec: https://github.com/book000/dotfiles/issues/328#issuecomment-5273840324
Plan: https://github.com/book000/dotfiles/issues/328#issuecomment-5274068313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
