### PR TITLE
fix: PR monitor の prompt 配送を安定化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Codex CLI では custom slash command の代わりに user scope の skill を�
 - `$ticket-pr <ticket-key-or-url>`: Jira チケットから PR 作成と PR 後フロー開始までを進めます。
 - `$glitchtip-pr [issue-id-or-url]`: GlitchTip issue から PR 作成と、user が明示的に要求した verified Resolve までを進めます。
 - `$pr-health-monitor <pr-number-or-url>`: CI、競合、PR 本文、Codex/Copilot レビューを確認し、XDG state に close/merge、CI failure、conflict、Copilot review を記録します。external scheduler がない `start` は `foreground_required` を返します。持続した terminal を user が明示的に用意できる場合だけ `watch` を foreground で実行します。GlitchTip callback は state に保存しません。
-- tmux 内で実行中の Codex では、PR monitor が専用 tmux window を起動し、pending event を固定形式の `$resume-pr-monitor` prompt として登録済み pane へ配送できます。delivery は at-least-once です。Codex が ready と記録された直後に user が入力を始めると text が混在し得るため、この mode はその race を許容する場合だけ使用します。tmux 外または pane registration が失敗した場合は、monitor を開始せず manual resume fallback を報告します。
+- tmux 内で実行中の Codex では、PR monitor が専用 tmux window を起動し、pending event を固定形式の `$resume-pr-monitor` prompt として登録済み pane へ配送できます。dispatcher は prompt 入力後に短く待って Enter を送り、同じ event を再注入しない at-most-once delivery を使います。`UserPromptSubmit` hook が一致する prompt を確認した場合だけ delivery を submitted と記録します。Codex が ready と記録された直後に user が入力を始めると text が混在し得るため、この mode はその race を許容する場合だけ使用します。tmux 外または pane registration が失敗した場合は、monitor を開始せず manual resume fallback を報告します。
 - `$resume-pr-monitor <pr-number-or-url>`: restart、agent capacity 不足、tmux 非対応、watcher 停止後に fresh GitHub state から event を reconcile し、lease を取得した pending action だけを処理します。watcher は action を実行しません。ChatGPT Desktop/Web の Scheduled Tasks を利用できる場合は project context の resume を予定できますが、local shell の detached watcher として扱いません。
 - `$handle-pr-reviews <pr-number-or-url>`: 未解決の PR レビュースレッドを処理します。
 - `$deep-review <pr-number-or-url>`: 複数観点で変更をレビューします。

--- a/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh
+++ b/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh
@@ -26,6 +26,8 @@ done
 
 [[ "$PR_URL" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+$ ]] || usage
 [[ -x "$STATE_HELPER" ]] || { echo "Error: Missing PR monitor state helper" >&2; exit 1; }
+SUBMIT_DELAY_SECONDS="${PR_MONITOR_SUBMIT_DELAY_SECONDS:-1}"
+[[ "$SUBMIT_DELAY_SECONDS" =~ ^([0-9]+([.][0-9]+)?|[.][0-9]+)$ ]] || { echo "Error: Invalid PR monitor submit delay" >&2; exit 1; }
 
 STATE=$($STATE_HELPER show --pr-url "$PR_URL")
 PANE=$(jq -r '.runtime.pane // empty' <<< "$STATE")
@@ -37,10 +39,11 @@ CURRENT_PANE=$(tmux display-message -p -t "$PANE" '#{pane_id}' 2>/dev/null || tr
 [[ "$CURRENT_PANE" == "$PANE" ]] || exit 0
 
 EVENT=$(jq -r '
-    if .events.close != null and .events.close.actions.cleanup.status == "pending" then
+    def deliverable: . != null and .status == "pending" and ((.delivery.status // "pending") == "pending");
+    if (.events.close | deliverable) and .events.close.actions.cleanup.status == "pending" then
         "close"
     else
-        .events | to_entries[] | select(.key != "close" and .value != null and .value.status == "pending") | .key
+        .events | to_entries[] | select(.key != "close" and (.value | deliverable)) | .key
     end
 ' <<< "$STATE" | head -n 1)
 [[ "$EVENT" =~ ^(close|ci_failure|conflict|copilot_review)$ ]] || exit 0
@@ -48,5 +51,14 @@ EVENT_ID=$(jq -r --arg event "$EVENT" 'if $event == "close" then .events.close.i
 [[ "$EVENT_ID" =~ ^(close|ci_failure|conflict|copilot_review):[1-9][0-9]*$ ]] || exit 0
 PROMPT="\$resume-pr-monitor $PR_URL --event-id $EVENT_ID"
 
+if ! "$STATE_HELPER" claim-delivery --pr-url "$PR_URL" --event-id "$EVENT_ID" --pane "$PANE" --session-id "$SESSION_ID"; then
+    exit 0
+fi
 tmux send-keys -t "$PANE" -l -- "$PROMPT"
+sleep "$SUBMIT_DELAY_SECONDS"
+
+STATE=$($STATE_HELPER show --pr-url "$PR_URL")
+STATUS=$(jq -r '.runtime.status // empty' <<< "$STATE")
+CURRENT_PANE=$(tmux display-message -p -t "$PANE" '#{pane_id}' 2>/dev/null || true)
+[[ "$STATUS" == "delivering" && "$CURRENT_PANE" == "$PANE" ]] || exit 0
 tmux send-keys -t "$PANE" Enter

--- a/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh
+++ b/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh
@@ -14,13 +14,14 @@ umask 077
 mkdir -p "$STATE_DIR"
 
 usage() {
-    echo "Usage: $0 <init|id|show|pending|transition|claim|renew|ack|release|watcher|watcher-error|api-failure|register-pane|pane-status|unregister-pane> --pr-url URL [...]" >&2
+    echo "Usage: $0 <init|id|show|pending|transition|claim|renew|ack|release|watcher|watcher-error|api-failure|register-pane|pane-status|unregister-pane|claim-delivery|confirm-delivery> --pr-url URL [...]" >&2
     exit 1
 }
 
 COMMAND=""
 PR_URL=""
 EVENT=""
+EVENT_ID=""
 VALUE=""
 ACTION=""
 LEASE_ID=""
@@ -33,10 +34,11 @@ TMUX_PANE=""
 REGISTRATION_NONCE=""
 SESSION_ID=""
 PANE_STATUS=""
+PROMPT=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        init|id|show|pending|transition|claim|renew|ack|release|watcher|watcher-error|api-failure|register-pane|pane-status|unregister-pane)
+        init|id|show|pending|transition|claim|renew|ack|release|watcher|watcher-error|api-failure|register-pane|pane-status|unregister-pane|claim-delivery|confirm-delivery)
             COMMAND="$1"
             ;;
         --pr-url)
@@ -45,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --event)
             EVENT="${2:-}"
+            shift
+            ;;
+        --event-id|--expected-event-id)
+            EVENT_ID="${2:-}"
             shift
             ;;
         --value)
@@ -93,6 +99,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --status)
             PANE_STATUS="${2:-}"
+            shift
+            ;;
+        --prompt)
+            PROMPT="${2:-}"
             shift
             ;;
         *)
@@ -255,6 +265,16 @@ event_path() {
     fi
 }
 
+event_root_path_from_id() {
+    case "$EVENT_ID" in
+        close:*) printf '.events.close' ;;
+        ci_failure:*) printf '.events.ci_failure' ;;
+        conflict:*) printf '.events.conflict' ;;
+        copilot_review:*) printf '.events.copilot_review' ;;
+        *) usage ;;
+    esac
+}
+
 case "$COMMAND" in
     init)
         acquire_lock
@@ -289,19 +309,19 @@ case "$COMMAND" in
         case "$EVENT" in
             close)
                 [[ "$VALUE" == "MERGED" || "$VALUE" == "CLOSED" ]] || { echo "Error: Invalid close value" >&2; exit 1; }
-                write_state 'if .observed.state == $value then . else .observed.state = $value | .generations.close = ((.generations.close // 0) + 1) | .events.close = {id: ("close:" + (.generations.close | tostring)), status: "pending", value: $value, detected_at: $now, actions: {cleanup: {status: "pending", lease: null}, "glitchtip-resolve": {status: "not_applicable", lease: null}}} end' --arg value "$VALUE" --arg now "$NOW"
+                write_state 'if .observed.state == $value then . else .observed.state = $value | .generations.close = ((.generations.close // 0) + 1) | .events.close = {id: ("close:" + (.generations.close | tostring)), status: "pending", value: $value, detected_at: $now, delivery: {status: "pending", pane: null, sent_at: null}, actions: {cleanup: {status: "pending", lease: null}, "glitchtip-resolve": {status: "not_applicable", lease: null}}} end' --arg value "$VALUE" --arg now "$NOW"
                 ;;
             ci)
                 [[ "$VALUE" == "failed" || "$VALUE" == "ok" ]] || { echo "Error: Invalid CI value" >&2; exit 1; }
-                write_state 'if .observed.ci == $value then . else .observed.ci = $value | (if $value == "failed" then .generations.ci_failure = ((.generations.ci_failure // 0) + 1) | .events.ci_failure = {id: ("ci_failure:" + (.generations.ci_failure | tostring)), status: "pending", value: $value, detected_at: $now, run_url: $run_url, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW" --arg run_url "$RUN_URL"
+                write_state 'if .observed.ci == $value then . else .observed.ci = $value | (if $value == "failed" then .generations.ci_failure = ((.generations.ci_failure // 0) + 1) | .events.ci_failure = {id: ("ci_failure:" + (.generations.ci_failure | tostring)), status: "pending", value: $value, detected_at: $now, run_url: $run_url, delivery: {status: "pending", pane: null, sent_at: null}, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW" --arg run_url "$RUN_URL"
                 ;;
             conflict)
                 [[ "$VALUE" == "conflicting" || "$VALUE" == "clear" ]] || { echo "Error: Invalid conflict value" >&2; exit 1; }
-                write_state 'if .observed.conflict == $value then . else .observed.conflict = $value | (if $value == "conflicting" then .generations.conflict = ((.generations.conflict // 0) + 1) | .events.conflict = {id: ("conflict:" + (.generations.conflict | tostring)), status: "pending", value: $value, detected_at: $now, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW"
+                write_state 'if .observed.conflict == $value then . else .observed.conflict = $value | (if $value == "conflicting" then .generations.conflict = ((.generations.conflict // 0) + 1) | .events.conflict = {id: ("conflict:" + (.generations.conflict | tostring)), status: "pending", value: $value, detected_at: $now, delivery: {status: "pending", pane: null, sent_at: null}, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW"
                 ;;
             copilot)
                 [[ "$VALUE" == "detected" || "$VALUE" == "none" ]] || { echo "Error: Invalid Copilot value" >&2; exit 1; }
-                write_state 'if .observed.copilot == $value then . else .observed.copilot = $value | (if $value == "detected" then .generations.copilot_review = ((.generations.copilot_review // 0) + 1) | .events.copilot_review = {id: ("copilot_review:" + (.generations.copilot_review | tostring)), status: "pending", value: $value, detected_at: $now, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW"
+                write_state 'if .observed.copilot == $value then . else .observed.copilot = $value | (if $value == "detected" then .generations.copilot_review = ((.generations.copilot_review // 0) + 1) | .events.copilot_review = {id: ("copilot_review:" + (.generations.copilot_review | tostring)), status: "pending", value: $value, detected_at: $now, delivery: {status: "pending", pane: null, sent_at: null}, lease: null} else . end) end' --arg value "$VALUE" --arg now "$NOW"
                 ;;
             *) usage ;;
         esac
@@ -310,11 +330,23 @@ case "$COMMAND" in
         verify_state
         [[ "$LEASE_ID" =~ ^[A-Za-z0-9_.-]+$ && "$LEASE_SECONDS" =~ ^[0-9]+$ ]] || usage
         PATH_EXPR=$(event_path)
+        ROOT_PATH="null"
+        if [[ -n "$EVENT_ID" ]]; then
+            [[ "$EVENT_ID" =~ ^(close|ci_failure|conflict|copilot_review):[1-9][0-9]*$ ]] || usage
+            ROOT_PATH=$(event_root_path_from_id)
+            case "$EVENT:$EVENT_ID" in
+                close:close:*|ci_failure:ci_failure:*|conflict:conflict:*|copilot_review:copilot_review:*) ;;
+                *) usage ;;
+            esac
+        fi
         NOW_EPOCH=$(date +%s)
         EXPIRES_AT=$((NOW_EPOCH + LEASE_SECONDS))
         acquire_lock
         verify_state
-        if ! jq -e --argjson now "$NOW_EPOCH" "$PATH_EXPR.status == \"pending\" and ($PATH_EXPR.lease == null or $PATH_EXPR.lease.expires_at_epoch <= \$now)" "$STATE_FILE" >/dev/null; then
+        if ! jq -e --argjson now "$NOW_EPOCH" --arg event_id "$EVENT_ID" "
+            $PATH_EXPR.status == \"pending\" and ($PATH_EXPR.lease == null or $PATH_EXPR.lease.expires_at_epoch <= \$now)
+            and (\$event_id == \"\" or $ROOT_PATH.id == \$event_id)
+        " "$STATE_FILE" >/dev/null; then
             exit 3
         fi
         # event_path は固定の列挙値だけから作るため jq filter に安全に埋め込める。
@@ -379,10 +411,10 @@ case "$COMMAND" in
         verify_state
         [[ "$REGISTRATION_NONCE" =~ ^[A-Za-z0-9_.-]{16,}$ && "$SESSION_ID" =~ ^[A-Za-z0-9_.-]+$ && "$PANE_STATUS" =~ ^(busy|ready|approval_pending|stopped)$ ]] || usage
         acquire_lock
-        if ! jq -e --arg nonce "$REGISTRATION_NONCE" '.runtime.nonce == $nonce' "$STATE_FILE" >/dev/null; then
+        if ! jq -e --arg nonce "$REGISTRATION_NONCE" --arg session "$SESSION_ID" '.runtime.nonce == $nonce and (.runtime.session_id == null or .runtime.session_id == $session)' "$STATE_FILE" >/dev/null; then
             exit 3
         fi
-        write_state '.version = 3 | .runtime.session_id = $session | .runtime.status = $status | .runtime.updated_at = $now' --arg session "$SESSION_ID" --arg status "$PANE_STATUS" --arg now "$(date -Iseconds)"
+        write_state '.version = 3 | .runtime.session_id = $session | .runtime.status = (if .runtime.status == "delivering" and $status == "ready" then "delivering" else $status end) | .runtime.updated_at = $now' --arg session "$SESSION_ID" --arg status "$PANE_STATUS" --arg now "$(date -Iseconds)"
         ;;
     unregister-pane)
         verify_state
@@ -392,5 +424,33 @@ case "$COMMAND" in
             exit 3
         fi
         write_state '.runtime = {pane: null, nonce: null, session_id: null, status: "stopped", updated_at: $now}' --arg now "$(date -Iseconds)"
+        ;;
+    claim-delivery)
+        verify_state
+        [[ "$EVENT_ID" =~ ^(close|ci_failure|conflict|copilot_review):[1-9][0-9]*$ && "$TMUX_PANE" =~ ^%[0-9]+$ && "$SESSION_ID" =~ ^[A-Za-z0-9_.-]+$ ]] || usage
+        ROOT_PATH=$(event_root_path_from_id)
+        acquire_lock
+        verify_state
+        if ! jq -e --arg event_id "$EVENT_ID" --arg pane "$TMUX_PANE" --arg session "$SESSION_ID" "
+            .runtime.pane == \$pane and .runtime.session_id == \$session and .runtime.status == \"ready\"
+            and $ROOT_PATH.id == \$event_id and $ROOT_PATH.status == \"pending\"
+            and (($ROOT_PATH.delivery.status // \"pending\") == \"pending\")
+        " "$STATE_FILE" >/dev/null; then
+            exit 3
+        fi
+        write_state "$ROOT_PATH.delivery = {status: \"dispatching\", pane: \$pane, sent_at: \$now, confirmed_at: null} | .runtime.status = \"delivering\" | .runtime.updated_at = \$now" --arg pane "$TMUX_PANE" --arg now "$(date -Iseconds)"
+        ;;
+    confirm-delivery)
+        verify_state
+        [[ "$REGISTRATION_NONCE" =~ ^[A-Za-z0-9_.-]{16,}$ && "$SESSION_ID" =~ ^[A-Za-z0-9_.-]+$ && -n "$PROMPT" ]] || usage
+        acquire_lock
+        verify_state
+        if ! jq -e --arg nonce "$REGISTRATION_NONCE" --arg session "$SESSION_ID" --arg prompt "$PROMPT" '
+            .pr.url as $url | .runtime.nonce == $nonce and .runtime.session_id == $session and
+            any(.events[]?; . != null and (.delivery.status // "pending") == "dispatching" and $prompt == ("$resume-pr-monitor " + $url + " --event-id " + .id))
+        ' "$STATE_FILE" >/dev/null; then
+            exit 3
+        fi
+        write_state '(.pr.url as $url | (.events | to_entries | map(select(.value != null and (.value.delivery.status // "pending") == "dispatching" and $prompt == ("$resume-pr-monitor " + $url + " --event-id " + .value.id))) | .[0].key)) as $event | .events[$event].delivery.status = "submitted" | .events[$event].delivery.confirmed_at = $now' --arg prompt "$PROMPT" --arg now "$(date -Iseconds)"
         ;;
 esac

--- a/home/dot_agents/skills/resume-pr-monitor/SKILL.md
+++ b/home/dot_agents/skills/resume-pr-monitor/SKILL.md
@@ -11,7 +11,7 @@ description: PR monitor の状態を再観測して、lease を取得した pend
 
 1. `gh pr view` で canonical `PR_URL` を解決する。番号のみでは `gh-pr-target-repo.sh`、次に GitHub の `upstream` remote を優先する。
 2. 最初に `~/.agents/skills/pr-health-monitor/scripts/watch-pr.sh once --pr-url "$PR_URL"` を実行する。この command は PR state、checks/conflict、Copilot review を fresh GitHub response から観測し、不足している close、CI failure（run URL を含む）、conflict、Copilot event を state lock 下で enqueue する。API 取得に失敗したら action を実行せず停止する。
-3. `pr-monitor-state.sh pending --pr-url "$PR_URL"` を読み、各 action/event について新しいランダム lease ID で `claim --lease-id <ID> --lease-seconds 300` を取得する。claim が exit 3 なら、別の resume が所有しているか event は既に処理済みなので skip する。
+3. `--event-id <type:generation>` が与えられた場合は、その ID と完全に一致する event だけを対象にする。`watch-pr.sh once` によって同種の新しい generation が作られ、指定 ID が一致しなくなった場合は何も処理せず停止する。event を列挙する通常の resume では、各 action/event について新しいランダム lease ID で `claim --lease-id <ID> --lease-seconds 300` を取得する。指定 ID を処理する場合は `claim --event-id <type:generation> --lease-id <ID> --lease-seconds 300` を使う。claim が exit 3 なら、別の resume が所有しているか event は既に処理済み・stale なので skip する。
 4. 長時間 action の前には同じ lease ID で 60 秒ごとに `renew --lease-id <ID> --lease-seconds 300` を実行する heartbeat を開始し、action の終了後に停止する。renew が exit 3 なら ownership を失ったため action を開始・継続せず、結果を報告する。heartbeat は lease を取得した resume だけが実行する。
 5. action が成功した場合だけ同じ lease ID で `ack` を実行する。失敗、再検証不一致、またはユーザー判断待ちは同じ lease ID で `release` を実行して pending に戻す。lease のない `ack` は行わない。ack/release 後は heartbeat を停止する。
 

--- a/home/dot_codex/hooks/executable_pr-monitor-pane-state.sh
+++ b/home/dot_codex/hooks/executable_pr-monitor-pane-state.sh
@@ -22,5 +22,15 @@ for state_file in "$STATE_DIR"/*.json; do
     nonce=$(jq -r '.runtime.nonce // empty' "$state_file" 2>/dev/null || true)
     url=$(jq -r '.pr.url // empty' "$state_file" 2>/dev/null || true)
     [[ "$pane" == "$TMUX_PANE" && "$nonce" =~ ^[A-Za-z0-9_.-]{16,}$ && -n "$url" ]] || continue
+    if [[ "$STATUS" == "stopped" ]]; then
+        "$HELPER" unregister-pane --pr-url "$url" --nonce "$nonce" >/dev/null 2>&1 || true
+        continue
+    fi
+    if [[ "$STATUS" == "busy" ]]; then
+        prompt=$(jq -r '.prompt // empty' <<< "$INPUT" 2>/dev/null || true)
+        if [[ -n "$prompt" ]]; then
+            "$HELPER" confirm-delivery --pr-url "$url" --nonce "$nonce" --session-id "$SESSION_ID" --prompt "$prompt" >/dev/null 2>&1 || true
+        fi
+    fi
     "$HELPER" pane-status --pr-url "$url" --nonce "$nonce" --session-id "$SESSION_ID" --status "$STATUS" >/dev/null 2>&1 || true
 done

--- a/tests/fixtures/pr_monitor_delayed_composer.py
+++ b/tests/fixtures/pr_monitor_delayed_composer.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+"""Codex の composer が prompt text を受け取れても、直後の Enter を無視する状態を模す。"""
+
+import os
+import select
+import sys
+import termios
+import time
+import tty
+
+
+def main() -> None:
+    output_file = sys.argv[1]
+    fd = sys.stdin.fileno()
+    original = termios.tcgetattr(fd)
+    buffer = bytearray()
+
+    try:
+        tty.setraw(fd)
+        deadline = time.monotonic() + 0.5
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([fd], [], [], 0.05)
+            if readable:
+                buffer.extend(byte for byte in os.read(fd, 1024) if byte not in (10, 13))
+
+        while True:
+            byte = os.read(fd, 1)
+            if byte in (b"\r", b"\n"):
+                with open(output_file, "wb") as output:
+                    output.write(buffer)
+                return
+            buffer.extend(byte)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, original)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_pr_monitor_tmux.sh
+++ b/tests/integration/test_pr_monitor_tmux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# 実 tmux の literal send-keys が resume prompt だけを target pane へ渡すことを確認する。
+# 実 tmux の delayed Enter が、ready 前の Enter を無視する composer へ resume prompt を送ることを確認する。
 set -euo pipefail
 
 if ! command -v tmux >/dev/null; then
@@ -11,6 +11,7 @@ fi
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 STATE="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh"
 DISPATCH="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh"
+DELAYED_COMPOSER="$ROOT_DIR/tests/fixtures/pr_monitor_delayed_composer.py"
 TEST_DIR=$(mktemp -d)
 SOCKET="pr-monitor-test-$$"
 PR_URL="https://github.com/example/repo/pull/99"
@@ -21,7 +22,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-tmux -L "$SOCKET" new-session -d -s monitor "read line; printf '%s' \"\$line\" > '$TEST_DIR/received'; sleep 30"
+tmux -L "$SOCKET" new-session -d -s monitor "python3 '$DELAYED_COMPOSER' '$TEST_DIR/received'"
 PANE=$(tmux -L "$SOCKET" display-message -p -t monitor:0.0 '#{pane_id}')
 SOCKET_PATH=$(tmux -L "$SOCKET" display-message -p -t monitor:0.0 '#{socket_path}')
 
@@ -29,7 +30,7 @@ HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$STATE" init --pr-url "$
 HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$STATE" register-pane --pr-url "$PR_URL" --pane "$PANE" --nonce 0123456789abcdef
 HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$STATE" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-99 --status ready
 HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$STATE" transition --pr-url "$PR_URL" --event ci --value failed --run-url 'https://example.invalid/run'
-TMUX="$SOCKET_PATH,0,0" HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" "$DISPATCH" --pr-url "$PR_URL"
+TMUX="$SOCKET_PATH,0,0" HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" PR_MONITOR_SUBMIT_DELAY_SECONDS=1.2 "$DISPATCH" --pr-url "$PR_URL"
 
 for _ in {1..50}; do
     [[ -f "$TEST_DIR/received" ]] && break
@@ -37,7 +38,12 @@ for _ in {1..50}; do
 done
 EXPECTED="\$resume-pr-monitor $PR_URL --event-id ci_failure:1"
 if [[ "$(cat "$TEST_DIR/received" 2>/dev/null || true)" != "$EXPECTED" ]]; then
-    echo "❌ Real tmux did not deliver the expected literal resume prompt" >&2
+    echo "❌ Real tmux did not submit the expected delayed resume prompt" >&2
     exit 1
 fi
-echo "✅ Real tmux delivered only the literal resume prompt"
+TMUX="$SOCKET_PATH,0,0" HOME="$TEST_DIR/home" XDG_STATE_HOME="$TEST_DIR/state" PR_MONITOR_SUBMIT_DELAY_SECONDS=0 "$DISPATCH" --pr-url "$PR_URL"
+if [[ "$(cat "$TEST_DIR/received")" != "$EXPECTED" ]]; then
+    echo "❌ Real tmux dispatcher repeated an in-flight delivery" >&2
+    exit 1
+fi
+echo "✅ Real tmux submitted one delayed resume prompt"

--- a/tests/unit/test_pr_monitor.sh
+++ b/tests/unit/test_pr_monitor.sh
@@ -7,6 +7,7 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 STATE_SCRIPT="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-state.sh"
 WATCH_SCRIPT="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_watch-pr.sh"
 DISPATCH_SCRIPT="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_pr-monitor-dispatch.sh"
+PANE_STATE_HOOK="$ROOT_DIR/home/dot_codex/hooks/executable_pr-monitor-pane-state.sh"
 COPILOT_SCRIPT="$ROOT_DIR/home/dot_agents/skills/pr-health-monitor/scripts/executable_wait-for-copilot-review.sh"
 RESUME_SKILL="$ROOT_DIR/home/dot_agents/skills/resume-pr-monitor/SKILL.md"
 TEST_DIR=$(mktemp -d)
@@ -25,6 +26,8 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$TEST_HOME" "$TEST_BIN"
+mkdir -p "$TEST_HOME/.agents/skills/pr-health-monitor/scripts"
+ln -s "$STATE_SCRIPT" "$TEST_HOME/.agents/skills/pr-health-monitor/scripts/pr-monitor-state.sh"
 export HOME="$TEST_HOME"
 export XDG_STATE_HOME="$TEST_DIR/state"
 export PATH="$TEST_BIN:$PATH"
@@ -112,18 +115,39 @@ fi
 echo "Testing state URL verification and stale/live lock recovery..."
 "$STATE_SCRIPT" init --pr-url "$PR_URL" >/dev/null
 
-echo "Testing registered ready pane receives only the fixed resume prompt..."
+echo "Testing dispatcher reserves delivery, waits before Enter, and avoids duplicate insertion..."
 "$STATE_SCRIPT" register-pane --pr-url "$PR_URL" --pane %77 --nonce 0123456789abcdef >/dev/null
 "$STATE_SCRIPT" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-42 --status ready
 UNTRUSTED_RUN_URL="https://example.invalid/\$(injected)"
 EXPECTED_DELIVERY="send-keys -t %77 -l -- \$resume-pr-monitor https://github.com/example/repo/pull/42 --event-id ci_failure:1"
 "$STATE_SCRIPT" transition --pr-url "$PR_URL" --event ci --value failed --run-url "$UNTRUSTED_RUN_URL"
+PR_MONITOR_SUBMIT_DELAY_SECONDS=1 TEST_DIR="$TEST_DIR" "$DISPATCH_SCRIPT" --pr-url "$PR_URL" &
+DISPATCH_PID=$!
+for _ in {1..20}; do
+    [[ -s "$TEST_DIR/tmux.log" ]] && break
+    sleep 0.05
+done
+TEST_DIR="$TEST_DIR" "$DISPATCH_SCRIPT" --pr-url "$PR_URL"
+if [[ "$(wc -l < "$TEST_DIR/tmux.log" | tr -d ' ')" != "1" ]] \
+    || ! grep -Fxq "$EXPECTED_DELIVERY" "$TEST_DIR/tmux.log" \
+    || grep -Fq 'injected' "$TEST_DIR/tmux.log" \
+    || [[ "$("$STATE_SCRIPT" show --pr-url "$PR_URL" | jq -r '.runtime.status')" != "delivering" ]]; then
+    echo "❌ Dispatcher did not reserve a single delayed delivery" >&2
+    exit 1
+fi
+wait "$DISPATCH_PID"
+if [[ "$(wc -l < "$TEST_DIR/tmux.log" | tr -d ' ')" != "2" ]] \
+    || ! grep -Fxq 'send-keys -t %77 Enter' "$TEST_DIR/tmux.log"; then
+    echo "❌ Dispatcher did not submit the delayed prompt" >&2
+    exit 1
+fi
+RESUME_PROMPT="\$resume-pr-monitor $PR_URL --event-id ci_failure:1"
+jq -n --arg session session-42 --arg prompt "$RESUME_PROMPT" '{session_id: $session, prompt: $prompt}' | TMUX_PANE=%77 HOME="$TEST_HOME" XDG_STATE_HOME="$TEST_DIR/state" "$PANE_STATE_HOOK" busy
+printf '%s\n' '{"session_id":"session-42"}' | TMUX_PANE=%77 HOME="$TEST_HOME" XDG_STATE_HOME="$TEST_DIR/state" "$PANE_STATE_HOOK" ready
 TEST_DIR="$TEST_DIR" "$DISPATCH_SCRIPT" --pr-url "$PR_URL"
 if [[ "$(wc -l < "$TEST_DIR/tmux.log" | tr -d ' ')" != "2" ]] \
-    || ! grep -Fxq "$EXPECTED_DELIVERY" "$TEST_DIR/tmux.log" \
-    || ! grep -Fxq 'send-keys -t %77 Enter' "$TEST_DIR/tmux.log" \
-    || grep -Fq 'injected' "$TEST_DIR/tmux.log"; then
-    echo "❌ Dispatcher did not safely deliver the fixed resume prompt" >&2
+    || [[ "$("$STATE_SCRIPT" show --pr-url "$PR_URL" | jq -r '.events.ci_failure.delivery.status')" != "submitted" ]]; then
+    echo "❌ Submitted delivery was injected again" >&2
     exit 1
 fi
 "$STATE_SCRIPT" transition --pr-url "$PR_URL" --event ci --value ok
@@ -132,6 +156,9 @@ if [[ "$("$STATE_SCRIPT" show --pr-url "$PR_URL" | jq -r '.events.ci_failure.id'
     echo "❌ Repeated CI failures did not receive a distinct event ID" >&2
     exit 1
 fi
+expect_failure "$STATE_SCRIPT" claim --pr-url "$PR_URL" --event ci_failure --event-id ci_failure:1 --lease-id stale-event
+"$STATE_SCRIPT" claim --pr-url "$PR_URL" --event ci_failure --event-id ci_failure:2 --lease-id current-event
+"$STATE_SCRIPT" release --pr-url "$PR_URL" --event ci_failure --lease-id current-event
 "$STATE_SCRIPT" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-42 --status approval_pending
 TEST_DIR="$TEST_DIR" "$DISPATCH_SCRIPT" --pr-url "$PR_URL"
 if [[ "$(wc -l < "$TEST_DIR/tmux.log" | tr -d ' ')" != "2" ]]; then
@@ -304,6 +331,16 @@ if GH_STUB_FAILURE=1 PR_MONITOR_INTERVAL=0 PR_MONITOR_MAX_POLLS=5 "$WATCH_SCRIPT
 fi
 if ! "$STATE_SCRIPT" show --pr-url "$PR_URL" | jq -e '.watcher.failures == 5 and .watcher.pid == null' >/dev/null; then
     echo "❌ Watcher did not persist the terminal API failure state" >&2
+    exit 1
+fi
+
+echo "Testing a new Codex session cannot reactivate a stopped registration..."
+"$STATE_SCRIPT" register-pane --pr-url "$PR_URL" --pane %77 --nonce 0123456789abcdef >/dev/null
+"$STATE_SCRIPT" pane-status --pr-url "$PR_URL" --nonce 0123456789abcdef --session-id session-42 --status ready
+printf '%s\n' '{"session_id":"session-42"}' | TMUX_PANE=%77 HOME="$TEST_HOME" XDG_STATE_HOME="$TEST_DIR/state" "$PANE_STATE_HOOK" stopped
+printf '%s\n' '{"session_id":"session-other"}' | TMUX_PANE=%77 HOME="$TEST_HOME" XDG_STATE_HOME="$TEST_DIR/state" "$PANE_STATE_HOOK" ready
+if [[ "$("$STATE_SCRIPT" show --pr-url "$PR_URL" | jq -r '.runtime.status')" != "stopped" ]]; then
+    echo "❌ A new Codex session reactivated a stopped pane registration" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## 概要

Codex tmux PR monitor の prompt 配送で、即時 Enter が submit として受理されず同じ event が繰り返し注入される問題を修正します。

## 変更内容

- delivery claim と UserPromptSubmit 確認による at-most-once 配送
- prompt と Enter の間に 1 秒の待機
- stale event ID と別 Codex session の拒否
- 実 tmux の delayed composer regression test

## 検証

- `bash tests/unit/test_pr_monitor.sh`
- `bash tests/unit/test_hooks.sh`
- `bash tests/integration/test_pr_monitor_tmux.sh`
- `bash tests/syntax/test_bash_syntax.sh`
- `bash tests/syntax/test_shellcheck.sh`
- `bash tests/integration/test_chezmoi_apply.sh`
- `bash tests/integration/test_gitleaks.sh`