### PR TITLE
feat: Codex tmux PR monitor を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Codex CLI では custom slash command の代わりに user scope の skill を�
 - `$ticket-pr <ticket-key-or-url>`: Jira チケットから PR 作成と PR 後フロー開始までを進めます。
 - `$glitchtip-pr [issue-id-or-url]`: GlitchTip issue から PR 作成と、user が明示的に要求した verified Resolve までを進めます。
 - `$pr-health-monitor <pr-number-or-url>`: CI、競合、PR 本文、Codex/Copilot レビューを確認し、XDG state に close/merge、CI failure、conflict、Copilot review を記録します。external scheduler がない `start` は `foreground_required` を返します。持続した terminal を user が明示的に用意できる場合だけ `watch` を foreground で実行します。GlitchTip callback は state に保存しません。
+- tmux 内で実行中の Codex では、PR monitor が専用 tmux window を起動し、pending event を固定形式の `$resume-pr-monitor` prompt として登録済み pane へ配送できます。delivery は at-least-once です。Codex が ready と記録された直後に user が入力を始めると text が混在し得るため、この mode はその race を許容する場合だけ使用します。tmux 外または pane registration が失敗した場合は、monitor を開始せず manual resume fallback を報告します。
 - `$resume-pr-monitor <pr-number-or-url>`: restart、agent capacity 不足、tmux 非対応、watcher 停止後に fresh GitHub state から event を reconcile し、lease を取得した pending action だけを処理します。watcher は action を実行しません。ChatGPT Desktop/Web の Scheduled Tasks を利用できる場合は project context の resume を予定できますが、local shell の detached watcher として扱いません。
 - `$handle-pr-reviews <pr-number-or-url>`: 未解決の PR レビュースレッドを処理します。
 - `$deep-review <pr-number-or-url>`: 複数観点で変更をレビューします。

--- a/home/dot_agents/skills/pr-health-monitor/SKILL.md
+++ b/home/dot_agents/skills/pr-health-monitor/SKILL.md
@@ -16,7 +16,15 @@ description: PR 作成直後に本文、CI、競合、レビューを確認し�
 1. PR を解決する。
    - 番号だけなら `gh-pr-target-repo.sh`、次に GitHub の `upstream` remote を優先する。
    - `gh pr view` で取得した `url` を canonical `PR_URL` とし、state/watcher にはこの URL だけを渡す。
-2. detached watcher は開始しない。`start` は `foreground_required` を state に記録して終了するため、成功した background 監視として報告しない。持続した terminal を user が明示的に用意できる場合だけ、次を foreground で実行する。
+2. Codex が tmux pane 内で動作している場合は、`TMUX_PANE` と 16 文字以上の random nonce を state に登録してから `watch-pr.sh start --pr-url "$PR_URL"` を実行する。start は専用 tmux window に supervisor を起動し、observer と dispatcher を継続実行する。
+
+   ```bash
+   nonce=$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')
+   ~/.agents/skills/pr-health-monitor/scripts/pr-monitor-state.sh register-pane --pr-url "$PR_URL" --pane "$TMUX_PANE" --nonce "$nonce"
+   ~/.agents/skills/pr-health-monitor/scripts/watch-pr.sh start --pr-url "$PR_URL"
+   ```
+
+   tmux 外、登録失敗、または window 起動失敗では `foreground_required` を state に記録し、成功した background 監視として報告しない。
 
    ```bash
    ~/.agents/skills/pr-health-monitor/scripts/watch-pr.sh watch --pr-url "$PR_URL"
@@ -30,8 +38,8 @@ description: PR 作成直後に本文、CI、競合、レビューを確認し�
    - 現在の worktree が対象 PR の repository と head に対応することを `git remote -v` と branch で確認する。対応しない worktree で修正や `codex review` を推測実行しない。
    - 対応する場合だけ target remote の base ref を確認し、必要なら `git fetch <target-remote> <base-ref>` を実行して `codex review --base <target-remote>/<base-ref>` を使う。`origin/master` を固定値にしない。
    - 対応する checkout がない場合は、その事実を報告し、対象 repository を明示して clone/worktree を用意してから再実行する。PR の diff と review threads の確認は続けられるが、ローカル修正は行わない。
-6. `request-review-copilot` が利用できる場合だけ review を依頼する。続けて `wait-for-copilot-review.sh "$PR_URL" &` を best effort で開始する。この補助 script は durable Copilot event を記録・通知するだけで、action は `$resume-pr-monitor` が実行する。
-7. CI、競合、本文、ローカルレビュー、Copilot request、foreground watcher の状態または resume fallback を報告する。Codex の agent capacity がない場合、CLI 以外の場合、tmux がない場合、または session/restart 後は `$resume-pr-monitor <PR_URL>` で pending event を安全に処理する。
+6. `request-review-copilot` が利用できる場合だけ review を依頼する。Copilot の観測は watcher に統合し、`wait-for-copilot-review.sh` を background 起動しない。
+7. CI、競合、本文、ローカルレビュー、Copilot request、tmux monitor の状態または resume fallback を報告する。dispatcher は lifecycle hook が `ready` と記録した pane へだけ固定の `$resume-pr-monitor` prompt を送る。user が ready 後に入力を始めた場合の入力混在 race は、user が許容した既知の制約である。
 
 ## 境界
 

--- a/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh
+++ b/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh
@@ -44,7 +44,8 @@ EVENT=$(jq -r '
     end
 ' <<< "$STATE" | head -n 1)
 [[ "$EVENT" =~ ^(close|ci_failure|conflict|copilot_review)$ ]] || exit 0
-EVENT_ID="${EVENT}:1"
+EVENT_ID=$(jq -r --arg event "$EVENT" 'if $event == "close" then .events.close.id // "close:1" else .events[$event].id // ($event + ":1") end' <<< "$STATE")
+[[ "$EVENT_ID" =~ ^(close|ci_failure|conflict|copilot_review):[1-9][0-9]*$ ]] || exit 0
 PROMPT="\$resume-pr-monitor $PR_URL --event-id $EVENT_ID"
 
 tmux send-keys -t "$PANE" -l -- "$PROMPT"

--- a/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh
+++ b/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# PR event を登録済み Codex pane へ固定形式で配送する。
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+STATE_HELPER="$SCRIPT_DIR/pr-monitor-state.sh"
+[[ -x "$STATE_HELPER" ]] || STATE_HELPER="$SCRIPT_DIR/executable_pr-monitor-state.sh"
+
+usage() {
+    echo "Usage: $0 --pr-url URL" >&2
+    exit 1
+}
+
+PR_URL=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr-url)
+            PR_URL="${2:-}"
+            shift
+            ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+[[ "$PR_URL" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+$ ]] || usage
+[[ -x "$STATE_HELPER" ]] || { echo "Error: Missing PR monitor state helper" >&2; exit 1; }
+
+STATE=$($STATE_HELPER show --pr-url "$PR_URL")
+PANE=$(jq -r '.runtime.pane // empty' <<< "$STATE")
+SESSION_ID=$(jq -r '.runtime.session_id // empty' <<< "$STATE")
+STATUS=$(jq -r '.runtime.status // empty' <<< "$STATE")
+[[ "$PANE" =~ ^%[0-9]+$ && "$SESSION_ID" =~ ^[A-Za-z0-9_.-]+$ && "$STATUS" == "ready" ]] || exit 0
+
+CURRENT_PANE=$(tmux display-message -p -t "$PANE" '#{pane_id}' 2>/dev/null || true)
+[[ "$CURRENT_PANE" == "$PANE" ]] || exit 0
+
+EVENT=$(jq -r '
+    if .events.close != null and .events.close.actions.cleanup.status == "pending" then
+        "close"
+    else
+        .events | to_entries[] | select(.key != "close" and .value != null and .value.status == "pending") | .key
+    end
+' <<< "$STATE" | head -n 1)
+[[ "$EVENT" =~ ^(close|ci_failure|conflict|copilot_review)$ ]] || exit 0
+EVENT_ID="${EVENT}:1"
+PROMPT="\$resume-pr-monitor $PR_URL --event-id $EVENT_ID"
+
+tmux send-keys -t "$PANE" -l -- "$PROMPT"
+tmux send-keys -t "$PANE" Enter

--- a/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh
+++ b/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh
@@ -262,7 +262,7 @@ case "$COMMAND" in
             temp_file=$(mktemp "$STATE_DIR/.${STATE_ID}.XXXXXX")
             chmod 600 "$temp_file"
             jq -n --arg url "$CANONICAL_PR_URL" --arg owner "$OWNER" --arg repo "$REPO" --argjson number "$PR_NUMBER" \
-                '{version: 3, pr: {url: $url, owner: $owner, repo: $repo, number: $number}, observed: {state: "OPEN", ci: "unknown", conflict: "unknown", copilot: "none"}, events: {close: null, ci_failure: null, conflict: null, copilot_review: null}, watcher: {pid: null, failures: 0, updated_at: null, last_error: null}, runtime: {pane: null, nonce: null, session_id: null, status: "unregistered", updated_at: null}}' > "$temp_file"
+                '{version: 3, pr: {url: $url, owner: $owner, repo: $repo, number: $number}, observed: {state: "OPEN", ci: "unknown", conflict: "unknown", copilot: "none"}, generations: {close: 0, ci_failure: 0, conflict: 0, copilot_review: 0}, events: {close: null, ci_failure: null, conflict: null, copilot_review: null}, watcher: {pid: null, failures: 0, updated_at: null, last_error: null}, runtime: {pane: null, nonce: null, session_id: null, status: "unregistered", updated_at: null}}' > "$temp_file"
             mv "$temp_file" "$STATE_FILE"
         else
             verify_state
@@ -289,19 +289,19 @@ case "$COMMAND" in
         case "$EVENT" in
             close)
                 [[ "$VALUE" == "MERGED" || "$VALUE" == "CLOSED" ]] || { echo "Error: Invalid close value" >&2; exit 1; }
-                write_state 'if .observed.state == $value then . else .observed.state = $value | .events.close = {status: "pending", value: $value, detected_at: $now, actions: {cleanup: {status: "pending", lease: null}, "glitchtip-resolve": {status: "not_applicable", lease: null}}} end' --arg value "$VALUE" --arg now "$NOW"
+                write_state 'if .observed.state == $value then . else .observed.state = $value | .generations.close = ((.generations.close // 0) + 1) | .events.close = {id: ("close:" + (.generations.close | tostring)), status: "pending", value: $value, detected_at: $now, actions: {cleanup: {status: "pending", lease: null}, "glitchtip-resolve": {status: "not_applicable", lease: null}}} end' --arg value "$VALUE" --arg now "$NOW"
                 ;;
             ci)
                 [[ "$VALUE" == "failed" || "$VALUE" == "ok" ]] || { echo "Error: Invalid CI value" >&2; exit 1; }
-                write_state 'if .observed.ci == $value then . else .observed.ci = $value | (if $value == "failed" then .events.ci_failure = {status: "pending", value: $value, detected_at: $now, run_url: $run_url, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW" --arg run_url "$RUN_URL"
+                write_state 'if .observed.ci == $value then . else .observed.ci = $value | (if $value == "failed" then .generations.ci_failure = ((.generations.ci_failure // 0) + 1) | .events.ci_failure = {id: ("ci_failure:" + (.generations.ci_failure | tostring)), status: "pending", value: $value, detected_at: $now, run_url: $run_url, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW" --arg run_url "$RUN_URL"
                 ;;
             conflict)
                 [[ "$VALUE" == "conflicting" || "$VALUE" == "clear" ]] || { echo "Error: Invalid conflict value" >&2; exit 1; }
-                write_state 'if .observed.conflict == $value then . else .observed.conflict = $value | (if $value == "conflicting" then .events.conflict = {status: "pending", value: $value, detected_at: $now, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW"
+                write_state 'if .observed.conflict == $value then . else .observed.conflict = $value | (if $value == "conflicting" then .generations.conflict = ((.generations.conflict // 0) + 1) | .events.conflict = {id: ("conflict:" + (.generations.conflict | tostring)), status: "pending", value: $value, detected_at: $now, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW"
                 ;;
             copilot)
                 [[ "$VALUE" == "detected" || "$VALUE" == "none" ]] || { echo "Error: Invalid Copilot value" >&2; exit 1; }
-                write_state 'if .observed.copilot == $value then . else .observed.copilot = $value | (if $value == "detected" then .events.copilot_review = {status: "pending", value: $value, detected_at: $now, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW"
+                write_state 'if .observed.copilot == $value then . else .observed.copilot = $value | (if $value == "detected" then .generations.copilot_review = ((.generations.copilot_review // 0) + 1) | .events.copilot_review = {id: ("copilot_review:" + (.generations.copilot_review | tostring)), status: "pending", value: $value, detected_at: $now, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW"
                 ;;
             *) usage ;;
         esac

--- a/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh
+++ b/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh
@@ -14,7 +14,7 @@ umask 077
 mkdir -p "$STATE_DIR"
 
 usage() {
-    echo "Usage: $0 <init|id|show|pending|transition|claim|renew|ack|release|watcher|watcher-error|api-failure> --pr-url URL [...]" >&2
+    echo "Usage: $0 <init|id|show|pending|transition|claim|renew|ack|release|watcher|watcher-error|api-failure|register-pane|pane-status|unregister-pane> --pr-url URL [...]" >&2
     exit 1
 }
 
@@ -29,10 +29,14 @@ WATCHER_PID=""
 FAILURE_COUNT=""
 RUN_URL=""
 WATCHER_REASON=""
+TMUX_PANE=""
+REGISTRATION_NONCE=""
+SESSION_ID=""
+PANE_STATUS=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        init|id|show|pending|transition|claim|renew|ack|release|watcher|watcher-error|api-failure)
+        init|id|show|pending|transition|claim|renew|ack|release|watcher|watcher-error|api-failure|register-pane|pane-status|unregister-pane)
             COMMAND="$1"
             ;;
         --pr-url)
@@ -73,6 +77,22 @@ while [[ $# -gt 0 ]]; do
             ;;
         --reason)
             WATCHER_REASON="${2:-}"
+            shift
+            ;;
+        --pane)
+            TMUX_PANE="${2:-}"
+            shift
+            ;;
+        --nonce)
+            REGISTRATION_NONCE="${2:-}"
+            shift
+            ;;
+        --session-id)
+            SESSION_ID="${2:-}"
+            shift
+            ;;
+        --status)
+            PANE_STATUS="${2:-}"
             shift
             ;;
         *)
@@ -203,7 +223,7 @@ trap release_lock EXIT
 
 verify_state() {
     [[ -f "$STATE_FILE" ]] || { echo "Error: PR monitor state does not exist; run init first" >&2; exit 1; }
-    if ! jq -e --arg url "$CANONICAL_PR_URL" '.version == 2 and .pr.url == $url and .pr.owner != null and .pr.repo != null and .pr.number != null' "$STATE_FILE" >/dev/null; then
+    if ! jq -e --arg url "$CANONICAL_PR_URL" '(.version == 2 or .version == 3) and .pr.url == $url and .pr.owner != null and .pr.repo != null and .pr.number != null' "$STATE_FILE" >/dev/null; then
         echo "Error: PR monitor state does not match the canonical PR URL" >&2
         exit 1
     fi
@@ -242,7 +262,7 @@ case "$COMMAND" in
             temp_file=$(mktemp "$STATE_DIR/.${STATE_ID}.XXXXXX")
             chmod 600 "$temp_file"
             jq -n --arg url "$CANONICAL_PR_URL" --arg owner "$OWNER" --arg repo "$REPO" --argjson number "$PR_NUMBER" \
-                '{version: 2, pr: {url: $url, owner: $owner, repo: $repo, number: $number}, observed: {state: "OPEN", ci: "unknown", conflict: "unknown", copilot: "none"}, events: {close: null, ci_failure: null, conflict: null, copilot_review: null}, watcher: {pid: null, failures: 0, updated_at: null, last_error: null}}' > "$temp_file"
+                '{version: 3, pr: {url: $url, owner: $owner, repo: $repo, number: $number}, observed: {state: "OPEN", ci: "unknown", conflict: "unknown", copilot: "none"}, events: {close: null, ci_failure: null, conflict: null, copilot_review: null}, watcher: {pid: null, failures: 0, updated_at: null, last_error: null}, runtime: {pane: null, nonce: null, session_id: null, status: "unregistered", updated_at: null}}' > "$temp_file"
             mv "$temp_file" "$STATE_FILE"
         else
             verify_state
@@ -348,5 +368,29 @@ case "$COMMAND" in
         acquire_lock
         verify_state
         write_state '.watcher.failures = ($count | tonumber) | .watcher.updated_at = $now' --arg count "$FAILURE_COUNT" --arg now "$(date -Iseconds)"
+        ;;
+    register-pane)
+        verify_state
+        [[ "$TMUX_PANE" =~ ^%[0-9]+$ && "$REGISTRATION_NONCE" =~ ^[A-Za-z0-9_.-]{16,}$ ]] || usage
+        acquire_lock
+        write_state '.version = 3 | .runtime = {pane: $pane, nonce: $nonce, session_id: null, status: "busy", updated_at: $now}' --arg pane "$TMUX_PANE" --arg nonce "$REGISTRATION_NONCE" --arg now "$(date -Iseconds)"
+        ;;
+    pane-status)
+        verify_state
+        [[ "$REGISTRATION_NONCE" =~ ^[A-Za-z0-9_.-]{16,}$ && "$SESSION_ID" =~ ^[A-Za-z0-9_.-]+$ && "$PANE_STATUS" =~ ^(busy|ready|approval_pending|stopped)$ ]] || usage
+        acquire_lock
+        if ! jq -e --arg nonce "$REGISTRATION_NONCE" '.runtime.nonce == $nonce' "$STATE_FILE" >/dev/null; then
+            exit 3
+        fi
+        write_state '.version = 3 | .runtime.session_id = $session | .runtime.status = $status | .runtime.updated_at = $now' --arg session "$SESSION_ID" --arg status "$PANE_STATUS" --arg now "$(date -Iseconds)"
+        ;;
+    unregister-pane)
+        verify_state
+        [[ "$REGISTRATION_NONCE" =~ ^[A-Za-z0-9_.-]{16,}$ ]] || usage
+        acquire_lock
+        if ! jq -e --arg nonce "$REGISTRATION_NONCE" '.runtime.nonce == $nonce' "$STATE_FILE" >/dev/null; then
+            exit 3
+        fi
+        write_state '.runtime = {pane: null, nonce: null, session_id: null, status: "stopped", updated_at: $now}' --arg now "$(date -Iseconds)"
         ;;
 esac

--- a/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-supervisor.sh
+++ b/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-supervisor.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# observer と dispatcher を同じ tmux monitor window で管理する。
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WATCH="$SCRIPT_DIR/watch-pr.sh"
+DISPATCH="$SCRIPT_DIR/pr-monitor-dispatch.sh"
+[[ -x "$WATCH" ]] || WATCH="$SCRIPT_DIR/executable_watch-pr.sh"
+[[ -x "$DISPATCH" ]] || DISPATCH="$SCRIPT_DIR/executable_pr-monitor-dispatch.sh"
+STATE="$SCRIPT_DIR/pr-monitor-state.sh"
+[[ -x "$STATE" ]] || STATE="$SCRIPT_DIR/executable_pr-monitor-state.sh"
+
+[[ "${1:-}" == "--pr-url" && -n "${2:-}" ]] || { echo "Usage: $0 --pr-url URL" >&2; exit 1; }
+PR_URL="$2"
+
+"$WATCH" watch --pr-url "$PR_URL" &
+WATCH_PID=$!
+cleanup() {
+    kill "$WATCH_PID" 2>/dev/null || true
+    wait "$WATCH_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM HUP
+
+while :; do
+    "$DISPATCH" --pr-url "$PR_URL" || true
+    if ! kill -0 "$WATCH_PID" 2>/dev/null; then
+        if ! "$STATE" pending --pr-url "$PR_URL" | grep -q .; then
+            break
+        fi
+    fi
+    sleep "${PR_MONITOR_INTERVAL:-30}"
+done
+wait "$WATCH_PID" || true

--- a/home/dot_agents/skills/pr-health-monitor/scripts/executable_watch-pr.sh
+++ b/home/dot_agents/skills/pr-health-monitor/scripts/executable_watch-pr.sh
@@ -55,6 +55,8 @@ STATE_ID=$("$STATE_HELPER" id --pr-url "$PR_URL")
 WATCH_LOCK="$STATE_DIR/${STATE_ID}.watch.lock"
 WATCH_GUARD_FILE="$STATE_DIR/${STATE_ID}.watch.guard"
 LOG_FILE="$LOG_DIR/watch-pr-${STATE_ID}.log"
+SUPERVISOR="$SCRIPT_DIR/pr-monitor-supervisor.sh"
+[[ -x "$SUPERVISOR" ]] || SUPERVISOR="$SCRIPT_DIR/executable_pr-monitor-supervisor.sh"
 WATCH_LOCK_OWNED=false
 WATCH_GUARD_FD=""
 
@@ -242,10 +244,25 @@ if [[ "$COMMAND" == "start" ]]; then
     if [[ -d "$WATCH_LOCK" ]]; then
         recover_stale_watch_lock || true
     fi
-    state watcher-error --reason foreground_required || true
-    state watcher --pid none || true
-    echo "Error: Detached PR monitoring is unavailable. Run '$0 watch --pr-url $PR_URL' in a persistent terminal, or use the scheduled-task/resume workflow." >&2
-    exit 1
+    runtime=$(state show)
+    pane=$(jq -r '.runtime.pane // empty' <<< "$runtime")
+    nonce=$(jq -r '.runtime.nonce // empty' <<< "$runtime")
+    if [[ ! "$pane" =~ ^%[0-9]+$ || ! "$nonce" =~ ^[A-Za-z0-9_.-]{16,}$ ]] \
+        || [[ "$(tmux display-message -p -t "$pane" '#{pane_id}' 2>/dev/null || true)" != "$pane" ]]; then
+        state watcher-error --reason foreground_required || true
+        state watcher --pid none || true
+        echo "Error: tmux pane registration is unavailable. Run '$0 watch --pr-url $PR_URL' in a persistent terminal, or use '$SUPERVISOR --pr-url $PR_URL'." >&2
+        exit 1
+    fi
+    window_name="codex-pr-monitor-${STATE_ID:0:12}"
+    if ! tmux new-window -d -n "$window_name" "$SUPERVISOR --pr-url $PR_URL"; then
+        state watcher-error --reason foreground_required || true
+        state watcher --pid none || true
+        echo "Error: Failed to create tmux monitor window. Use '$SUPERVISOR --pr-url $PR_URL'." >&2
+        exit 1
+    fi
+    echo "started $PR_URL $window_name"
+    exit 0
 fi
 
 if ! acquire_watch_lock; then

--- a/home/dot_agents/skills/resume-pr-monitor/SKILL.md
+++ b/home/dot_agents/skills/resume-pr-monitor/SKILL.md
@@ -5,7 +5,7 @@ description: PR monitor の状態を再観測して、lease を取得した pend
 
 # PR Monitor Resume
 
-`$resume-pr-monitor <PR 番号または URL>` は action processor の唯一の入口である。watcher と Copilot watcher は event を記録・通知するだけで、cleanup、Git 変更、review handling、GlitchTip 更新を実行しない。
+`$resume-pr-monitor <PR 番号または URL> [--event-id <type:generation>]` は action processor の唯一の入口である。tmux dispatcher から届く event ID は `[a-z_]+:[0-9]+` だけを受け付け、同じ event を再配送されても action lease と acknowledge state により idempotent に扱う。watcher と Copilot watcher は event を記録・通知するだけで、cleanup、Git 変更、review handling、GlitchTip 更新を実行しない。
 
 ## Reconcile してから処理する
 

--- a/home/dot_codex/AGENTS.md
+++ b/home/dot_codex/AGENTS.md
@@ -13,7 +13,7 @@
 - 実装前に、リポジトリ構成、作業ブランチ、最新のリモート既定ブランチ、不要なローカルブランチ、必要な依存関係を確認する。調査目的の GitHub リポジトリは一時ディレクトリへ clone する。
 - コミット前に、秘密情報、lint/format エラー、必要な検証、期待どおりの動作を確認する。
 - PR 作成前に、ユーザーの依頼、秘密情報、競合リスク、変更内容に応じたローカルコードレビューを確認する。PR 作成先は `gh-pr-target-repo.sh` を優先し、GitHub の `upstream` remote があればそれを既定にする。
-- PR 本文には現在の状態のみを記載し、更新履歴を列挙しない。PR 作成後は `$pr-health-monitor` を実行して CI、競合、Codex/Copilot レビューを確認する。external scheduler がない `start` は `foreground_required` を返すため、detached watcher を開始したと報告しない。持続した terminal を user が明示的に用意できる場合だけ `watch` を foreground で実行し、それ以外は ChatGPT Desktop/Web の Scheduled Tasks が利用可能なら project context の resume を予定するか、`$resume-pr-monitor` で pending event を再検証して処理する。watcher は action を実行しない。未解決レビューの対応は `$handle-pr-reviews` を使う。
+- PR 本文には現在の状態のみを記載し、更新履歴を列挙しない。PR 作成後は `$pr-health-monitor` を実行して CI、競合、Codex/Copilot レビューを確認する。tmux 内の Codex は登録済み pane に専用 monitor window から固定の `$resume-pr-monitor` prompt を配送できる。tmux 外または登録失敗時は `foreground_required` と manual resume fallback を報告する。ready state と配送の間に user input が始まる race は既知の制約である。watcher は Git/GitHub action を実行しない。未解決レビューの対応は `$handle-pr-reviews` を使う。
 
 ## 実装と検証
 

--- a/home/dot_codex/hooks.json
+++ b/home/dot_codex/hooks.json
@@ -30,6 +30,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash ~/.codex/hooks/pr-monitor-pane-state.sh approval_pending",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bash ~/.codex/scripts/completion-notify/notify-permission-request.sh",
             "timeout": 5
           }
@@ -39,6 +44,11 @@
     "UserPromptSubmit": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.codex/hooks/pr-monitor-pane-state.sh busy",
+            "timeout": 5
+          },
           {
             "type": "command",
             "command": "bash ~/.codex/scripts/completion-notify/notify-user-prompt-submit.sh",
@@ -52,6 +62,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash ~/.codex/hooks/pr-monitor-pane-state.sh ready",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bash ~/.codex/scripts/completion-notify/notify-completion.sh",
             "timeout": 5
           }
@@ -61,6 +76,11 @@
     "SessionEnd": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.codex/hooks/pr-monitor-pane-state.sh stopped",
+            "timeout": 5
+          },
           {
             "type": "command",
             "command": "bash ~/.codex/scripts/completion-notify/notify-post-tool-use.sh",

--- a/home/dot_codex/hooks/executable_pr-monitor-pane-state.sh
+++ b/home/dot_codex/hooks/executable_pr-monitor-pane-state.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Codex lifecycle event を、同じ tmux pane に登録された PR monitor へ反映する。
+set -euo pipefail
+
+STATUS="${1:-}"
+[[ "$STATUS" =~ ^(busy|ready|approval_pending|stopped)$ ]] || exit 0
+[[ "${TMUX_PANE:-}" =~ ^%[0-9]+$ ]] || exit 0
+
+INPUT=$(cat)
+SESSION_ID=$(jq -r '.session_id // empty' <<< "$INPUT" 2>/dev/null || true)
+[[ "$SESSION_ID" =~ ^[A-Za-z0-9_.-]+$ ]] || exit 0
+
+STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+STATE_DIR="$STATE_HOME/codex-pr-monitor"
+HELPER="$HOME/.agents/skills/pr-health-monitor/scripts/pr-monitor-state.sh"
+[[ -x "$HELPER" ]] || exit 0
+
+shopt -s nullglob
+for state_file in "$STATE_DIR"/*.json; do
+    pane=$(jq -r '.runtime.pane // empty' "$state_file" 2>/dev/null || true)
+    nonce=$(jq -r '.runtime.nonce // empty' "$state_file" 2>/dev/null || true)
+    url=$(jq -r '.pr.url // empty' "$state_file" 2>/dev/null || true)
+    [[ "$pane" == "$TMUX_PANE" && "$nonce" =~ ^[A-Za-z0-9_.-]{16,}$ && -n "$url" ]] || continue
+    "$HELPER" pane-status --pr-url "$url" --nonce "$nonce" --session-id "$SESSION_ID" --status "$STATUS" >/dev/null 2>&1 || true
+done

--- a/tests/integration/test_pr_monitor_tmux.sh
+++ b/tests/integration/test_pr_monitor_tmux.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# 実 tmux の literal send-keys が resume prompt だけを target pane へ渡すことを確認する。
+set -euo pipefail
+
+if ! command -v tmux >/dev/null; then
+    echo "SKIP: tmux is unavailable"
+    exit 0
+fi
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+STATE="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh"
+DISPATCH="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh"
+TEST_DIR=$(mktemp -d)
+SOCKET="pr-monitor-test-$$"
+PR_URL="https://github.com/example/repo/pull/99"
+
+cleanup() {
+    tmux -L "$SOCKET" kill-server 2>/dev/null || true
+    rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+tmux -L "$SOCKET" new-session -d -s monitor "read line; printf '%s' \"\$line\" > '$TEST_DIR/received'; sleep 30"
+PANE=$(tmux -L "$SOCKET" display-message -p -t monitor:0.0 '#{pane_id}')
+SOCKET_PATH=$(tmux -L "$SOCKET" display-message -p -t monitor:0.0 '#{socket_path}')
+
+HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$STATE" init --pr-url "$PR_URL" >/dev/null
+HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$STATE" register-pane --pr-url "$PR_URL" --pane "$PANE" --nonce 0123456789abcdef
+HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$STATE" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-99 --status ready
+HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$STATE" transition --pr-url "$PR_URL" --event ci --value failed --run-url 'https://example.invalid/run'
+TMUX="$SOCKET_PATH,0,0" HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$DISPATCH" --pr-url "$PR_URL"
+
+for _ in {1..50}; do
+    [[ -f "$TEST_DIR/received" ]] && break
+    sleep 0.1
+done
+EXPECTED="\$resume-pr-monitor $PR_URL --event-id ci_failure:1"
+if [[ "$(cat "$TEST_DIR/received" 2>/dev/null || true)" != "$EXPECTED" ]]; then
+    echo "❌ Real tmux did not deliver the expected literal resume prompt" >&2
+    exit 1
+fi
+echo "✅ Real tmux delivered only the literal resume prompt"

--- a/tests/unit/test_hooks.sh
+++ b/tests/unit/test_hooks.sh
@@ -15,6 +15,7 @@ HOOKS=(
   "home/dot_claude/hooks/executable_git-config-guard.sh"
   "home/dot_claude/hooks/executable_detect-leaked-toolcall.sh"
   "home/dot_codex/hooks/executable_git-config-guard.sh"
+  "home/dot_codex/hooks/executable_pr-monitor-pane-state.sh"
 )
 
 # 各フックの構文チェック
@@ -391,9 +392,9 @@ elif ! jq -e '
   .hooks.PreToolUse[0].matcher == "^Bash$"
   and .hooks.PreToolUse[0].hooks[0].command == "bash ~/.codex/hooks/git-config-guard.sh"
   and .hooks.PostToolUse[0].hooks[0].command == "bash ~/.codex/scripts/completion-notify/notify-post-tool-use.sh"
-  and .hooks.PermissionRequest[0].hooks[0].command == "bash ~/.codex/scripts/completion-notify/notify-permission-request.sh"
-  and .hooks.UserPromptSubmit[0].hooks[0].command == "bash ~/.codex/scripts/completion-notify/notify-user-prompt-submit.sh"
-  and .hooks.Stop[0].hooks[0].command == "bash ~/.codex/scripts/completion-notify/notify-completion.sh"
+  and .hooks.PermissionRequest[0].hooks[0].command == "bash ~/.codex/hooks/pr-monitor-pane-state.sh approval_pending"
+  and .hooks.UserPromptSubmit[0].hooks[0].command == "bash ~/.codex/hooks/pr-monitor-pane-state.sh busy"
+  and .hooks.Stop[0].hooks[0].command == "bash ~/.codex/hooks/pr-monitor-pane-state.sh ready"
 ' home/dot_codex/hooks.json >/dev/null; then
   echo "❌ Codex hooks.json does not register the expected lifecycle hooks"
   FAILED=1

--- a/tests/unit/test_pr_monitor.sh
+++ b/tests/unit/test_pr_monitor.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 STATE_SCRIPT="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh"
 WATCH_SCRIPT="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_watch-pr.sh"
+DISPATCH_SCRIPT="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh"
 COPILOT_SCRIPT="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_wait-for-copilot-review.sh"
 RESUME_SKILL="$ROOT_DIR/home/dot_agents/skills/resume-pr-monitor/SKILL.md"
 TEST_DIR=$(mktemp -d)
@@ -27,6 +28,21 @@ mkdir -p "$TEST_HOME" "$TEST_BIN"
 export HOME="$TEST_HOME"
 export XDG_STATE_HOME="$TEST_DIR/state"
 export PATH="$TEST_BIN:$PATH"
+
+cat > "$TEST_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "display-message" ]]; then
+    printf '%%77\n'
+    exit 0
+fi
+if [[ "$1" == "send-keys" ]]; then
+    printf '%s\n' "$*" >> "$TEST_DIR/tmux.log"
+    exit 0
+fi
+exit 1
+EOF
+chmod +x "$TEST_BIN/tmux"
 
 cat > "$TEST_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
@@ -82,6 +98,7 @@ process_identity() {
 echo "Testing PR monitor script syntax..."
 bash -n "$STATE_SCRIPT"
 bash -n "$WATCH_SCRIPT"
+bash -n "$DISPATCH_SCRIPT"
 
 echo "Testing absolute state directory and collision-resistant keys..."
 expect_failure env XDG_STATE_HOME=relative HOME="$TEST_HOME" "$STATE_SCRIPT" init --pr-url "$PR_URL"
@@ -94,6 +111,35 @@ fi
 
 echo "Testing state URL verification and stale/live lock recovery..."
 "$STATE_SCRIPT" init --pr-url "$PR_URL" >/dev/null
+
+echo "Testing registered ready pane receives only the fixed resume prompt..."
+"$STATE_SCRIPT" register-pane --pr-url "$PR_URL" --pane %77 --nonce 0123456789abcdef >/dev/null
+"$STATE_SCRIPT" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-42 --status ready
+UNTRUSTED_RUN_URL="https://example.invalid/\$(injected)"
+EXPECTED_DELIVERY="send-keys -t %77 -l -- \$resume-pr-monitor https://github.com/example/repo/pull/42 --event-id ci_failure:1"
+"$STATE_SCRIPT" transition --pr-url "$PR_URL" --event ci --value failed --run-url "$UNTRUSTED_RUN_URL"
+TEST_DIR="$TEST_DIR" "$DISPATCH_SCRIPT" --pr-url "$PR_URL"
+if [[ "$(wc -l < "$TEST_DIR/tmux.log" | tr -d ' ')" != "2" ]] \
+    || ! grep -Fxq "$EXPECTED_DELIVERY" "$TEST_DIR/tmux.log" \
+    || ! grep -Fxq 'send-keys -t %77 Enter' "$TEST_DIR/tmux.log" \
+    || grep -Fq 'injected' "$TEST_DIR/tmux.log"; then
+    echo "❌ Dispatcher did not safely deliver the fixed resume prompt" >&2
+    exit 1
+fi
+"$STATE_SCRIPT" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-42 --status approval_pending
+TEST_DIR="$TEST_DIR" "$DISPATCH_SCRIPT" --pr-url "$PR_URL"
+if [[ "$(wc -l < "$TEST_DIR/tmux.log" | tr -d ' ')" != "2" ]]; then
+    echo "❌ Dispatcher sent to an approval-pending pane" >&2
+    exit 1
+fi
+"$STATE_SCRIPT" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-42 --status ready
+"$STATE_SCRIPT" transition --pr-url "$PR_URL" --event close --value MERGED
+TEST_DIR="$TEST_DIR" "$DISPATCH_SCRIPT" --pr-url "$PR_URL"
+EXPECTED_CLOSE_DELIVERY="send-keys -t %77 -l -- \$resume-pr-monitor https://github.com/example/repo/pull/42 --event-id close:1"
+if ! grep -Fxq "$EXPECTED_CLOSE_DELIVERY" "$TEST_DIR/tmux.log"; then
+    echo "❌ Dispatcher did not deliver the pending close event" >&2
+    exit 1
+fi
 STATE_ID=$("$STATE_SCRIPT" id --pr-url "$PR_URL")
 STATE_FILE="$XDG_STATE_HOME/codex-pr-monitor/${STATE_ID}.json"
 jq '.pr.url = "https://github.com/example/repo/pull/999"' "$STATE_FILE" > "$STATE_FILE.tmp"

--- a/tests/unit/test_pr_monitor.sh
+++ b/tests/unit/test_pr_monitor.sh
@@ -126,6 +126,12 @@ if [[ "$(wc -l < "$TEST_DIR/tmux.log" | tr -d ' ')" != "2" ]] \
     echo "❌ Dispatcher did not safely deliver the fixed resume prompt" >&2
     exit 1
 fi
+"$STATE_SCRIPT" transition --pr-url "$PR_URL" --event ci --value ok
+"$STATE_SCRIPT" transition --pr-url "$PR_URL" --event ci --value failed --run-url "$UNTRUSTED_RUN_URL"
+if [[ "$("$STATE_SCRIPT" show --pr-url "$PR_URL" | jq -r '.events.ci_failure.id')" != "ci_failure:2" ]]; then
+    echo "❌ Repeated CI failures did not receive a distinct event ID" >&2
+    exit 1
+fi
 "$STATE_SCRIPT" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-42 --status approval_pending
 TEST_DIR="$TEST_DIR" "$DISPATCH_SCRIPT" --pr-url "$PR_URL"
 if [[ "$(wc -l < "$TEST_DIR/tmux.log" | tr -d ' ')" != "2" ]]; then


### PR DESCRIPTION
Closes #332

## 概要

Codex が tmux 内で動作している場合に、PR event を専用 monitor window で観測し、登録済み pane へ固定形式の `$resume-pr-monitor` prompt を配送できるようにしました。

## 変更内容

- lifecycle hook による pane の busy / approval pending / ready / stopped state を追加
- tmux supervisor と literal `send-keys` dispatcher を追加
- PR state に pane registration と dispatch 用 runtime state を追加
- 実 tmux を使用する integration test を追加

## 検証

- `bash tests/unit/test_pr_monitor.sh`
- `bash tests/unit/test_hooks.sh`
- `bash tests/integration/test_pr_monitor_tmux.sh`
- `bash tests/syntax/test_bash_syntax.sh`
- `bash tests/syntax/test_shellcheck.sh`
- `bash tests/integration/test_chezmoi_apply.sh`
- staged `gitleaks git --staged --redact`

## 前提・既知の制約

- Codex は tmux pane 内で動作する。
- ready state の直後に user が入力を始めた場合、dispatcher の入力と混在し得る race を許容する。