### PR TITLE
feat: route Codex TUI through app server

### DIFF
--- a/home/dot_bashrc.d/executable_90-ai-alias.sh
+++ b/home/dot_bashrc.d/executable_90-ai-alias.sh
@@ -58,7 +58,35 @@ claude() {
       command claude --permission-mode auto "$@" ;;
   esac
 }
-alias codex='[ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only codex; ~/.local/share/chezmoi/update.sh; codex --yolo'
+# Codex のラッパー関数。managed app-server が稼働中なら TUI を同じ app-server へ接続する。
+# 管理・非対話サブコマンドは remote 接続せず、従来どおり直接実行する。
+unalias codex 2>/dev/null
+_codex_app_server_running() {
+  command codex app-server daemon version 2>/dev/null \
+    | grep -Eq '"status"[[:space:]]*:[[:space:]]*"running"'
+}
+
+_codex_is_direct_invocation() {
+  case "${1:-}" in
+    app-server|remote-control|exec|review|login|logout|mcp|mcp-server|completion|sandbox|debug|apply|cloud|features|help|--help|-h|--version|-V)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+codex() {
+  [ -x ~/bin/update-ai-agents.sh ] && ~/bin/update-ai-agents.sh --quick --only codex
+  ~/.local/share/chezmoi/update.sh
+
+  if _codex_is_direct_invocation "$@"; then
+    command codex --yolo "$@"
+  elif _codex_app_server_running; then
+    command codex --remote unix:// --yolo "$@"
+  else
+    command codex --yolo "$@"
+  fi
+}
 # copilot コマンドのラッパー関数。
 # AI エージェント・chezmoi の更新を行い、カレントディレクトリに .copilot/mcp-config.json が
 # 存在する場合は --additional-mcp-config オプションを付与して実行する。

--- a/tests/unit/test_ai_alias.sh
+++ b/tests/unit/test_ai_alias.sh
@@ -97,3 +97,55 @@ HOME="$FAKE_HOME" PATH="$FAKE_BIN:/usr/bin:/bin" CLAUDE_ENV_FILE="$WRAPPER_ENV" 
 [[ "$(sed -n '1p' "$EVENT_LOG")" == "sleep:10" ]] || { echo "❌ warning delay did not occur before Claude launch"; exit 1; }
 grep -Fq 'claude:--permission-mode auto --version' "$EVENT_LOG" || { echo "❌ wrapped Claude command was not launched"; exit 1; }
 echo "✅ claude wrapper warning order test passed"
+
+
+echo "Testing codex wrapper auto-connects only TUI launches to running app-server..."
+declare -F codex >/dev/null || { echo "❌ codex wrapper function is not defined"; exit 1; }
+CODEX_HOME="$TEST_ROOT/codex-home"
+CODEX_BIN="$TEST_ROOT/codex-bin"
+CODEX_LOG="$TEST_ROOT/codex-events.log"
+mkdir -p "$CODEX_HOME/.local/share/chezmoi" "$CODEX_BIN"
+printf '#!/bin/bash\nexit 0\n' > "$CODEX_HOME/.local/share/chezmoi/update.sh"
+cat > "$CODEX_BIN/codex" <<'EOF'
+#!/bin/bash
+printf 'codex:%s\n' "$*" >> "$CODEX_LOG"
+if [[ "$*" == "app-server daemon version" ]]; then
+  if [[ "${FAKE_CODEX_DAEMON_STATUS:-running}" == "running" ]]; then
+    printf '{"status":"running"}\n'
+  else
+    printf '{"status":"stopped"}\n'
+  fi
+fi
+EOF
+chmod +x "$CODEX_HOME/.local/share/chezmoi/update.sh" "$CODEX_BIN/codex"
+export CODEX_LOG
+
+: > "$CODEX_LOG"
+HOME="$CODEX_HOME" PATH="$CODEX_BIN:/usr/bin:/bin" FAKE_CODEX_DAEMON_STATUS=running codex resume session-123
+[[ "$(tail -n 1 "$CODEX_LOG")" == "codex:--remote unix:// --yolo resume session-123" ]] || {
+  echo "❌ running daemon did not route Codex TUI through unix remote"
+  cat "$CODEX_LOG"
+  exit 1
+}
+
+: > "$CODEX_LOG"
+HOME="$CODEX_HOME" PATH="$CODEX_BIN:/usr/bin:/bin" FAKE_CODEX_DAEMON_STATUS=stopped codex resume session-123
+[[ "$(tail -n 1 "$CODEX_LOG")" == "codex:--yolo resume session-123" ]] || {
+  echo "❌ stopped daemon did not fall back to local Codex TUI"
+  cat "$CODEX_LOG"
+  exit 1
+}
+
+: > "$CODEX_LOG"
+HOME="$CODEX_HOME" PATH="$CODEX_BIN:/usr/bin:/bin" FAKE_CODEX_DAEMON_STATUS=running codex app-server daemon version >/dev/null
+[[ "$(tail -n 1 "$CODEX_LOG")" == "codex:--yolo app-server daemon version" ]] || {
+  echo "❌ app-server management command was unexpectedly remote-routed"
+  cat "$CODEX_LOG"
+  exit 1
+}
+! grep -Fq -- '--remote' "$CODEX_LOG" || {
+  echo "❌ management command log contains --remote"
+  cat "$CODEX_LOG"
+  exit 1
+}
+echo "✅ codex wrapper routing test passed"


### PR DESCRIPTION
## Summary
- replace the Codex alias with a wrapper function
- detect a running managed app-server via `codex app-server daemon version`
- route interactive TUI launches through `--remote unix://` when available
- keep management/non-interactive subcommands on the direct CLI path
- fall back to the existing local TUI behavior when the daemon is not running

## Tests
- `bash tests/unit/test_ai_alias.sh`
- `bash tests/syntax/test_bash_syntax.sh`
- `bash tests/syntax/test_shellcheck.sh`
- `git diff --check`
- verified on Pine that the current 0.147.0 daemon is detected as running and that `resume` is classified for remote routing while `app-server` is direct

Note: the full unit-test set was not completed locally because Remote Desktop Commander blocked execution of `tests/unit/test_install.sh`; the affected alias tests and shell syntax/static checks passed.